### PR TITLE
Implement named instances support

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -111,6 +111,20 @@ Connection
 
         main();
 
+    .. note::
+
+       For compatibility this function also supports passing options as
+       the first argument:
+
+       .. code-block:: js
+
+          await connect({host: 'localhost', port: 5656})
+          // or
+          await connect({dsn: 'edgedb://localhost'})
+
+       But this form is deprecated and will be removed in the future.
+
+
 .. js:class:: Connection
 
     A representation of a database session.
@@ -279,6 +293,19 @@ Pool
     :returns:
         Returns a ``Promise`` of an :js:class:`Pool` is returned.
 
+    .. note::
+
+       For compatibility this function also supports passing options as
+       the first argument:
+
+       .. code-block:: js
+
+          await createPool({
+            maxSize: 10,
+            connectOptions: {dsn: 'edgedb://localhost'},
+          })
+
+       But this form is deprecated and will be removed in the future.
 
 .. js:class:: Pool
 

--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -9,18 +9,20 @@ API
 Connection
 ==========
 
-.. js:function:: connect(options)
+.. js:function:: connect(dsn, options)
 
     Establish a connection to an EdgeDB server.
 
-    :param options: Connection parameters object.
+    :param string dsn:
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
 
-    :param string options.dsn:
-        Connection arguments specified using as a single string in the
-        connection URI format:
+        Otherwise it specifies a single string in the connection URI format:
         ``edgedb://user:password@host:port/database?option=value``.
         The following options are recognized: host, port,
         user, database, password.
+
+    :param options: Connection parameters object.
 
     :param string|string[] options.host:
         Database host address as one of the following:
@@ -224,9 +226,23 @@ Connection
 Pool
 ====
 
-.. js:function:: createPool(options)
+.. js:function:: createPool(dsn, options)
 
     Create a connection pool to an EdgeDB server.
+
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
+
+        Otherwise it specifies a single string in the connection URI format:
+
+    :param string dsn:
+        If this parameter does not start with ``edgedb://`` then this is
+        a :ref:`name of an instance <edgedb-instances>`.
+
+        Otherwise it specifies a single string in the connection URI format:
+        ``edgedb://user:password@host:port/database?option=value``.
+        The following options are recognized: host, port,
+        user, database, password.
 
     :param options: Connection pool parameters object.
 
@@ -278,12 +294,9 @@ Pool
         const edgedb = require("edgedb");
 
         async function main() {
-            const pool = await edgedb.createPool({
-                connectOptions: {
-                    user: "edgedb",
-                    host: "127.0.0.1",
-                },
-            });
+            const pool = await edgedb.createPool(
+                "edgedb://edgedb@localhost/test"
+            );
 
             try {
                 let data = await pool.queryOne("SELECT [1, 2, 3]");

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,9 +18,7 @@ run queries.
     async function main() {
       // Establish a connection to an existing database
       // named "test" as an "edgedb" user.
-      const conn = await edgedb.connect({
-        dsn: "edgedb://edgedb@localhost/test"
-      });
+      const conn = await edgedb.connect("edgedb://edgedb@localhost/test");
 
       try {
         // Create a User object type.
@@ -113,12 +111,7 @@ a certain number of open connections and borrow them when needed.
 
     async function main() {
       // Create a connection pool to an existing database
-      const pool = await edgedb.createPool({
-        connectOptions: {
-          user: "edgedb",
-          host: "127.0.0.1"
-        },
-      });
+      const pool = await edgedb.createPool("edgedb://edgedb@localhost/test");
 
       try {
         // Create a User object type.

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,9 +65,10 @@ enum TransactionStatus {
 export const proxyMap = new WeakMap<Connection, IConnectionProxied>();
 
 export default function connect(
+  dsn?: string,
   options?: ConnectConfig | null
 ): Promise<Connection> {
-  return ConnectionImpl.connect(options);
+  return ConnectionImpl.connect({...options, dsn});
 }
 
 class ConnectionImpl implements Connection {

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,10 +65,21 @@ enum TransactionStatus {
 export const proxyMap = new WeakMap<Connection, IConnectionProxied>();
 
 export default function connect(
-  dsn?: string,
+  dsn?: string | ConnectConfig | null,
   options?: ConnectConfig | null
 ): Promise<Connection> {
-  return ConnectionImpl.connect({...options, dsn});
+  if (typeof dsn === "string") {
+    return ConnectionImpl.connect({...options, dsn});
+  } else {
+    if (dsn != null) {
+      console.warn(
+        "`options` as the first argument to `edgedb.connect` is " +
+          "deprecated, use " +
+          "`edgedb.connect('instance_name_or_dsn', options)`"
+      );
+    }
+    return ConnectionImpl.connect({...dsn, ...options});
+  }
 }
 
 class ConnectionImpl implements Connection {

--- a/src/con_utils.ts
+++ b/src/con_utils.ts
@@ -36,7 +36,6 @@ export interface NormalizedConnectConfig {
 
 export interface ConnectConfig {
   dsn?: string;
-  credentialsFile?: string;
   host?: string | string[];
   port?: number | number[];
   user?: string;
@@ -253,12 +252,17 @@ function parseConnectDsnAndArgs({
       }
     }
   } else if (dsn) {
-    if (!/[A-Za-z_][A-Za-z_0-9]*/.test(dsn)) {
-        throw Error(`dsn "${dsn}" is neither a edgedb:// URI \
-            nor valid instance name`)
+    if (!/^[A-Za-z_][A-Za-z_0-9]*$/.test(dsn)) {
+      throw Error(
+        `dsn "${dsn}" is neither a edgedb:// URI nor valid instance name`
+      );
     }
-    const credentials_file = path.join(os.homedir(),
-        ".edgedb", "credentials", dsn + ".json");
+    const credentials_file = path.join(
+      os.homedir(),
+      ".edgedb",
+      "credentials",
+      dsn + ".json"
+    );
     const credentials = readCredentialsFile(credentials_file);
     port = credentials.port;
     user = credentials.user;

--- a/src/con_utils.ts
+++ b/src/con_utils.ts
@@ -280,6 +280,9 @@ function parseConnectDsnAndArgs({
       } else {
         host = ["/run/edgedb", "/var/run/edgedb"];
       }
+      if (!admin) {
+        host.push("localhost");
+      }
     }
   } else if (!(host instanceof Array)) {
     host = [host];

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+
+export interface Credentials {
+  host?: string;
+  port: number;
+  user: string;
+  password?: string;
+  database?: string;
+}
+
+export function readCredentialsFile(file: string): Credentials {
+  try {
+    const data = fs.readFileSync(file, {encoding: "utf-8"});
+    return validateCredentials(JSON.parse(data));
+  } catch (e) {
+    throw Error(`cannot read credentials file ${file}: ${e}`);
+  }
+}
+
+export function validateCredentials(data: any): Credentials {
+  let port = data.port;
+  if (port == null) {
+    port = 5656;
+  }
+  if (typeof port !== "number" || port < 1 || port > 65535) {
+    throw Error("invalid `port` value");
+  }
+
+  const user = data.user;
+  if (user == null) {
+    throw Error("`user` key is required");
+  }
+  if (typeof user !== "string") {
+    throw Error("`user` must be string");
+  }
+
+  const result: Credentials = {user, port};
+
+  const host = data.host;
+  if (host != null) {
+    if (typeof host !== "string") {
+      throw Error("`host` must be string");
+    }
+    result.host = host;
+  }
+
+  const database = data.database;
+  if (database != null) {
+    if (typeof database !== "string") {
+      throw Error("`database` must be string");
+    }
+    result.database = database;
+  }
+
+  const password = data.password;
+  if (password != null) {
+    if (typeof password !== "string") {
+      throw Error("`password` must be string");
+    }
+    result.password = password;
+  }
+
+  return result;
+}

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -802,8 +802,19 @@ class PoolImpl implements Pool {
 }
 
 export function createPool(
-  dsn?: string,
+  dsn?: string | PoolOptions | null,
   options?: PoolOptions | null
 ): Promise<Pool> {
-  return PoolImpl.create(dsn, options);
+  if (typeof dsn === "string") {
+    return PoolImpl.create(dsn, options);
+  } else {
+    if (dsn != null) {
+      console.warn(
+        "`options` as the first argument to `edgedb.connect` is " +
+          "deprecated, use " +
+          "`edgedb.connect('instance_name_or_dsn', options)`"
+      );
+    }
+    return PoolImpl.create(undefined, {...dsn, ...options});
+  }
 }

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -319,7 +319,9 @@ test("parseConnectArguments", () => {
 
     {
       opts: {dsn: "pq:///dbname?host=/unix_sock/test&user=spam"},
-      error: "invalid DSN",
+      error:
+        'dsn "pq:///dbname?host=/unix_sock/test&user=spam" ' +
+        "is neither a edgedb:// URI nor valid instance name",
     },
 
     {
@@ -360,47 +362,6 @@ test("parseConnectArguments", () => {
         addrs: [path.join("/tmp", ".s.EDGEDB.5656")],
         user: "user",
         database: "user",
-      },
-    },
-    {
-      opts: {credentialsFile: "test/credentials1.json"},
-      result: {
-        addrs: [
-          "/run/edgedb/.s.EDGEDB.10702",
-          "/var/run/edgedb/.s.EDGEDB.10702",
-          ["localhost", 10702],
-        ],
-        user: "test3n",
-        database: "test3n",
-        password: "lZTBy1RVCfOpBAOwSCwIyBIR",
-      },
-    },
-    {
-      opts: {
-        credentialsFile: "test/credentials1.json",
-        database: "hello",
-      },
-      result: {
-        addrs: [
-          "/run/edgedb/.s.EDGEDB.10702",
-          "/var/run/edgedb/.s.EDGEDB.10702",
-          ["localhost", 10702],
-        ],
-        user: "test3n",
-        database: "hello",
-        password: "lZTBy1RVCfOpBAOwSCwIyBIR",
-      },
-    },
-    {
-      opts: {
-        dsn: "edgedb://user3@localhost:5555/abcdef",
-        // We don't even read credentials file if dns is present
-        credentialsFile: "non-existent.json",
-      },
-      result: {
-        addrs: [["localhost", 5555]],
-        user: "user3",
-        database: "abcdef",
       },
     },
   ];

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -362,6 +362,39 @@ test("parseConnectArguments", () => {
         database: "user",
       },
     },
+    {
+      opts: {credentialsFile: "test/credentials1.json"},
+      result: {
+        addrs: [["localhost", 10702]],
+        user: "test3n",
+        database: "test3n",
+        password: "lZTBy1RVCfOpBAOwSCwIyBIR",
+      },
+    },
+    {
+      opts: {
+        credentialsFile: "test/credentials1.json",
+        database: "hello",
+      },
+      result: {
+        addrs: [["localhost", 10702]],
+        user: "test3n",
+        database: "hello",
+        password: "lZTBy1RVCfOpBAOwSCwIyBIR",
+      },
+    },
+    {
+      opts: {
+        dsn: "edgedb://user3@localhost:5555/abcdef",
+        // We don't even read credentials file if dns is present
+        credentialsFile: "non-existent.json",
+      },
+      result: {
+        addrs: [["localhost", 5555]],
+        user: "user3",
+        database: "abcdef",
+      },
+    },
   ];
 
   for (const testCase of TESTS) {

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -365,7 +365,11 @@ test("parseConnectArguments", () => {
     {
       opts: {credentialsFile: "test/credentials1.json"},
       result: {
-        addrs: [["localhost", 10702]],
+        addrs: [
+          "/run/edgedb/.s.EDGEDB.10702",
+          "/var/run/edgedb/.s.EDGEDB.10702",
+          ["localhost", 10702],
+        ],
         user: "test3n",
         database: "test3n",
         password: "lZTBy1RVCfOpBAOwSCwIyBIR",
@@ -377,7 +381,11 @@ test("parseConnectArguments", () => {
         database: "hello",
       },
       result: {
-        addrs: [["localhost", 10702]],
+        addrs: [
+          "/run/edgedb/.s.EDGEDB.10702",
+          "/var/run/edgedb/.s.EDGEDB.10702",
+          ["localhost", 10702],
+        ],
         user: "test3n",
         database: "hello",
         password: "lZTBy1RVCfOpBAOwSCwIyBIR",

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -1,0 +1,33 @@
+import {readCredentialsFile, validateCredentials} from "../src/credentials";
+
+test("readCredentialsFile", () => {
+  let data = readCredentialsFile("test/credentials1.json");
+  expect(data).toEqual({
+    database: "test3n",
+    password: "lZTBy1RVCfOpBAOwSCwIyBIR",
+    port: 10702,
+    user: "test3n",
+  });
+});
+
+test("emptyCredentials", () => {
+  expect(() => validateCredentials({})).toThrow("`user` key is required");
+});
+
+test("port", () => {
+  expect(() => validateCredentials({user: "u1", port: "abc"})).toThrow(
+    "invalid `port` value"
+  );
+  expect(() => validateCredentials({user: "u1", port: 0})).toThrow(
+    "invalid `port` value"
+  );
+  expect(() => validateCredentials({user: "u1", port: 0.5})).toThrow(
+    "invalid `port` value"
+  );
+  expect(() => validateCredentials({user: "u1", port: -1})).toThrow(
+    "invalid `port` value"
+  );
+  expect(() => validateCredentials({user: "u1", port: 65536})).toThrow(
+    "invalid `port` value"
+  );
+});

--- a/test/credentials1.json
+++ b/test/credentials1.json
@@ -1,0 +1,6 @@
+{
+  "port": 10702,
+  "user": "test3n",
+  "password": "lZTBy1RVCfOpBAOwSCwIyBIR",
+  "database": "test3n"
+}

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -48,7 +48,7 @@ export default async () => {
   global.edgedbProc = proc;
 
   const [host, port] = await done;
-  const con = await connect({
+  const con = await connect(undefined, {
     host,
     port,
     user: "edgedb",

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -58,7 +58,7 @@ describe("pool.initialize: creates minSize count of connections", () => {
       }
 
       const maxSize = minSize + 50;
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize,
         maxSize,
@@ -158,7 +158,7 @@ describe("pool concurrency 1", () => {
   each([1, 5, 10, 20, 100]).it(
     "when concurrency is '%s'",
     async (concurrency) => {
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize: 5,
         maxSize: 10,
@@ -184,7 +184,7 @@ describe("pool concurrency 2", () => {
   each([1, 3, 5, 10, 20, 100]).it(
     "when concurrency is '%s'",
     async (concurrency) => {
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize: 5,
         maxSize: 5,
@@ -210,7 +210,7 @@ describe("pool concurrency 3", () => {
   each([1, 3, 5, 10, 20, 100]).it(
     "when concurrency is '%s'",
     async (concurrency) => {
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize: 5,
         maxSize: 5,
@@ -240,7 +240,7 @@ test("pool.onAcquire callback", async () => {
     deferred.setResult(connection);
   }
 
-  const pool = await createPool({
+  const pool = await createPool(undefined, {
     connectOptions: getConnectOptions(),
     minSize: 5,
     maxSize: 5,
@@ -263,7 +263,7 @@ test("pool.onRelease callback", async () => {
     deferred.setResult(connection);
   }
 
-  const pool = await createPool({
+  const pool = await createPool(undefined, {
     connectOptions: getConnectOptions(),
     minSize: 5,
     maxSize: 5,
@@ -310,7 +310,7 @@ test(
       await pool.release(proxy);
     }
 
-    const _pool = await createPool({
+    const _pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 2,
       maxSize: 5,
@@ -330,12 +330,12 @@ test(
 test(
   "pool.release raises for foreign connection proxy",
   async () => {
-    const pool1 = await createPool({
+    const pool1 = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
     });
-    const pool2 = await createPool({
+    const pool2 = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -360,7 +360,7 @@ test(
 test(
   "pool.release more than once does not raise exception",
   async () => {
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -379,7 +379,7 @@ test(
 test(
   "pool.release more than once does not raise exception",
   async () => {
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -400,7 +400,7 @@ test(
   async () => {
     // This method tests that a released connection proxy cannot be used to
     // do further queries
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -440,7 +440,7 @@ test(
       }
     }
 
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -488,7 +488,7 @@ test(
       }
     }
 
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 0,
       maxSize: 1,
@@ -522,7 +522,7 @@ test(
 test(
   "no acquire deadlock",
   async (done) => {
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -553,7 +553,7 @@ test(
   async () => {
     let called = false;
 
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -574,13 +574,14 @@ test(
     let calls = 0;
 
     async function connectionFactory(
+      dsn: string | undefined,
       options?: ConnectConfig | null
     ): Promise<Connection> {
       calls += 1;
-      return await connect(options);
+      return await connect(dsn, options);
     }
 
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 3,
       maxSize: 5,
@@ -620,7 +621,7 @@ describe("pool connection methods", () => {
     times: number,
     method: (_pool: Pool) => Promise<number>
   ): Promise<void> {
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 5,
       maxSize: 10,
@@ -651,7 +652,7 @@ test(
     let connectionReleased = false;
     const flag = new Deferred<boolean>();
 
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -679,7 +680,7 @@ test(
 test(
   "pool expire connections",
   async () => {
-    const pool = await createPool({
+    const pool = await createPool(undefined, {
       connectOptions: getConnectOptions(),
       minSize: 1,
       maxSize: 1,
@@ -705,7 +706,7 @@ test(
 );
 
 test("createPool.queryOne", async () => {
-  const pool = await createPool({
+  const pool = await createPool(undefined, {
     connectOptions: getConnectOptions(),
   });
   let res;
@@ -724,7 +725,7 @@ describe("pool.getStats: includes the number of open connections", () => {
     "when minSize is '%s'",
     async (minSize) => {
       const maxSize = minSize + 50;
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize,
         maxSize,
@@ -749,7 +750,7 @@ describe("pool.getStats: includes queue length", () => {
       const minSize = 0;
       const maxSize = 10;
 
-      const pool = await createPool({
+      const pool = await createPool(undefined, {
         connectOptions: getConnectOptions(),
         minSize,
         maxSize,

--- a/test/testbase.ts
+++ b/test/testbase.ts
@@ -44,11 +44,11 @@ export function getConnectOptions(): ConnectConfig {
 }
 
 export async function asyncConnect(opts?: ConnectConfig): Promise<Connection> {
-  return await connect(_getOpts(opts ?? {}));
+  return await connect(undefined, _getOpts(opts ?? {}));
 }
 
 export async function getPool(opts?: ConnectConfig): Promise<Pool> {
-  return await createPool({
+  return await createPool(undefined, {
     connectOptions: _getOpts(opts ?? {}),
   });
 }


### PR DESCRIPTION
This adds positional argument to `connect()` and `createPool()` functions which can be either DSN or an instance name.

This is a part of what's discussed in https://github.com/edgedb/edgedb/discussions/1683 other things will follow in the next release.

This also deprecates `admin=True` parameter and `edgedbadmin` schema, as
they aren't needed if proper permissions are set up. And were introduced
mainly for command-line tools.

Supersedes #62 