### PR TITLE
Fix duration to obey new semantics

### DIFF
--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -394,24 +394,29 @@ Local Date and Time
 Duration
 ========
 
-.. js:class:: Duration(\
-        months: number = 0, \
-        days: number = 0, \
-        microseconds: number = 0)
+.. js:class:: Duration(milliseconds: number = 0)
 
     A JavaScript  representation of an EdgeDB ``duration`` value.
 
-    .. js:method:: getMonths(): number
+    .. js:method:: fromMicroseconds(us: bigint): Duration
+        :staticmethod:
 
-        Get the number of months in the duration.
+        Create duration from bigint number of microseconds.
 
-    .. js:method:: getDays(): number
-
-        Get the number of days in the duration.
+        Note: new Duration() accepts fractional seconds too but can loose
+        precision because it's floating point.
 
     .. js:method:: getMilliseconds(): number
 
-        Get the number of microseconds in the duration.
+        Get the number of microseconds in the duration (can be fractional).
+
+    .. js:method:: getSeconds(): number
+
+        Get the number of seconds in the duration (can be fractional).
+
+    .. js:method:: getMicroseconds(): bigint
+
+        Get the precise number of microseconds in the duration.
 
     .. js:method:: toString(): string
 

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -406,15 +406,15 @@ Duration
         Note: new Duration() accepts fractional seconds too but can loose
         precision because it's floating point.
 
-    .. js:method:: getMilliseconds(): number
+    .. js:method:: toMilliseconds(): number
 
         Get the number of microseconds in the duration (can be fractional).
 
-    .. js:method:: getSeconds(): number
+    .. js:method:: toSeconds(): number
 
         Get the number of seconds in the duration (can be fractional).
 
-    .. js:method:: getMicroseconds(): bigint
+    .. js:method:: toMicroseconds(): bigint
 
         Get the precise number of microseconds in the duration.
 

--- a/src/codecs/datetime.ts
+++ b/src/codecs/datetime.ts
@@ -126,7 +126,7 @@ export class DurationCodec extends ScalarCodec implements ICodec {
       throw new Error(`a Duration instance was expected, got "${object}"`);
     }
     buf.writeInt32(16);
-    buf.writeBigInt64(object.getMicroseconds());
+    buf.writeBigInt64(object.toMicroseconds());
     buf.writeInt32(0);
     buf.writeInt32(0);
   }

--- a/src/codecs/datetime.ts
+++ b/src/codecs/datetime.ts
@@ -47,8 +47,8 @@ export class DateTimeCodec extends ScalarCodec implements ICodec {
   }
 
   decode(buf: ReadBuffer): any {
-    const us = buf.readInt64();
-    const ms = us / 1000.0;
+    const us = buf.readBigInt64();
+    const ms = Number(us) / 1000.0;
     return new Date(ms + TIMESHIFT);
   }
 }
@@ -67,8 +67,8 @@ export class LocalDateTimeCodec extends ScalarCodec implements ICodec {
   }
 
   decode(buf: ReadBuffer): any {
-    const us = buf.readInt64();
-    const ms = us / 1000.0;
+    const us = buf.readBigInt64();
+    const ms = Number(us) / 1000.0;
     return new LocalDateTime(
       (new Date(ms + TIMESHIFT) as unknown) as number,
       (DATE_PRIVATE as unknown) as number
@@ -109,7 +109,7 @@ export class LocalTimeCodec extends ScalarCodec implements ICodec {
   }
 
   decode(buf: ReadBuffer): any {
-    const us = buf.readInt64();
+    const us = Number(buf.readBigInt64());
     let seconds = Math.floor(us / 1_000_000);
     const ms = Math.floor((us % 1_000_000) / 1000);
     let minutes = Math.floor(seconds / 60);
@@ -126,15 +126,17 @@ export class DurationCodec extends ScalarCodec implements ICodec {
       throw new Error(`a Duration instance was expected, got "${object}"`);
     }
     buf.writeInt32(16);
-    buf.writeInt64(object.getMilliseconds() * 1000.0);
-    buf.writeInt32(object.getDays());
-    buf.writeInt32(object.getMonths());
+    buf.writeBigInt64(object.getMicroseconds());
+    buf.writeInt32(0);
+    buf.writeInt32(0);
   }
 
   decode(buf: ReadBuffer): any {
-    const us = buf.readInt64();
+    const us = buf.readBigInt64();
     const days = buf.readInt32();
     const months = buf.readInt32();
-    return new Duration(months, days, us / 1000.0);
+    console.assert(days == 0, "non-zero reserved bytes in duration")
+    console.assert(months == 0, "non-zero reserved bytes in duration")
+    return Duration.fromMicroseconds(us);
   }
 }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -284,15 +284,15 @@ export class Duration {
     return new Duration(undefined, microseconds)
   }
 
-  getSeconds(): number {
+  toSeconds(): number {
     return Number(this._microseconds) / 1000000;
   }
 
-  getMilliseconds(): number {
+  toMilliseconds(): number {
     return Number(this._microseconds) / 1000;
   }
 
-  getMicroseconds(): bigint {
+  toMicroseconds(): bigint {
     return this._microseconds;
   }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -364,8 +364,14 @@ test("fetch: duration fuzz", async () => {
 
     for (let i = 0; i < durs.length; i++) {
       expect(durs[i].toString()).toBe(dursAsText[i]);
-      expect(dursFromDb[i].getMilliseconds()).toEqual(
-        durs[i].getMilliseconds()
+      expect(dursFromDb[i].toMilliseconds()).toEqual(
+        durs[i].toMilliseconds()
+      );
+      expect(dursFromDb[i].toSeconds()).toEqual(
+        durs[i].toSeconds()
+      );
+      expect(dursFromDb[i].toMicroseconds()).toEqual(
+        durs[i].toMicroseconds()
       );
     }
   } finally {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -314,6 +314,7 @@ test("fetch: duration", async () => {
 });
 
 test("fetch: duration fuzz", async () => {
+  jest.setTimeout(10_000);
   const randint = (min: number, max: number) => {
     const x = Math.round(Math.random() * (max - min) + min);
     return x === -0 ? 0 : x;
@@ -321,26 +322,22 @@ test("fetch: duration fuzz", async () => {
 
   const durs = [
     new Duration(),
-    new Duration(0, 0, 1),
-    new Duration(0, 0, -1),
-    new Duration(0, 1),
-    new Duration(0, -1),
-    new Duration(1, 0),
-    new Duration(-1, 0),
-    new Duration(1, 0),
-    new Duration(1, 1, 1),
-    new Duration(-1, -1, -1),
-    new Duration(1, -1, 1),
-    new Duration(-1, 1, -1),
+    new Duration(1),
+    new Duration(-1),
+    new Duration(1),
+    new Duration(-1),
+    new Duration(-752043.296),
+    new Duration(3542924),
+    new Duration(86400000),
+    new Duration(-86400000),
   ];
 
   // Fuzz it!
   for (let _i = 0; _i < 5000; _i++) {
     durs.push(
       new Duration(
-        randint(-50, 50),
-        randint(-500, 500),
-        randint(-1000000, 1000000)
+        randint(-500, 500)*86400 +
+        randint(-1000, 1000)
       )
     );
   }
@@ -367,9 +364,6 @@ test("fetch: duration fuzz", async () => {
 
     for (let i = 0; i < durs.length; i++) {
       expect(durs[i].toString()).toBe(dursAsText[i]);
-
-      expect(dursFromDb[i].getMonths()).toEqual(durs[i].getMonths());
-      expect(dursFromDb[i].getDays()).toEqual(durs[i].getDays());
       expect(dursFromDb[i].getMilliseconds()).toEqual(
         durs[i].getMilliseconds()
       );

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -19,7 +19,7 @@
 import * as util from "util";
 
 import {UUID} from "../src/index";
-import {LocalDate} from "../src/datatypes/datetime";
+import {LocalDate, Duration} from "../src/datatypes/datetime";
 
 test("types: UUID", async () => {
   expect(() => {
@@ -77,3 +77,7 @@ test("types: LocalDate", async () => {
     return new LocalDate(2009, 1, 31);
   }).toThrow(/invalid number of days 31.*1\.\.28/);
 });
+
+test("types: Duration", async () => {
+  expect(new Duration(68464977074.011).toString()).toBe("19018:02:57.074011");
+})


### PR DESCRIPTION
The controversial decisions:
1. `new Duration` takes **milliseconds** as it's what JS uses for `Date - Date`
2. Internally we store microseconds (but this can be changed in future)
3. Currently, it crashes with overflow when duration doesn't fit 53 bits (size of a float). But there are few ways to fix it (bigint in node > 12.0, split the number for earlier versions). But fortunately, it's forward-compatible.