### PR TITLE
Fix bug when arg properties are in different order to query args

### DIFF
--- a/src/codecs/namedtuple.ts
+++ b/src/codecs/namedtuple.ts
@@ -49,9 +49,20 @@ export class NamedTupleCodec extends Codec implements ICodec, IArgsCodec {
       );
     }
 
+    const keys = Object.keys(args);
     const names = this.names;
+    const namesSet = this.namesSet;
     const codecs = this.subCodecs;
     const codecsLen = codecs.length;
+
+    if (keys.length > codecsLen) {
+      const extraKeys = keys.filter((key) => !namesSet.has(key));
+      throw new Error(
+        `unexpected named argument${ extraKeys.length === 1 ? '' : 's' }: "${
+          extraKeys.join('", "')
+        }"`
+      );
+    }
 
     if (!codecsLen) {
       return EmptyTupleCodec.BUFFER;

--- a/src/codecs/namedtuple.ts
+++ b/src/codecs/namedtuple.ts
@@ -58,9 +58,9 @@ export class NamedTupleCodec extends Codec implements ICodec, IArgsCodec {
     if (keys.length > codecsLen) {
       const extraKeys = keys.filter((key) => !namesSet.has(key));
       throw new Error(
-        `unexpected named argument${ extraKeys.length === 1 ? '' : 's' }: "${
-          extraKeys.join('", "')
-        }"`
+        `unexpected named argument${
+          extraKeys.length === 1 ? "" : "s"
+        }: "${extraKeys.join('", "')}"`
       );
     }
 

--- a/src/codecs/namedtuple.ts
+++ b/src/codecs/namedtuple.ts
@@ -49,18 +49,9 @@ export class NamedTupleCodec extends Codec implements ICodec, IArgsCodec {
       );
     }
 
-    const keys = Object.keys(args);
-    const names = this.namesSet;
+    const names = this.names;
     const codecs = this.subCodecs;
     const codecsLen = codecs.length;
-
-    if (keys.length !== codecsLen) {
-      throw new Error(
-        `expected ${codecsLen} argument${codecsLen === 1 ? "" : "s"}, got ${
-          keys.length
-        }`
-      );
-    }
 
     if (!codecsLen) {
       return EmptyTupleCodec.BUFFER;
@@ -68,12 +59,14 @@ export class NamedTupleCodec extends Codec implements ICodec, IArgsCodec {
 
     const elemData = new WriteBuffer();
     for (let i = 0; i < codecsLen; i++) {
-      const key = keys[i];
-      if (!names.has(key)) {
-        throw new Error(`unexpected named argument "${key}"`);
-      }
+      const key = names[i];
       const val = args[key];
-      if (val == null) {
+
+      if (val === undefined) {
+        throw new Error(`missing named argument "${key}"`);
+      }
+
+      if (val === null) {
         elemData.writeInt32(-1);
       } else {
         const codec = codecs[i];

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -280,17 +280,20 @@ test("fetch: named args", async () => {
     });
     expect(res).toBe("123abc");
 
-    res = await con.fetchOne(`select <str>$a ++ <str>$b`, {
-      b: "abc",
-      a: "123",
-      c: "def",
-    })
-    .then(() => {
-      throw new Error("there should have been an unexpected named argument error");
-    })
-    .catch((e) => {
-      expect(e.toString()).toMatch(/unexpected named argument: "c"/);
-    });
+    res = await con
+      .fetchOne(`select <str>$a ++ <str>$b`, {
+        b: "abc",
+        a: "123",
+        c: "def",
+      })
+      .then(() => {
+        throw new Error(
+          "there should have been an unexpected named argument error"
+        );
+      })
+      .catch((e) => {
+        expect(e.toString()).toMatch(/unexpected named argument: "c"/);
+      });
 
     res = await con.fetchOne(`select len(<str>$a ?? "aa")`, {a: null});
     expect(res).toBe(2);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -280,6 +280,14 @@ test("fetch: named args", async () => {
     });
     expect(res).toBe("123abc");
 
+    res = await con.fetchOne(`select <str>$a ++ <str>$b`, {
+      b: "abc",
+      a: "123",
+      c: "def",
+    }).catch((e) => {
+      expect(e.toString()).toMatch(/unexpected named argument: "c"/);
+    });
+
     res = await con.fetchOne(`select len(<str>$a ?? "aa")`, {a: null});
     expect(res).toBe(2);
   } finally {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -284,7 +284,11 @@ test("fetch: named args", async () => {
       b: "abc",
       a: "123",
       c: "def",
-    }).catch((e) => {
+    })
+    .then(() => {
+      throw new Error("there should have been an unexpected named argument error");
+    })
+    .catch((e) => {
       expect(e.toString()).toMatch(/unexpected named argument: "c"/);
     });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -275,8 +275,8 @@ test("fetch: named args", async () => {
     expect(res).toBe("123");
 
     res = await con.fetchOne(`select <str>$a ++ <str>$b`, {
-      a: "123",
       b: "abc",
+      a: "123",
     });
     expect(res).toBe("123abc");
 


### PR DESCRIPTION
Fixes bug in `NamedTupleCodec.encodeArgs` where the properties of an args object are just assigned to the query args in the order that they are returned by `Object.keys`, not by name, leading to correctness bugs (if the types happen to be compatible) or codec encoding errors.
```js
const edgedb = require('edgedb') // 0.7.0-alpha.5

async function main() {
  const conn = await edgedb.connect({
    // connection config
  })

  try {

    console.log(
      await conn.fetchAll(`SELECT <int64>$a - <int64>$b`, {
        a: 10,
        b: 5,
      })
    )
    // Set [ 5 ]

    console.log(
      await conn.fetchAll(`SELECT <int64>$a - <int64>$b`, {
        b: 5,
        a: 10,
      })
    )
    // Set [ -5 ]

    console.log(
      await conn.fetchAll(`SELECT (
        <int64>$number,
        <str>$string
      )`, {
        string: 'test',
        number: 42,
      })
    )
    // Error: a number was expected, got "test"
    // at Int64Codec.encode (##############\node_modules\edgedb\dist\src\codecs\numbers.js:24:19)
    // at NamedTupleCodec.encodeArgs (##############\node_modules\edgedb\dist\src\codecs\namedtuple.js:61:23)
    // at AwaitConnection._encodeArgs (##############\node_modules\edgedb\dist\src\client.js:485:28)
    // at AwaitConnection._execute (##############\node_modules\edgedb\dist\src\client.js:494:31)

  } catch (error) {
    console.error(error)
  }

  await conn.close()
}

main()
```
This commit does also change how extra properties on the args object are handled, as they are now ignored, which allows using an existing object with other properties as the args parameter, for example:
```js
const user = {
  id: 12345,
  name: 'test',
  // ...etc
}

await conn.fetchOne(`
UPDATE User
FILTER .id = <int64>$id
SET {
  status := 'online'
};
`, user)

// instead of ...
await conn.fetchOne(`
UPDATE User
FILTER .id = <int64>$id
SET {
  status := 'online'
};
`, {
  id: user.id
})
```
Though I can add checks for extra properties if you prefer enforcing the more explicit usage.