### PR TITLE
Switch UUID decoding from a rich object to a string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -136,6 +136,10 @@ class ConnectionImpl implements Connection {
     this.sock.on("close", this._onClose.bind(this));
 
     this.config = config;
+
+    if (config.legacyUUIDMode) {
+      this.codecsRegistry.enableLegacyUUID();
+    }
   }
 
   private async _waitForMessage(): Promise<void> {
@@ -1143,13 +1147,13 @@ class ConnectionImpl implements Connection {
       const connPromise = conn.connect();
       let timeout = null;
       // set-up a timeout
-      if (cfg.connect_timeout) {
-        err = new Error(errMsg + " in " + cfg.connect_timeout + "ms");
+      if (cfg.connectTimeout) {
+        err = new Error(errMsg + " in " + cfg.connectTimeout + "ms");
         timeout = setTimeout(() => {
           if (!conn.connected) {
             conn.sock.destroy(err);
           }
-        }, cfg.connect_timeout);
+        }, cfg.connectTimeout);
       }
 
       try {

--- a/src/codecs/registry.ts
+++ b/src/codecs/registry.ts
@@ -30,6 +30,7 @@ import {NamedTupleCodec} from "./namedtuple";
 import {EnumCodec} from "./enum";
 import {ObjectCodec} from "./object";
 import {SetCodec} from "./set";
+import {UUIDObjectCodec} from "./uuid";
 import {UUID} from "../datatypes/uuid";
 
 const CODECS_CACHE_SIZE = 1000;
@@ -57,6 +58,7 @@ const BIGINT_TYPEID = KNOWN_TYPENAMES.get("std::bigint")!;
 const INT64_TYPEID = KNOWN_TYPENAMES.get("std::int64")!;
 const DATETIME_TYPEID = KNOWN_TYPENAMES.get("std::datetime")!;
 const LOCAL_DATETIME_TYPEID = KNOWN_TYPENAMES.get("cal::local_datetime")!;
+const UUID_TYPEID = KNOWN_TYPENAMES.get("std::uuid")!;
 
 export class CodecsRegistry {
   private codecsBuildCache: LRU<uuid, ICodec>;
@@ -67,6 +69,10 @@ export class CodecsRegistry {
     this.codecs = new LRU({capacity: CODECS_CACHE_SIZE});
     this.codecsBuildCache = new LRU({capacity: CODECS_BUILD_CACHE_SIZE});
     this.customScalarCodecs = new Map();
+  }
+
+  enableLegacyUUID(): void {
+    this.customScalarCodecs.set(UUID_TYPEID, new UUIDObjectCodec(UUID_TYPEID));
   }
 
   setStringCodecs({

--- a/src/codecs/uuid.ts
+++ b/src/codecs/uuid.ts
@@ -20,7 +20,7 @@ import {ReadBuffer, WriteBuffer} from "../buffer";
 import {ICodec, ScalarCodec} from "./ifaces";
 import {UUID, UUIDBufferFromString} from "../datatypes/uuid";
 
-export class UUIDCodec extends ScalarCodec implements ICodec {
+export class UUIDObjectCodec extends ScalarCodec implements ICodec {
   encode(buf: WriteBuffer, object: any): void {
     if (object instanceof UUID) {
       const val = <UUID>object;
@@ -38,5 +38,22 @@ export class UUIDCodec extends ScalarCodec implements ICodec {
 
   decode(buf: ReadBuffer): any {
     return new UUID(buf.readBuffer(16));
+  }
+}
+
+export class UUIDCodec extends ScalarCodec implements ICodec {
+  encode(buf: WriteBuffer, object: any): void {
+    if (typeof object === "string") {
+      const val = <string>object;
+      const ubuf = UUIDBufferFromString(val);
+      buf.writeInt32(16);
+      buf.writeBuffer(ubuf);
+    } else {
+      throw new Error(`cannot encode UUID "${object}": invalid type`);
+    }
+  }
+
+  decode(buf: ReadBuffer): any {
+    return buf.readBuffer(16).toString("hex");
   }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -819,7 +819,10 @@ test("fetch: tuple", async () => {
 });
 
 test("fetch: object", async () => {
-  const con = await asyncConnect();
+  const con = await asyncConnect({
+    legacyUUIDMode: true,
+  });
+
   let res;
   try {
     res = await con.queryOne(`
@@ -945,7 +948,7 @@ test("fetch: object implicit fields", async () => {
       limit 1
     `);
 
-    expect(JSON.stringify(res)).toMatch(/^\{"id":"([\w\d\-]{36})"\}$/);
+    expect(JSON.stringify(res)).toMatch(/^\{"id":"([\w\d]{32})"\}$/);
     expect(JSON.stringify(res)).not.toMatch(/"__tid__"/);
 
     res = await con.queryOne(`
@@ -953,7 +956,7 @@ test("fetch: object implicit fields", async () => {
       limit 1
     `);
 
-    expect(JSON.stringify(res)).toMatch(/"id":"([\w\d\-]{36})"/);
+    expect(JSON.stringify(res)).toMatch(/"id":"([\w\d]{32})"/);
 
     res = await con.queryOne(`
       select schema::Function {
@@ -974,15 +977,13 @@ test("fetch: uuid", async () => {
   let res;
   try {
     res = await con.queryOne("SELECT schema::ObjectType.id LIMIT 1");
-    expect(res instanceof UUID).toBeTruthy();
-    expect(res.buffer.length).toBe(16);
+    expect(typeof res).toBe("string");
+    expect(res.length).toBe(32);
 
     res = await con.queryOne(
       "SELECT <uuid>'759637d8-6635-11e9-b9d4-098002d459d5'"
     );
-    expect(res instanceof UUID).toBeTruthy();
-    expect(res.buffer.length).toBe(16);
-    expect(res.toString()).toBe("759637d8-6635-11e9-b9d4-098002d459d5");
+    expect(res).toBe("759637d8663511e9b9d4098002d459d5");
   } finally {
     await con.close();
   }

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -151,14 +151,14 @@ test("parseConnectArguments", () => {
         user: "user2",
         password: "passw2",
         database: "db2",
-        server_settings: {ssl: "False"},
+        serverSettings: {ssl: "False"},
       },
       result: {
         addrs: [["host2", 456]],
         user: "user2",
         password: "passw2",
         database: "db2",
-        server_settings: {ssl: "False"},
+        serverSettings: {ssl: "False"},
       },
     },
 
@@ -179,7 +179,7 @@ test("parseConnectArguments", () => {
         user: "user3",
         password: "123123",
         database: "abcdef",
-        command_timeout: 10,
+        commandTimeout: 10,
       },
     },
 
@@ -279,7 +279,7 @@ test("parseConnectArguments", () => {
       },
       result: {
         addrs: [["127.0.0.1", 888]],
-        server_settings: {param: "123"},
+        serverSettings: {param: "123"},
         user: "me",
         password: "ask",
         database: "db",
@@ -297,11 +297,11 @@ test("parseConnectArguments", () => {
         user: "me",
         password: "ask",
         database: "db",
-        server_settings: {aa: "bb"},
+        serverSettings: {aa: "bb"},
       },
       result: {
         addrs: [["127.0.0.1", 888]],
-        server_settings: {aa: "bb", param: "123"},
+        serverSettings: {aa: "bb", param: "123"},
         user: "me",
         password: "ask",
         database: "db",


### PR DESCRIPTION
Due to JS' Map and Set objects hashing by identity (and not
via __eq__ and __hash__ like in Python), wrapping a UUID in
an object makes it way less usable.

From now on, by default, EdgeDB UUIDs will be decoded into JS
strings and decoded from JS strings. Since UUIDs are quite
common, they are decoded to strings as fast as possible. That
means that a '759637d8-6635-11e9-b9d4-098002d459d5' UUID would
be decoded into a '759637d8663511e9b9d4098002d459d5' string.
Although properly formatted UUIDs are accepted as input as well.

To enable the old behavior set the `legacyUUIDMode: true`
connect config option.

While at it, rename command_timeout and server_settings undocumented
connect config options to commandTimeout and serverSettings.