### PR TITLE
Fixes forward compability with the new edgedb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Install EdgeDB
         env:
           OS_NAME: ${{ matrix.os }}
-          SLOT: 1-alpha4
+          SLOT: 1-alpha6-dev5104
         run: |
           .github/workflows/install-edgedb.sh
 
       - name: Run functional tests
         env:
-          EDGEDB_SLOT: 1-alpha4
+          EDGEDB_SLOT: 1-alpha6-dev5104
         run: |
           yarn test

--- a/src/client.ts
+++ b/src/client.ts
@@ -363,8 +363,8 @@ class ConnectionImpl implements Connection {
 
     handshake
       .beginMessage(chars.$V)
-      .writeInt16(1)
-      .writeInt16(0);
+      .writeInt16(PROTO_VER_MAJOR)
+      .writeInt16(PROTO_VER_MINOR);
 
     handshake.writeInt16(2);
     handshake.writeString("user");


### PR DESCRIPTION
With how it's written before the change server returns the largest
protocol it supports and as long as server is updated JavaScript
bindings crash with unsupported protocol error.

This, together with edgedb/edgedb#2019 fixes tests with nightly edgedb.