### PR TITLE
Updates of the bindings to fix support of edgedb 1-beta1

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -212,10 +212,12 @@ class ConnectionImpl implements Connection {
     }
   }
 
-  private _rejectHeaders(): void {
-    const nheaders = this.buffer.readInt16();
-    if (nheaders) {
-      throw new Error("unexpected headers");
+  private _ignoreHeaders(): void {
+    let numFields = this.buffer.readInt16();
+    while (numFields) {
+      this.buffer.readInt16();
+      this.buffer.readLenPrefixedBuffer();
+      numFields--;
     }
   }
 
@@ -238,7 +240,7 @@ class ConnectionImpl implements Connection {
     Buffer,
     Buffer
   ] {
-    this._rejectHeaders();
+    this._ignoreHeaders();
 
     const cardinality: char = this.buffer.readChar();
 
@@ -264,7 +266,7 @@ class ConnectionImpl implements Connection {
   }
 
   private _parseCommandCompleteMessage(): string {
-    this._rejectHeaders();
+    this._ignoreHeaders();
     const status = this.buffer.readString();
     this.buffer.finishMessage();
     return status;
@@ -595,7 +597,7 @@ class ConnectionImpl implements Connection {
 
       switch (mtype) {
         case chars.$1: {
-          this._rejectHeaders();
+          this._ignoreHeaders();
           cardinality = this.buffer.readChar();
           inTypeId = this.buffer.readUUID();
           outTypeId = this.buffer.readUUID();

--- a/src/con_utils.ts
+++ b/src/con_utils.ts
@@ -347,7 +347,7 @@ function parseConnectDsnAndArgs({
     user = process.env.EDGEDB_USER;
   }
   if (!user) {
-    throw new Error("could not determine user name to connect with");
+    user = "edgedb";
   }
 
   if (!password) {
@@ -358,10 +358,7 @@ function parseConnectDsnAndArgs({
     database = process.env.EDGEDB_DATABASE;
   }
   if (!database) {
-    database = user;
-  }
-  if (!database) {
-    throw new Error("could not determine database name to connect to");
+    database = "edgedb";
   }
 
   let haveUnixSockets = false;

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -92,7 +92,7 @@ test("parseConnectArguments", () => {
       result: {
         addrs: [["localhost", 5656]],
         user: "user",
-        database: "user",
+        database: "edgedb",
       },
     },
 
@@ -334,7 +334,7 @@ test("parseConnectArguments", () => {
       result: {
         addrs: [path.join("/tmp", ".s.EDGEDB.56226")],
         user: "user",
-        database: "user",
+        database: "edgedb",
       },
     },
 
@@ -343,7 +343,7 @@ test("parseConnectArguments", () => {
       result: {
         addrs: [path.join("/tmp", ".s.EDGEDB.admin.5656")],
         user: "user",
-        database: "user",
+        database: "edgedb",
       },
     },
 
@@ -352,7 +352,7 @@ test("parseConnectArguments", () => {
       result: {
         addrs: [path.join("/tmp", ".s.EDGEDB.admin.5656")],
         user: "user",
-        database: "user",
+        database: "edgedb",
       },
     },
 
@@ -361,7 +361,7 @@ test("parseConnectArguments", () => {
       result: {
         addrs: [path.join("/tmp", ".s.EDGEDB.5656")],
         user: "user",
-        database: "user",
+        database: "edgedb",
       },
     },
   ];


### PR DESCRIPTION
* Ignore extra headers by default
* Use `edgedb` as username and database name by default 