### PR TITLE
Increase timeout for `pool.onAcquire` and `pool.onRelease` tests

### DIFF
--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -235,6 +235,7 @@ describe("pool concurrency 3", () => {
 });
 
 test("pool.onAcquire callback", async () => {
+  jest.setTimeout(10_000);
   const deferred = new Deferred<Connection>();
 
   async function onAcquire(connection: Connection): Promise<void> {
@@ -258,6 +259,7 @@ test("pool.onAcquire callback", async () => {
 });
 
 test("pool.onRelease callback", async () => {
+  jest.setTimeout(10_000);
   const deferred = new Deferred<Connection>();
 
   async function onRelease(connection: Connection): Promise<void> {


### PR DESCRIPTION
Some tests are sporadically failing ([1130711574](https://github.com/edgedb/edgedb-js/runs/1130711574), [1032853292](https://github.com/edgedb/edgedb-js/runs/1032853292), [1114594457](https://github.com/edgedb/edgedb-js/runs/1114594457), [1060061425](https://github.com/edgedb/edgedb-js/runs/1060061425)) due to `pool.onAcquire` or `pool.onRelease` tests timing out. This increases the timeout from the default 5 seconds to 10 seconds.