### PR TITLE
docs: Add a note about using JSON when fetching values.

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -179,6 +179,19 @@ Connection
         This method takes :js:class:`optional query arguments
         <AwaitConnection>`.
 
+        .. note::
+
+            Caution is advised when reading ``decimal`` or ``bigint``
+            values using this method. The JSON specification does not
+            have a limit on significant digits, so a ``decimal`` or a
+            ``bigint`` number can be losslessly represented in JSON.
+            However, JSON decoders in JavaScript will often read all
+            such numbers as ``number`` values, which may result in
+            precision loss. If such loss is unacceptable, then
+            consider casting the value into ``str`` and decoding it on
+            the client side into a more appropriate type, such as
+            BigInt_.
+
     .. js:method:: fetchOneJSON(query: string, args)
 
         Run a singleton-returning query and return its element in JSON.
@@ -188,6 +201,19 @@ Connection
 
         The *query* must return exactly one element.  If the query returns
         more than one element or an empty set, an ``Error`` is thown.
+
+        .. note::
+
+            Caution is advised when reading ``decimal`` or ``bigint``
+            values using this method. The JSON specification does not
+            have a limit on significant digits, so a ``decimal`` or a
+            ``bigint`` number can be losslessly represented in JSON.
+            However, JSON decoders in JavaScript will often read all
+            such numbers as ``number`` values, which may result in
+            precision loss. If such loss is unacceptable, then
+            consider casting the value into ``str`` and decoding it on
+            the client side into a more appropriate type, such as
+            BigInt_.
 
     .. js:method:: close()
 
@@ -257,6 +283,19 @@ Connection
 
         This method takes :js:class:`optional query arguments <Connection>`.
 
+        .. note::
+
+            Caution is advised when reading ``decimal`` or ``bigint``
+            values using this method. The JSON specification does not
+            have a limit on significant digits, so a ``decimal`` or a
+            ``bigint`` number can be losslessly represented in JSON.
+            However, JSON decoders in JavaScript will often read all
+            such numbers as ``number`` values, which may result in
+            precision loss. If such loss is unacceptable, then
+            consider casting the value into ``str`` and decoding it on
+            the client side into a more appropriate type, such as
+            BigInt_.
+
     .. js:method:: fetchOneJSON(query: string, args, callback)
 
         Run a singleton-returning query and return its element in JSON.
@@ -265,6 +304,19 @@ Connection
 
         The *query* must return exactly one element.  If the query returns
         more than one element or an empty set, an ``Error`` is thown.
+
+        .. note::
+
+            Caution is advised when reading ``decimal`` or ``bigint``
+            values using this method. The JSON specification does not
+            have a limit on significant digits, so a ``decimal`` or a
+            ``bigint`` number can be losslessly represented in JSON.
+            However, JSON decoders in JavaScript will often read all
+            such numbers as ``number`` values, which may result in
+            precision loss. If such loss is unacceptable, then
+            consider casting the value into ``str`` and decoding it on
+            the client side into a more appropriate type, such as
+            BigInt_.
 
     .. js:method:: close(callback)
 
@@ -278,3 +330,6 @@ Connection
         :staticmethod:
 
         Convert an :js:class:`AwaitConnection` into :js:class:`Connection`.
+
+.. _BigInt:
+    https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -43,6 +43,8 @@ The table below shows the correspondence between EdgeDB and JavaScript types.
 | ``int32``,           |                                                     |
 | ``int64``            |                                                     |
 +----------------------+-----------------------------------------------------+
+| ``bigint``           | BigInt_                                             |
++----------------------+-----------------------------------------------------+
 | ``decimal``          | n/a                                                 |
 +----------------------+-----------------------------------------------------+
 | ``json``             | ``string``                                          |
@@ -398,10 +400,10 @@ Duration
 
     A JavaScript  representation of an EdgeDB ``duration`` value.
 
-    .. js:method:: fromMicroseconds(us: bigint): Duration
+    .. js:method:: fromMicroseconds(us: BigInt): Duration
         :staticmethod:
 
-        Create duration from bigint number of microseconds.
+        Create duration from BigInt_ number of microseconds.
 
         Note: new Duration() accepts fractional seconds too but can loose
         precision because it's floating point.
@@ -414,7 +416,7 @@ Duration
 
         Get the number of seconds in the duration (can be fractional).
 
-    .. js:method:: toMicroseconds(): bigint
+    .. js:method:: toMicroseconds(): BigInt
 
         Get the precise number of microseconds in the duration.
 
@@ -422,3 +424,7 @@ Duration
 
         Get the string representation of the ``duration`` that is similar to
         the result of a ``str`` cast of a ``duration`` in EdgeDB.
+
+
+.. _BigInt:
+    https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -801,9 +801,18 @@ test("fetch: long strings", async () => {
 
 test("fetchOneJSON", async () => {
   const con = await asyncConnect();
+  let res;
   try {
-    const res = await con.fetchOneJSON("select (a := 1)");
+    res = await con.fetchOneJSON("select (a := 1)");
     expect(JSON.parse(res)).toEqual({a: 1});
+
+    res = await con.fetchOneJSON("select (a := 1n)");
+    expect(JSON.parse(res)).toEqual({a: 1});
+    expect(typeof JSON.parse(res).a).toEqual("number");
+
+    res = await con.fetchOneJSON("select (a := 1.5n)");
+    expect(JSON.parse(res)).toEqual({a: 1.5});
+    expect(typeof JSON.parse(res).a).toEqual("number");
   } finally {
     await con.close();
   }


### PR DESCRIPTION
Add a cautionary note about fetching `decimal` values using
`fetchAllJSON` or `fetchOneJSON`.

State that `biging` is mapped onto `BigInt` in JavaScript.

Add some `fetchOneJSON` tests.

This is trying to address edgedb/edgedb#1151