### PR TITLE
Drop callback-based Connection & Pool APIs

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -10,7 +10,6 @@ Connection
 ==========
 
 .. js:function:: connect(options)
-                 connect(options, callback)
 
     Establish a connection to an EdgeDB server.
 
@@ -81,17 +80,8 @@ Connection
     :param number options.timeout:
         Connection timeout in seconds.
 
-    :param callback:
-        A callback function that will be invoked when the connection is ready.
-        The callback function should be of the form ``function(error,
-        connection)``. The *connection* is an instance of
-        :js:class:`Connection`.
-
     :returns:
-        There are two ways of creating an EdgeDB connection: a Promise-based
-        approach and a callback-based. When a *callback* argument is provided,
-        the function does not return anything and instead uses the *callback*.
-        Otherwise, a ``Promise`` of an :js:class:`AwaitConnection` is returned.
+        Returns a ``Promise`` of an :js:class:`Connection` is returned.
 
     Example:
 
@@ -107,7 +97,7 @@ Connection
           });
 
           try{
-            let data = await conn.fetchOne("SELECT 1 + 1");
+            let data = await conn.queryOne("SELECT 1 + 1");
 
             // The result is a number 2.
             assert(typeof data === "number");
@@ -119,11 +109,11 @@ Connection
 
         main();
 
-.. js:class:: AwaitConnection
+.. js:class:: Connection
 
     A representation of a database session.
 
-    :js:class:`AwaitConnection` is not meant to be instantiated by directly,
+    :js:class:`Connection` is not meant to be instantiated by directly,
     :js:func:`connect` should be used instead.
 
 
@@ -159,7 +149,7 @@ Connection
                 UNION INSERT MyType { a := x };
             `)
 
-    .. js:method:: fetchAll(query: string, args)
+    .. js:method:: query(query: string, args)
 
         Run a query and return the results as a
         :js:class:`Set` instance.
@@ -167,7 +157,7 @@ Connection
         This method takes :ref:`optional query arguments
         <edgedb-js-api-async-optargs>`.
 
-    .. js:method:: fetchOne(query: string, args)
+    .. js:method:: queryOne(query: string, args)
 
         Run a singleton-returning query and return its element.
 
@@ -177,7 +167,7 @@ Connection
         The *query* must return exactly one element.  If the query returns
         more than one element or an empty set, an ``Error`` is thrown.
 
-    .. js:method:: fetchAllJSON(query: string, args)
+    .. js:method:: queryJSON(query: string, args)
 
         Run a query and return the results as JSON.
 
@@ -197,7 +187,7 @@ Connection
             the client side into a more appropriate type, such as
             BigInt_.
 
-    .. js:method:: fetchOneJSON(query: string, args)
+    .. js:method:: queryOneJSON(query: string, args)
 
         Run a singleton-returning query and return its element in JSON.
 
@@ -224,120 +214,6 @@ Connection
 
         Close the connection gracefully.
 
-.. js:class:: Connection
-
-    A representation of a database session.
-
-    :js:class:`Connection` is not meant to be instantiated by directly,
-    :js:func:`connect` should be used instead.
-
-    Every method of this class takes a *callback* of the form
-    ``function(err, data)``.
-
-    .. _edgedb-js-api-sync-optargs:
-
-    .. note::
-
-        Some methods take query arguments as optional *args*:
-
-        * single values of any of the :ref:`basic types
-          recognized<edgedb-js-datatypes>` by EdgeDB
-        * an ``Array`` of values of any of the basic types
-        * an ``object`` with property names and values corresponding to
-          argument names and values of any of the basic types
-
-    .. js:method:: execute(query: string, callback)
-
-        Execute an EdgeQL command (or commands).
-
-        The commands must take no arguments.
-
-        Example:
-
-        .. code-block:: js
-
-            con.execute(`
-                CREATE TYPE MyType {
-                    CREATE PROPERTY a -> int64
-                };
-                FOR x IN {100, 200, 300}
-                UNION INSERT MyType { a := x };
-            `, (err, data) => {
-                if (err) {
-                    console.log('migration failed: ', err)
-                } else {
-                    console.log('migration complete');
-                }
-            })
-
-    .. js:method:: fetchAll(query: string, args)
-
-        Run a query and return the results as a
-        :js:class:`Set` instance.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-    .. js:method:: fetchOne(query: string, args, callback)
-
-        Run a singleton-returning query and return its element.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element or an empty set, an ``Error`` is thrown.
-
-    .. js:method:: fetchAllJSON(query: string, args, callback)
-
-        Run a query and return the results as JSON.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-        .. note::
-
-            Caution is advised when reading ``decimal`` or ``bigint``
-            values using this method. The JSON specification does not
-            have a limit on significant digits, so a ``decimal`` or a
-            ``bigint`` number can be losslessly represented in JSON.
-            However, JSON decoders in JavaScript will often read all
-            such numbers as ``number`` values, which may result in
-            precision loss. If such loss is unacceptable, then
-            consider casting the value into ``str`` and decoding it on
-            the client side into a more appropriate type, such as
-            BigInt_.
-
-    .. js:method:: fetchOneJSON(query: string, args, callback)
-
-        Run a singleton-returning query and return its element in JSON.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element or an empty set, an ``Error`` is thrown.
-
-        .. note::
-
-            Caution is advised when reading ``decimal`` or ``bigint``
-            values using this method. The JSON specification does not
-            have a limit on significant digits, so a ``decimal`` or a
-            ``bigint`` number can be losslessly represented in JSON.
-            However, JSON decoders in JavaScript will often read all
-            such numbers as ``number`` values, which may result in
-            precision loss. If such loss is unacceptable, then
-            consider casting the value into ``str`` and decoding it on
-            the client side into a more appropriate type, such as
-            BigInt_.
-
-    .. js:method:: close(callback)
-
-        Close the connection gracefully and invoke the *callback*.
-
-        :param callback:
-            The *callback* to be invoked after closing the connection.
-
 
 .. _BigInt:
     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
@@ -346,10 +222,9 @@ Connection
 .. _edgedb-js-api-pool:
 
 Pool
-==========
+====
 
 .. js:function:: createPool(options)
-                 createPool(options, callback)
 
     Create a connection pool to an EdgeDB server.
 
@@ -378,24 +253,16 @@ Pool
 
     :param func options.onConnect:
         Optional callback, called when a new connection is created.
-        *(connection: AwaitConnection) => Promise<void>*
+        *(connection: Connection) => Promise<void>*
 
     :param func options.connectionFactory:
         Optional function, used to obtain a new connection. By default, the
         function is :js:func:`connect` *(options?: ConnectConfig) =>
-        Promise<AwaitConnection>*
-
-    :param callback:
-        A callback function that will be invoked when the connection pool is
-        ready. The callback function should be of the form ``function(error,
-        pool)``. The *pool* is an instance of :js:class:`CallbackPool`.
+        Promise<Connection>*
 
     :returns:
-        There are two ways of creating an EdgeDB connection pool: a
-        Promise-based approach and a callback-based. When a *callback*
-        argument is provided, the function does not return anything and instead
-        uses the *callback* with an instance of :js:class:`CallbackPool`.
-        Otherwise, a ``Promise`` of an :js:class:`Pool` is returned.
+        Returns a ``Promise`` of an :js:class:`Pool` is returned.
+
 
 .. js:class:: Pool
 
@@ -404,7 +271,7 @@ Pool
     used to maintain and reuse connections, enhancing the performance of
     database interactions.
 
-    Pools can be created using the method ``createPool``:
+    Pools must be created using the method ``createPool``:
 
     .. code-block:: js
 
@@ -419,7 +286,7 @@ Pool
             });
 
             try {
-                let data = await pool.fetchOne("SELECT [1, 2, 3]");
+                let data = await pool.queryOne("SELECT [1, 2, 3]");
 
                 console.log(data);
             } finally {
@@ -451,7 +318,7 @@ Pool
                 UNION INSERT MyType { a := x };
             `)
 
-    .. js:method:: fetchAll(query: string, args)
+    .. js:method:: query(query: string, args)
 
         Acquire a connection, then run a query and return the results as a
         :js:class:`Set` instance.
@@ -461,7 +328,7 @@ Pool
 
         .. code-block:: js
 
-            const items = await pool.fetchAll(
+            const items = await pool.query(
                 `SELECT Movie {
                     title,
                     year,
@@ -480,7 +347,7 @@ Pool
                 }
             );
 
-    .. js:method:: fetchOne(query: string, args)
+    .. js:method:: queryOne(query: string, args)
 
         Acquire a connection, then run a query that returns a single item
         and return its result.
@@ -493,16 +360,16 @@ Pool
 
         .. code-block:: js
 
-            await pool.fetchOne("SELECT 1");
+            await pool.queryOne("SELECT 1");
 
-    .. js:method:: fetchAllJSON(query: string, args)
+    .. js:method:: queryJSON(query: string, args)
 
         Acquire a connection, then run a query and return the results as JSON.
 
         This method takes :ref:`optional query arguments
         <edgedb-js-api-async-optargs>`.
 
-    .. js:method:: fetchOneJSON(query: string, args)
+    .. js:method:: queryOneJSON(query: string, args)
 
         Acquire a connection, then run a singleton-returning query and return
         its element in JSON.
@@ -527,7 +394,7 @@ Pool
             let value: number;
 
             try {
-                value = await connection.fetchOne("select 1");
+                value = await connection.queryOne("select 1");
             } finally {
                 await pool.release(connection);
             }
@@ -549,7 +416,7 @@ Pool
         .. code-block:: js
 
             const result = await pool.run(async (connection) => {
-                return await connection.fetchOne("SELECT 1");
+                return await connection.queryOne("SELECT 1");
             });
             expect(result).toBe(1);
 
@@ -585,133 +452,3 @@ Pool
         Terminate all connections in the pool, closing all connections non
         gracefully. If the pool is already closed, return without doing
         anything.
-
-.. _edgedb-js-api-callbackpool:
-
-CallbackPool
-============
-
-.. js:class:: CallbackPool
-
-    A :js:class:`CallbackPool` exposes a callback-based API, and can be created
-    using the function :js:func:`createPool`, specifying a callback as second
-    argument.
-
-    Every method of this class takes a *callback* of the form
-    ``function(err, data)``.
-
-    .. code-block:: js
-
-      const edgedb = require("edgedb");
-
-      edgedb.createPool({
-          connectOptions: {
-              user: "edgedb",
-              host: "127.0.0.1"
-          },
-      }, (err, pool) => {
-          if (err) {
-              throw err;
-          }
-
-          pool.fetchOne("select <int64>$i + 1", { i: 10 }, (err2, data2) => {
-              if (err2) {
-                  throw err2;
-              }
-
-              console.log(data2);
-
-              pool.close();
-          });
-      });
-
-    .. js:method:: execute(query: string, callback)
-
-        Acquire a connection and execute an EdgeQL command (or commands).
-
-        The commands must take no arguments.
-
-        Example:
-
-        .. code-block:: js
-
-            pool.execute(`
-                CREATE TYPE MyType {
-                    CREATE PROPERTY a -> int64
-                };
-                FOR x IN {100, 200, 300}
-                UNION INSERT MyType { a := x };
-            `, (err, data) => {
-                if (err) {
-                    console.log('migration failed: ', err)
-                } else {
-                    console.log('migration complete');
-                }
-            })
-
-    .. js:method:: fetchAll(query: string, args)
-
-        Acquire a connection and run a query and return the results as a
-        :js:class:`Set` instance.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-    .. js:method:: fetchOne(query: string, args, callback)
-
-        Acquire a connection and run a singleton-returning query and return
-        its element.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element or an empty set, an ``Error`` is thrown.
-
-    .. js:method:: fetchAllJSON(query: string, args, callback)
-
-        Acquire a connection and run a query and return the results as JSON.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-    .. js:method:: fetchOneJSON(query: string, args, callback)
-
-        Acquire a connection and run a singleton-returning query and return
-        its element in JSON.
-
-        This method takes :ref:`optional query arguments
-        <edgedb-js-api-sync-optargs>`.
-
-        The *query* must return exactly one element.  If the query returns
-        more than one element or an empty set, an ``Error`` is thrown.
-
-    .. js:method:: close(callback)
-
-        Close the connection pool gracefully and invoke the *callback*.
-
-        :param callback:
-            The *callback* to be invoked after closing the connection.
-
-    .. js:method:: acquire(callback)
-
-        Acquire a connection proxy, which provides access to an open database
-        connection. The proxy must be released to return the connection to the
-        pool. Then invoke the *callback*.
-
-        :param callback:
-            The *callback* to be invoked after closing the connection.
-
-    .. js:method:: release(proxy: CallbackPoolConnectionProxy, callback)
-
-        Release a previously acquired connection proxy, to return it to the
-        pool, and invoke the *callback*.
-
-        :param callback:
-            The *callback* to be invoked after closing the connection.
-
-    .. js:method:: expireConnections()
-
-        Expire all currently open connections.
-        Cause all currently open connections to be replaced when they are
-        acquired by the next *.acquire()* call.

--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -100,7 +100,7 @@ EdgeDB ``array``  maps onto the JavaScript ``Array``.
       });
 
       try {
-        let data = await conn.fetchOne("SELECT [1, 2, 3]");
+        let data = await conn.queryOne("SELECT [1, 2, 3]");
 
         // The result is an Array.
         assert(data instanceof Array);
@@ -134,7 +134,7 @@ object property or a link can be accessed through a corresponding object key:
       });
 
       try {
-        let data = await conn.fetchOne(`
+        let data = await conn.queryOne(`
           SELECT schema::Property {
               name,
               annotations: {name, @value}
@@ -177,7 +177,7 @@ A regular EdgeDB ``tuple`` becomes an ``Array`` in JavaScript.
       });
 
       try {
-        let data = await conn.fetchOne(`
+        let data = await conn.queryOne(`
           SELECT (1, 'a', [3])
         `);
 
@@ -212,7 +212,7 @@ where the elements are accessible either by their names or indexes.
       });
 
       try {
-        let data = await conn.fetchOne(`
+        let data = await conn.queryOne(`
           SELECT (a := 1, b := 'a', c := [3])
         `);
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,70 +7,9 @@ Basic Usage
 **edgedb-js** has two APIs: Promise-based and callback-based.
 
 The interaction with the database normally starts with a call to ``connect()``,
-which establishes a new database session. This either results in setting up a
-callback or getting a connection ``Promise``.  The connection instance
-provides methods to run queries.
-
-Callback connection example:
-
-.. code-block:: js
-
-    const edgedb = require("edgedb");
-
-    // Establish a connection to an existing database
-    // named "test" as an "edgedb" user.
-    edgedb.connect(
-      {
-        dsn: "edgedb://edgedb@localhost/test"
-      },
-      (err, conn) => {
-        // Create a User object type.
-        conn.execute(
-          `
-          CREATE TYPE User {
-              CREATE REQUIRED PROPERTY name -> str;
-              CREATE PROPERTY dob -> cal::local_date;
-          }
-          `,
-          (err, data) => {
-            // Insert a new User object.
-            conn.fetchAll(
-              `
-              INSERT User {
-                  name := <str>$name,
-                  dob := <cal::local_date>$dob
-              }
-              `,
-              {
-                name: "Bob",
-                dob: new edgedb.LocalDate(1984, 3, 1) // 1 April 1984
-              },
-              (err, data) => {
-                // Select User objects.
-                conn.fetchAll(
-                  `
-                    SELECT User {name, dob}
-                    FILTER .name = <str>$name
-                  `,
-                  { name: "Bob" },
-                  (err, userSet) => {
-                    // *user_set* now contains
-                    // Set{Object{name := 'Bob',
-                    //            dob := datetime.date(1984, 3, 1)}}
-                    console.log(userSet);
-
-                    // Close the connection.
-                    conn.close();
-                  }
-                );
-              }
-            );
-          }
-        );
-      }
-    );
-
-An equivalent example using the Promise-based API:
+which establishes a new database session. This results in getting a
+connection ``Promise``.  The connection instance provides methods to
+run queries.
 
 .. code-block:: js
 
@@ -93,7 +32,7 @@ An equivalent example using the Promise-based API:
         `);
 
         // Insert a new User object.
-        await conn.fetchAll(
+        await conn.query(
           `
           INSERT User {
               name := <str>$name,
@@ -107,7 +46,7 @@ An equivalent example using the Promise-based API:
         );
 
         // Select User objects.
-        let userSet = await conn.fetchAll(
+        let userSet = await conn.query(
           "SELECT User {name, dob} FILTER .name = <str>$name",
           { name: "Bob" }
         );
@@ -168,8 +107,6 @@ To create a connection pool, use the ``createPool()`` method.
 The resulting :js:class:`edgedb.Pool <Pool>` object can be used to maintain
 a certain number of open connections and borrow them when needed.
 
-Below is an example of a connection pool usage, using the Promise-based API:
-
 .. code-block:: js
 
     const edgedb = require("edgedb");
@@ -193,7 +130,7 @@ Below is an example of a connection pool usage, using the Promise-based API:
         `);
 
         // Insert a new User object.
-        await pool.fetchAll(
+        await pool.query(
           `
            INSERT User {
              name := <str>$name,
@@ -207,7 +144,7 @@ Below is an example of a connection pool usage, using the Promise-based API:
         );
 
         // Select User objects.
-        let userSet = await pool.fetchAll(
+        let userSet = await pool.query(
           "SELECT User {name, dob} FILTER .name = <str>$name",
           { name: "Bob" }
         );
@@ -222,34 +159,6 @@ Below is an example of a connection pool usage, using the Promise-based API:
     }
 
     main();
-
-Below is an example using the callback API:
-
-.. code-block:: js
-
-    const edgedb = require("edgedb");
-
-    edgedb.createPool({
-      connectOptions: {
-        user: "edgedb",
-        host: "127.0.0.1"
-      },
-    }, (err, pool) => {
-      if (err) {
-        throw err;
-      }
-
-      pool.fetchOne("select <int64>$i + 1", { i: 10 }, (err2, data2) => {
-        if (err2) {
-          throw err2;
-        }
-
-        console.log(data2);
-
-        pool.close();
-      });
-    });
-
 
 See :ref:`edgedb-js-api-pool` API documentation for
 more information.

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -1,0 +1,80 @@
+/*!
+ * This source file is part of the EdgeDB open source project.
+ *
+ * Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {UUID} from "./datatypes/uuid";
+
+import {
+  LocalDateTime,
+  LocalDate,
+  LocalTime,
+  Duration,
+} from "./datatypes/datetime";
+
+import {Set} from "./datatypes/set";
+
+export type NodeCallback<T = any> = (
+  err: Error | null,
+  data: T | null
+) => void;
+
+type QueryArgPrimitive =
+  | number
+  | string
+  | boolean
+  | BigInt
+  | Buffer
+  | Date
+  | LocalDateTime
+  | LocalDate
+  | LocalTime
+  | Duration
+  | UUID;
+
+type QueryArg = QueryArgPrimitive | QueryArgPrimitive[] | null;
+
+export type QueryArgs = {[_: string]: QueryArg} | QueryArg[] | null;
+
+export interface Connection {
+  execute(query: string): Promise<void>;
+  query(query: string, args?: QueryArgs): Promise<Set>;
+  queryJSON(query: string, args?: QueryArgs): Promise<string>;
+  queryOne(query: string, args?: QueryArgs): Promise<any>;
+  queryOneJSON(query: string, args?: QueryArgs): Promise<string>;
+  close(): Promise<void>;
+  isClosed(): boolean;
+}
+
+export interface IPoolStats {
+  queueLength: number;
+  openConnections: number;
+}
+
+export interface Pool extends Connection {
+  acquire(): Promise<Connection>;
+  release(connectionProxy: Connection): Promise<void>;
+  run<T>(action: (connection: Connection) => Promise<T>): Promise<T>;
+  expireConnections(): void;
+  getStats(): IPoolStats;
+  terminate(): void;
+}
+
+export const onConnectionClose = Symbol.for("onConnectionClose");
+
+export interface IConnectionProxied extends Connection {
+  [onConnectionClose](): void;
+}

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -20,7 +20,8 @@ import _connect from "./client";
 export const connect = _connect;
 export default connect;
 
-export {createPool, Pool, PoolConnectionProxy, PoolOptions} from "./pool";
+export {createPool} from "./pool";
 
-/* Private exports */
+export {Connection, Pool} from "./ifaces";
+
 export * from "./index.shared";

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -23,7 +23,7 @@ import {
   NormalizedConnectConfig,
 } from "../src/con_utils";
 import {asyncConnect} from "./testbase";
-import {AwaitConnection} from "../src/client";
+import {Connection} from "../src/ifaces";
 
 function env_wrap(env: {[key: string]: any}, func: () => void): void {
   const old_env: {[key: string]: any} = {};
@@ -370,7 +370,7 @@ test("parseConnectArguments", () => {
 });
 
 test("connect: timeout", async () => {
-  let con: AwaitConnection | undefined;
+  let con: Connection | undefined;
   try {
     con = await asyncConnect({timeout: 1});
     throw new Error("conneciton didn't time out");

--- a/test/testbase.ts
+++ b/test/testbase.ts
@@ -20,9 +20,9 @@ import * as process from "process";
 
 import connect from "../src/index.node";
 import {createPool} from "../src/index.node";
-import {NodeCallback, AwaitConnection, Connection} from "../src/client";
+import {CallbackConnection} from "../src/client";
 import {ConnectConfig} from "../src/con_utils";
-import {Pool, CallbackPool} from "../src/pool";
+import {NodeCallback, Connection, Pool} from "../src/ifaces";
 
 function _getOpts(opts: ConnectConfig): ConnectConfig {
   const port = process.env._JEST_EDGEDB_PORT;
@@ -44,33 +44,19 @@ export function getConnectOptions(): ConnectConfig {
   return _getOpts({});
 }
 
-export async function asyncConnect(
-  opts?: ConnectConfig
-): Promise<AwaitConnection> {
+export async function asyncConnect(opts?: ConnectConfig): Promise<Connection> {
   return await connect(_getOpts(opts ?? {}));
 }
 
 export function connectWithCallback(
   opts?: ConnectConfig,
-  cb?: NodeCallback<Connection>
+  cb?: NodeCallback<CallbackConnection>
 ): void {
   return connect(_getOpts(opts ?? {}), cb);
 }
 
 export async function getPool(opts?: ConnectConfig): Promise<Pool> {
-  return await Pool.create({
+  return await createPool({
     connectOptions: _getOpts(opts ?? {}),
   });
-}
-
-export function getPoolWithCallback(
-  opts?: ConnectConfig,
-  cb?: NodeCallback<CallbackPool>
-): void {
-  return createPool(
-    {
-      connectOptions: _getOpts(opts ?? {}),
-    },
-    cb
-  );
 }


### PR DESCRIPTION
First and foremost this commit drops the NodeJS-style callback APIs.
The callback-based 'connect()' still exists, although it now emits a
warning and isn't documented.

The motivation for dropping callback APIs is the excessive complexity
of the support code & overall UX they require.  While using callbacks is
what NodeJS started with, they are discouraged from being used in favor
of async/await.  And even if one needs to use callbacks, the
promise-based API makes that simple, just use '.then()' and '.catch()'
promise methods.

While at it, I refactored all APIs to be defined in terms of Connection
and Pool interfaces, which are now exported. All implementation details
are hidden from the user this way.  The PoolConnectionProxy now goes
even further, by using Symbols to make it impossible to unwrap the
underlying connection object.

Lastly, pool proxing code now uses a WeakMap to break a strong reference
cycle between connection proxies and the actual connection objects they
wrap.