### PR TITLE
Fix bug where connection is in broken state after no codec error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -246,32 +246,29 @@ export class AwaitConnection {
   }
 
   private _parseDescribeTypeMessage(): [number, ICodec, ICodec] {
-    try {
-      this._rejectHeaders();
+    this._rejectHeaders();
 
-      const cardinality: char = this.buffer.readChar();
+    const cardinality: char = this.buffer.readChar();
 
-      const inTypeId = this.buffer.readUUID();
-      const inTypeData = this.buffer.readLenPrefixedBuffer();
-      let inCodec = this.codecsRegistry.getCodec(inTypeId);
-      if (inCodec == null) {
-        inCodec = this.codecsRegistry.buildCodec(inTypeData);
-      }
+    const inTypeId = this.buffer.readUUID();
+    const inTypeData = this.buffer.readLenPrefixedBuffer();
 
-      const outTypeId = this.buffer.readUUID();
-      const outTypeData = this.buffer.readLenPrefixedBuffer();
-      let outCodec = this.codecsRegistry.getCodec(outTypeId);
-      if (outCodec == null) {
-        outCodec = this.codecsRegistry.buildCodec(outTypeData);
-      }
+    const outTypeId = this.buffer.readUUID();
+    const outTypeData = this.buffer.readLenPrefixedBuffer();
 
-      this.buffer.finishMessage();
+    this.buffer.finishMessage();
 
-      return [cardinality, inCodec, outCodec];
-    } catch (e) {
-      this.buffer.discardMessage();
-      throw e;
+    let inCodec = this.codecsRegistry.getCodec(inTypeId);
+    if (inCodec == null) {
+      inCodec = this.codecsRegistry.buildCodec(inTypeData);
     }
+
+    let outCodec = this.codecsRegistry.getCodec(outTypeId);
+    if (outCodec == null) {
+      outCodec = this.codecsRegistry.buildCodec(outTypeData);
+    }
+
+    return [cardinality, inCodec, outCodec];
   }
 
   private _parseCommandCompleteMessage(): string {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1013,6 +1013,9 @@ test("fetch no codec", async () => {
       .catch((e) => {
         expect(e.toString()).toMatch(/no JS codec for std::decimal/);
       });
+    await con.fetchOne("select 123").then((res) => {
+      expect(res).toEqual(123);
+    });
   } finally {
     await con.close();
   }


### PR DESCRIPTION
Fixes bug where queries made after a query that fails with a no codec error, also fail as there is still the "T" message from the previous query left over in the read message buffer.
```js
const conn = await connect(...)

async function runQuery(query) {
  try {
    return await conn.fetchOne(query)
  } catch (err) {
    console.log(err)
  }
}

console.log( await runQuery(`SELECT 123.456n`) )
// Error: no JS codec for std::decimal                 <-- Expected error

console.log( await runQuery(`SELECT 123.456`) )
// Error: unexpected message type 84 ("T")
//   at AwaitConnection._fallthrough (.../edgedb-js/dist/src/client.js:247:23)
//   at AwaitConnection._parse (.../edgedb-js/dist/src/client.js:426:26)
//   at AwaitConnection._fetch (.../edgedb-js/dist/src/client.js:637:58)
//   at AwaitConnection.fetchOne (.../edgedb-js/dist/src/client.js:736:31)
```