### PR TITLE
Bring argument tuple encoding up to date with protocol version 0.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install EdgeDB
         env:
           OS_NAME: ${{ matrix.os }}
-          SLOT: 1-alpha2
+          SLOT: 1-alpha3
         run: |
           .github/workflows/install-edgedb.sh
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,9 @@ import {
   NormalizedConnectConfig,
 } from "./con_utils";
 
+const PROTO_VER_MAJOR = 0;
+const PROTO_VER_MINOR = 8;
+
 type QueryArgPrimitive =
   | number
   | string
@@ -388,7 +391,7 @@ export class AwaitConnection {
           this._parseHeaders();
           this.buffer.finishMessage();
 
-          if (hi !== 0 || lo !== 7) {
+          if (hi !== PROTO_VER_MAJOR || (hi === 0 && lo !== PROTO_VER_MINOR)) {
             throw new Error(
               `the server requested an unsupported version of ` +
                 `the protocol ${hi}.${lo}`

--- a/src/codecs/namedtuple.ts
+++ b/src/codecs/namedtuple.ts
@@ -77,6 +77,7 @@ export class NamedTupleCodec extends Codec implements ICodec, IArgsCodec {
         throw new Error(`missing named argument "${key}"`);
       }
 
+      elemData.writeInt32(0); // reserved bytes
       if (val === null) {
         elemData.writeInt32(-1);
       } else {

--- a/src/codecs/tuple.ts
+++ b/src/codecs/tuple.ts
@@ -58,6 +58,7 @@ export class TupleCodec extends Codec implements ICodec, IArgsCodec {
     const elemData = new WriteBuffer();
     for (let i = 0; i < codecsLen; i++) {
       const arg = args[i];
+      elemData.writeInt32(0); // reserved bytes
       if (arg == null) {
         elemData.writeInt32(-1);
       } else {


### PR DESCRIPTION
Ported from https://github.com/edgedb/edgedb-python/pull/89