### PR TITLE
RFC1004: Add `try_transaction` and `retry`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ enum TransactionStatus {
 
 const DEFAULT_MAX_ITERATIONS = 3;
 
-function default_backoff(attempt: number) {
+function default_backoff(attempt: number): number {
   return 2 ** attempt * 100 + Math.random() * 100;
 }
 
@@ -268,8 +268,8 @@ class StandaloneConnection implements Connection {
     }
     return await connection.queryOneJSON(query, args);
   }
-  _check_borrow() {
-    let borrow = this[BORROW];
+  _check_borrow(): void {
+    const borrow = this[BORROW];
     if (borrow) {
       let text;
       switch (borrow) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -185,7 +185,7 @@ class StandaloneConnection implements Connection {
     let result: T;
     for (let iteration = 0; iteration < DEFAULT_MAX_ITERATIONS; ++iteration) {
       const transaction = new Transaction(this);
-      await transaction[START_TRANSACTION_IMPL](iteration != 0);
+      await transaction[START_TRANSACTION_IMPL](iteration !== 0);
       try {
         result = await action(transaction);
       } catch (err) {
@@ -196,7 +196,7 @@ class StandaloneConnection implements Connection {
             // We ignore EdgeDBError errors on rollback, retrying
             // if possible. All other errors are propagated.
             throw rollback_err;
-          }          
+          }
         }
         if (
           err instanceof errors.EdgeDBError &&
@@ -247,7 +247,7 @@ class StandaloneConnection implements Connection {
   }
 
   async execute(query: string): Promise<void> {
-    let borrowed_for = this[BORROWED_FOR];
+    const borrowed_for = this[BORROWED_FOR];
     if (borrowed_for) {
       throw borrow_error(borrowed_for);
     }
@@ -259,7 +259,7 @@ class StandaloneConnection implements Connection {
   }
 
   async query(query: string, args?: QueryArgs): Promise<Set> {
-    let borrowed_for = this[BORROWED_FOR];
+    const borrowed_for = this[BORROWED_FOR];
     if (borrowed_for) {
       throw borrow_error(borrowed_for);
     }
@@ -271,7 +271,7 @@ class StandaloneConnection implements Connection {
   }
 
   async queryJSON(query: string, args?: QueryArgs): Promise<string> {
-    let borrowed_for = this[BORROWED_FOR];
+    const borrowed_for = this[BORROWED_FOR];
     if (borrowed_for) {
       throw borrow_error(borrowed_for);
     }
@@ -283,7 +283,7 @@ class StandaloneConnection implements Connection {
   }
 
   async queryOne(query: string, args?: QueryArgs): Promise<any> {
-    let borrowed_for = this[BORROWED_FOR];
+    const borrowed_for = this[BORROWED_FOR];
     if (borrowed_for) {
       throw borrow_error(borrowed_for);
     }
@@ -295,7 +295,7 @@ class StandaloneConnection implements Connection {
   }
 
   async queryOneJSON(query: string, args?: QueryArgs): Promise<string> {
-    let borrowed_for = this[BORROWED_FOR];
+    const borrowed_for = this[BORROWED_FOR];
     if (borrowed_for) {
       throw borrow_error(borrowed_for);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,7 @@ enum TransactionStatus {
 const DEFAULT_MAX_ITERATIONS = 3;
 
 function default_backoff(attempt: number) {
-    return (2**attempt) * 100 + Math.random()*100;
+  return 2 ** attempt * 100 + Math.random() * 100;
 }
 
 /* Internal mapping used to break strong reference between
@@ -137,8 +137,8 @@ class StandaloneConnection implements Connection {
     // tslint:disable-next-line: no-console
     console.warn(
       "The `transaction()` method is deprecated and is scheduled to be " +
-      "removed. Use the `retry()` or `try_transaction()` method " +
-      "instead"
+        "removed. Use the `retry()` or `try_transaction()` method " +
+        "instead"
     );
     let connection = this._connection;
     if (!connection || connection.isClosed()) {
@@ -148,7 +148,7 @@ class StandaloneConnection implements Connection {
   }
 
   async try_transaction<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     let result: T;
     const transaction = new Transaction(this);
@@ -164,10 +164,10 @@ class StandaloneConnection implements Connection {
   }
 
   async retry<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     let result: T;
-    for(let iteration = 0; iteration < DEFAULT_MAX_ITERATIONS; ++iteration) {
+    for (let iteration = 0; iteration < DEFAULT_MAX_ITERATIONS; ++iteration) {
       const transaction = new Transaction(this);
       await transaction.start();
       try {
@@ -175,18 +175,19 @@ class StandaloneConnection implements Connection {
       } catch (err) {
         try {
           await transaction.rollback();
-        } catch(rollback_err) {
-          if(rollback_err instanceof errors.EdgeDBError) {
+        } catch (rollback_err) {
+          if (rollback_err instanceof errors.EdgeDBError) {
             // ignore errors on rollback, just retry if possible
             // or propagate normal error if it isn't
           } else {
             throw rollback_err; // rethrow other errors normally
           }
         }
-        if(err instanceof errors.EdgeDBError &&
+        if (
+          err instanceof errors.EdgeDBError &&
           err.hasTag(errors.SHOULD_RETRY) &&
-          iteration + 1 < DEFAULT_MAX_ITERATIONS)
-        {
+          iteration + 1 < DEFAULT_MAX_ITERATIONS
+        ) {
           await sleep(default_backoff(iteration));
           continue;
         }
@@ -203,7 +204,6 @@ class StandaloneConnection implements Connection {
     }
     throw Error("unreachable");
   }
-
 
   async close(): Promise<void> {
     try {
@@ -270,15 +270,16 @@ class StandaloneConnection implements Connection {
   }
   _check_borrow() {
     let borrow = this[BORROW];
-    if(borrow) {
+    if (borrow) {
       let text;
-      switch(borrow) {
+      switch (borrow) {
         case BorrowReason.TRANSACTION:
-          text = "Connection object is borrowed for the transaction. " +
+          text =
+            "Connection object is borrowed for the transaction. " +
             "Use the methods on transaction object instead.";
           break;
       }
-      throw new errors.InterfaceError(text)
+      throw new errors.InterfaceError(text);
     }
   }
   private async _reconnect(): Promise<ConnectionImpl> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -176,12 +176,11 @@ class StandaloneConnection implements Connection {
         try {
           await transaction.rollback();
         } catch (rollback_err) {
-          if (rollback_err instanceof errors.EdgeDBError) {
-            // ignore errors on rollback, just retry if possible
-            // or propagate normal error if it isn't
-          } else {
-            throw rollback_err; // rethrow other errors normally
-          }
+          if (!(rollback_err instanceof errors.EdgeDBError)) {
+            // We ignore EdgeDBError errors on rollback, retrying
+            // if possible. All other errors are propagated.
+            throw rollback_err;
+          }          
         }
         if (
           err instanceof errors.EdgeDBError &&

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -1,6 +1,6 @@
 export class EdgeDBError extends Error {
   source?: Error;
-  protected static tags: object;
+  protected static tags: object = {};
 
   hasTag(tag: symbol): boolean {
     // Can't index by symbol, except when using <any>:

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -398,12 +398,14 @@ export class TransactionError extends ExecutionError {
 }
 
 export class TransactionSerializationError extends TransactionError {
+  protected static tags = {[tags.SHOULD_RETRY]: true};
   get code(): number {
     return 0x05_03_00_01;
   }
 }
 
 export class TransactionDeadlockError extends TransactionError {
+  protected static tags = {[tags.SHOULD_RETRY]: true};
   get code(): number {
     return 0x05_03_00_02;
   }
@@ -458,16 +460,32 @@ export class ClientConnectionFailedError extends ClientConnectionError {
 }
 
 export class ClientConnectionFailedTemporarilyError extends ClientConnectionFailedError {
-  protected static tags = {[tags.SHOULD_RECONNECT]: true};
+  protected static tags = {
+    [tags.SHOULD_RETRY]: true,
+    [tags.SHOULD_RECONNECT]: true,
+  };
   get code(): number {
     return 0xff_01_01_01;
   }
 }
 
 export class ClientConnectionTimeoutError extends ClientConnectionError {
-  protected static tags = {[tags.SHOULD_RECONNECT]: true};
+  protected static tags = {
+    [tags.SHOULD_RETRY]: true,
+    [tags.SHOULD_RECONNECT]: true,
+  };
   get code(): number {
     return 0xff_01_02_00;
+  }
+}
+
+export class ClientConnectionClosedError extends ClientConnectionError {
+  protected static tags = {
+    [tags.SHOULD_RETRY]: true,
+    [tags.SHOULD_RECONNECT]: true,
+  };
+  get code(): number {
+    return 0xff_01_03_00;
   }
 }
 

--- a/src/errors/map.ts
+++ b/src/errors/map.ts
@@ -97,6 +97,7 @@ errorMapping.set(0xff_01_00_00, errors.ClientConnectionError);
 errorMapping.set(0xff_01_01_00, errors.ClientConnectionFailedError);
 errorMapping.set(0xff_01_01_01, errors.ClientConnectionFailedTemporarilyError);
 errorMapping.set(0xff_01_02_00, errors.ClientConnectionTimeoutError);
+errorMapping.set(0xff_01_03_00, errors.ClientConnectionClosedError);
 errorMapping.set(0xff_02_00_00, errors.InterfaceError);
 errorMapping.set(0xff_02_01_00, errors.QueryArgumentError);
 errorMapping.set(0xff_02_01_01, errors.MissingArgumentError);

--- a/src/errors/tags.ts
+++ b/src/errors/tags.ts
@@ -1,1 +1,2 @@
 export const SHOULD_RECONNECT: symbol = Symbol("SHOULD_RECONNECT");
+export const SHOULD_RETRY: symbol = Symbol("SHOULD_RETRY");

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -92,6 +92,9 @@ export interface Connection extends Executor {
   try_transaction<T>(
     action: (transaction: Transaction) => Promise<T>,
   ): Promise<T>;
+  retry<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T>;
   close(): Promise<void>;
   isClosed(): boolean;
 }
@@ -107,6 +110,9 @@ export interface Pool extends Executor {
     options?: TransactionOptions
   ): Promise<T>;
   try_transaction<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T>;
+  retry<T>(
     action: (transaction: Transaction) => Promise<T>,
   ): Promise<T>;
   close(): Promise<void>;

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -24,8 +24,8 @@ import {
   LocalTime,
   Duration,
 } from "./datatypes/datetime";
-import {Transaction} from "./transaction"
-import {ConnectionImpl} from "./client"
+import {Transaction} from "./transaction";
+import {ConnectionImpl} from "./client";
 
 import {Set} from "./datatypes/set";
 
@@ -90,11 +90,9 @@ export interface Connection extends Executor {
     options?: TransactionOptions
   ): Promise<T>;
   try_transaction<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T>;
-  retry<T>(
-    action: (transaction: Transaction) => Promise<T>,
-  ): Promise<T>;
+  retry<T>(action: (transaction: Transaction) => Promise<T>): Promise<T>;
   close(): Promise<void>;
   isClosed(): boolean;
 }
@@ -110,11 +108,9 @@ export interface Pool extends Executor {
     options?: TransactionOptions
   ): Promise<T>;
   try_transaction<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T>;
-  retry<T>(
-    action: (transaction: Transaction) => Promise<T>,
-  ): Promise<T>;
+  retry<T>(action: (transaction: Transaction) => Promise<T>): Promise<T>;
   close(): Promise<void>;
   isClosed(): boolean;
 

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -69,7 +69,7 @@ export interface ReadOnlyExecutor {
   queryOneJSON(query: string, args?: QueryArgs): Promise<string>;
 }
 
-export const BORROW = Symbol();
+export const BORROWED_FOR = Symbol();
 export const CONNECTION_IMPL = Symbol();
 export const ALLOW_MODIFICATIONS = Symbol();
 
@@ -83,7 +83,7 @@ interface Modifiable {
 export type Executor = ReadOnlyExecutor & Modifiable;
 
 export interface Connection extends Executor {
-  [BORROW]?: BorrowReason;
+  [BORROWED_FOR]?: BorrowReason;
   [CONNECTION_IMPL](single_connect?: boolean): Promise<ConnectionImpl>;
   transaction<T>(
     action: () => Promise<T>,

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -84,7 +84,7 @@ export type Executor = ReadOnlyExecutor & Modifiable;
 
 export interface Connection extends Executor {
   [BORROW]?: BorrowReason;
-  [CONNECTION_IMPL](): Promise<ConnectionImpl>;
+  [CONNECTION_IMPL](single_connect?: boolean): Promise<ConnectionImpl>;
   transaction<T>(
     action: () => Promise<T>,
     options?: TransactionOptions

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -325,6 +325,12 @@ export class PoolConnectionProxy implements IConnectionProxied {
     return await this[unwrapConnection]().try_transaction(action);
   }
 
+  async retry<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T> {
+    return await this[unwrapConnection]().retry(action);
+  }
+
   async query(query: string, args?: QueryArgs): Promise<Set> {
     return await this[unwrapConnection]().query(query, args);
   }
@@ -733,6 +739,14 @@ class PoolImpl implements Pool {
   ): Promise<T> {
     return await this.run(async (connection) => {
       return await connection.try_transaction(action);
+    });
+  }
+
+  async retry<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T> {
+    return await this.run(async (connection) => {
+      return await connection.retry(action);
     });
   }
 

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -21,10 +21,11 @@ import {ConnectConfig} from "./con_utils";
 import {LifoQueue} from "./queues";
 import {Set} from "./datatypes/set";
 
-import connect, {proxyMap} from "./client";
+import connect, {proxyMap, ConnectionImpl} from "./client";
 
 import {
   ALLOW_MODIFICATIONS,
+  CONNECTION_IMPL,
   QueryArgs,
   Connection,
   IConnectionProxied,
@@ -273,12 +274,12 @@ class PoolConnectionHolder {
   }
 }
 
-const holderAttr = Symbol.for("holder");
-const detach = Symbol.for("detach");
-export const getHolder = Symbol.for("getHolder");
-const connectionAttr = Symbol.for("connection");
-export const unwrapConnection = Symbol.for("unwrap");
-const isDetached = Symbol.for("isDetached");
+const holderAttr = Symbol("holder");
+const detach = Symbol("detach");
+export const getHolder = Symbol("getHolder");
+const connectionAttr = Symbol("connection");
+export const unwrapConnection = Symbol("unwrap");
+const isDetached = Symbol("isDetached");
 
 export class PoolConnectionProxy implements IConnectionProxied {
   [ALLOW_MODIFICATIONS]: never;
@@ -295,6 +296,9 @@ export class PoolConnectionProxy implements IConnectionProxied {
       );
     }
     proxyMap.set(connection, this);
+  }
+  async [CONNECTION_IMPL](): Promise<ConnectionImpl> {
+    return await this[unwrapConnection]()[CONNECTION_IMPL]()
   }
 
   private [unwrapConnection](): Connection {
@@ -314,6 +318,11 @@ export class PoolConnectionProxy implements IConnectionProxied {
     options?: TransactionOptions
   ): Promise<T> {
     return await this[unwrapConnection]().transaction(action, options);
+  }
+  async try_transaction<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T> {
+    return await this[unwrapConnection]().try_transaction(action);
   }
 
   async query(query: string, args?: QueryArgs): Promise<Set> {
@@ -715,11 +724,16 @@ class PoolImpl implements Pool {
     options?: TransactionOptions
   ): Promise<T> {
     throw new errors.InterfaceError(
-      "Operation not supported. Use a `transaction` on a specific db " +
-        "connection. For example: pool.run((con) => {" +
-        "con.transaction(() => {...})" +
-        "})"
+      "Operation not supported. Use a `try_transaction()` or `retry()`"
     );
+  }
+
+  async try_transaction<T>(
+    action: (transaction: Transaction) => Promise<T>,
+  ): Promise<T> {
+    return await this.run(async (connection) => {
+      return await connection.try_transaction(action);
+    });
   }
 
   async execute(query: string): Promise<void> {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -298,7 +298,7 @@ export class PoolConnectionProxy implements IConnectionProxied {
     proxyMap.set(connection, this);
   }
   async [CONNECTION_IMPL](): Promise<ConnectionImpl> {
-    return await this[unwrapConnection]()[CONNECTION_IMPL]()
+    return await this[unwrapConnection]()[CONNECTION_IMPL]();
   }
 
   private [unwrapConnection](): Connection {
@@ -320,13 +320,13 @@ export class PoolConnectionProxy implements IConnectionProxied {
     return await this[unwrapConnection]().transaction(action, options);
   }
   async try_transaction<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     return await this[unwrapConnection]().try_transaction(action);
   }
 
   async retry<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     return await this[unwrapConnection]().retry(action);
   }
@@ -735,7 +735,7 @@ class PoolImpl implements Pool {
   }
 
   async try_transaction<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     return await this.run(async (connection) => {
       return await connection.try_transaction(action);
@@ -743,7 +743,7 @@ class PoolImpl implements Pool {
   }
 
   async retry<T>(
-    action: (transaction: Transaction) => Promise<T>,
+    action: (transaction: Transaction) => Promise<T>
   ): Promise<T> {
     return await this.run(async (connection) => {
       return await connection.retry(action);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -172,7 +172,7 @@ export class Transaction implements Executor {
     if (!conn) {
       throw new errors.InterfaceError("Transaction is not started");
     } else {
-      return conn
+      return conn;
     }
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 import * as errors from "./errors";
-import {BORROW, BorrowReason, Connection, TransactionOptions} from "./ifaces";
+import {BorrowReason, Connection, TransactionOptions} from "./ifaces";
 import {Executor, QueryArgs, CONNECTION_IMPL} from "./ifaces";
-import {ALLOW_MODIFICATIONS} from "./ifaces";
+import {ALLOW_MODIFICATIONS, BORROWED_FOR} from "./ifaces";
 import {getUniqueId} from "./utils";
 import {ConnectionImpl} from "./client";
 import {Set} from "./datatypes/set";
@@ -158,18 +158,18 @@ export class Transaction implements Executor {
   async [START_TRANSACTION_IMPL](
     single_connect: boolean = false
   ): Promise<void> {
-    this._connection[BORROW] = BorrowReason.TRANSACTION;
+    this._connection[BORROWED_FOR] = BorrowReason.TRANSACTION;
     this._impl = await this._connection[CONNECTION_IMPL](single_connect);
     await this._execute(this._makeStartQuery(), TransactionState.STARTED);
   }
 
   async commit(): Promise<void> {
-    this._connection[BORROW] = undefined;
+    this._connection[BORROWED_FOR] = undefined;
     await this._execute(this._makeCommitQuery(), TransactionState.COMMITTED);
   }
 
   async rollback(): Promise<void> {
-    this._connection[BORROW] = undefined;
+    this._connection[BORROWED_FOR] = undefined;
     await this._execute(
       this._makeRollbackQuery(),
       TransactionState.ROLLEDBACK

--- a/test/legacy_transaction.test.ts
+++ b/test/legacy_transaction.test.ts
@@ -1,0 +1,263 @@
+/*!
+ * This source file is part of the EdgeDB open source project.
+ *
+ * Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as errors from "../src/errors";
+import {asyncConnect} from "./testbase";
+import {
+  connectionsInTransaction,
+  Transaction,
+  TransactionState,
+} from "../src/legacy_transaction";
+import {Connection, IsolationLevel} from "../src/ifaces";
+
+const typename = "TransactionTest";
+
+async function run(test: (con: Connection) => Promise<void>): Promise<void> {
+  const connection = await asyncConnect();
+
+  try {
+    await test(connection);
+  } finally {
+    await connection.close();
+  }
+}
+
+beforeAll(async () => {
+  await run(async (con) => {
+    await con.execute(`
+      CREATE TYPE ${typename} {
+        CREATE REQUIRED PROPERTY name -> std::str;
+      };
+    `);
+  });
+});
+
+afterAll(async () => {
+  await run(async (con) => {
+    await con.execute(`DROP TYPE ${typename};`);
+  });
+});
+
+test("transaction: regular 01", async () => {
+  await run(async (con) => {
+    async function faulty(): Promise<void> {
+      await con.transaction(async () => {
+        await con.execute(`
+          INSERT ${typename} {
+            name := 'Test Transaction'
+          };
+        `);
+        await con.execute("SELECT 1 / 0;");
+      });
+    }
+
+    await expect(faulty()).rejects.toThrow(
+      new errors.DivisionByZeroError().message
+    );
+
+    const items = await con.query(
+      `select ${typename} {name} filter .name = 'Test Transaction'`
+    );
+
+    expect(items).toHaveLength(0);
+  });
+});
+
+test("transaction: nested 01", async () => {
+  await run(async (con) => {
+    expect(connectionsInTransaction.get(con)).toBeUndefined();
+
+    function assertTransactionIsDefined(connection: Connection): void {
+      // @ts-ignore
+      const transaction = connectionsInTransaction.get(connection._connection);
+      expect(transaction).toBeDefined();
+      // @ts-ignore
+      expect(transaction?._connection).toBe(connection._connection);
+    }
+
+    try {
+      await con.transaction(async () => {
+        assertTransactionIsDefined(con);
+
+        // internal transaction
+        await con.transaction(async () => {
+          assertTransactionIsDefined(con);
+          await con.execute(`
+            INSERT ${typename} {
+              name := 'TXTEST 1'
+            };
+          `);
+        });
+
+        assertTransactionIsDefined(con);
+
+        async function faulty(): Promise<void> {
+          await con.transaction(async () => {
+            assertTransactionIsDefined(con);
+
+            await con.execute(`
+              INSERT ${typename} {
+                name := 'TXTEST 2'
+              };
+            `);
+            await con.execute("SELECT 1 / 0;");
+          });
+        }
+
+        await expect(faulty()).rejects.toThrow(
+          new errors.DivisionByZeroError().message
+        );
+
+        const records2 = await con.query(`
+          SELECT ${typename} {
+            name
+          }
+          FILTER .name LIKE 'TXTEST%';
+        `);
+
+        expect(records2[0].name).toEqual("TXTEST 1");
+        assertTransactionIsDefined(con);
+
+        await con.execute("SELECT 1 / 0;");
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(errors.DivisionByZeroError);
+    }
+
+    expect(connectionsInTransaction.get(con)).toBeUndefined();
+
+    const records = await con.query(`
+      SELECT ${typename} {
+        name
+      }
+      FILTER .name LIKE 'TXTEST%';
+    `);
+
+    expect(records).toHaveLength(0);
+  });
+});
+
+test("transaction_nested_02", async () => {
+  await run(async (con) => {
+    await con.transaction(
+      async () => {
+        await con.transaction(async () => {
+          // no explicit isolation, OK, because the nested transaction
+          // inherits the setting from the top transaction
+        });
+      },
+      {
+        isolation: IsolationLevel.REPEATABLE_READ,
+      }
+    );
+
+    async function faulty1(): Promise<void> {
+      await con.transaction(
+        async () => {
+          await con.transaction(
+            async () => {
+              // ...
+            },
+            {
+              isolation: IsolationLevel.SERIALIZABLE,
+            }
+          );
+        },
+        {
+          isolation: IsolationLevel.REPEATABLE_READ,
+        }
+      );
+    }
+
+    await expect(faulty1()).rejects.toThrowError(
+      new errors.InterfaceError(
+        "nested transaction has a different isolation level: " +
+          "current serializable != outer repeatable_read"
+      )
+    );
+
+    async function faulty2(): Promise<void> {
+      await con.transaction(async () => {
+        await con.transaction(
+          async () => {
+            // ...
+          },
+          {
+            readonly: true,
+          }
+        );
+      });
+    }
+
+    await expect(faulty2()).rejects.toThrowError(
+      new errors.InterfaceError(
+        "nested transaction has a different read-write spec: " +
+          "current true != outer undefined"
+      )
+    );
+
+    async function faulty3(): Promise<void> {
+      await con.transaction(async () => {
+        await con.transaction(
+          async () => {
+            // ...
+          },
+          {
+            deferrable: true,
+          }
+        );
+      });
+    }
+
+    await expect(faulty3()).rejects.toThrowError(
+      new errors.InterfaceError(
+        "nested transaction has a different deferrable spec: " +
+          "current true != outer undefined"
+      )
+    );
+  });
+});
+
+test("transaction interface errors", async () => {
+  await run(async (con) => {
+    const transaction = new Transaction(con);
+
+    async function faulty1(): Promise<void> {
+      await transaction.start();
+      await transaction.start();
+    }
+
+    await expect(faulty1()).rejects.toThrowError(
+      new errors.InterfaceError(
+        "cannot start; the transaction is already started"
+      )
+    );
+
+    expect(transaction.state === TransactionState.FAILED);
+
+    await transaction.rollback();
+
+    expect(transaction.state === TransactionState.ROLLEDBACK);
+
+    await expect(faulty1()).rejects.toThrowError(
+      new errors.InterfaceError(
+        "cannot start; the transaction is already rolled back"
+      )
+    );
+  });
+});

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -808,10 +808,7 @@ test("pool transaction throws", async () => {
 
     await expect(faulty()).rejects.toThrowError(
       new errors.InterfaceError(
-        "Operation not supported. Use a `transaction` on a specific db " +
-          "connection. For example: pool.run((con) => {" +
-          "con.transaction(() => {...})" +
-          "})"
+        "Operation not supported. Use a `try_transaction()` or `retry()`"
       )
     );
   } finally {

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -820,7 +820,6 @@ test("pool retry works", async () => {
   const pool = await getPool();
 
   try {
-
     let result = await pool.retry(async (tx) => {
       return await tx.queryOne(`SELECT 33*21`);
     });

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -815,3 +815,17 @@ test("pool transaction throws", async () => {
     await pool.close();
   }
 });
+
+test("pool retry works", async () => {
+  const pool = await getPool();
+
+  try {
+
+    let result = await pool.retry(async (tx) => {
+      return await tx.queryOne(`SELECT 33*21`);
+    });
+    expect(result).toEqual(693);
+  } finally {
+    await pool.close();
+  }
+});

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,154 @@
+/*!
+ * This source file is part of the EdgeDB open source project.
+ *
+ * Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as errors from "../src/errors";
+import {asyncConnect} from "./testbase";
+import {
+  Transaction,
+  TransactionState,
+} from "../src/transaction";
+import {Connection, IsolationLevel} from "../src/ifaces";
+
+class Barrier {
+  _counter: number;
+  _waiters: (() => void)[];
+  constructor(counter: number) {
+    this._counter = counter;
+    this._waiters = [];
+  }
+  async ready() {
+    if(this._counter == 0) {
+      return;
+    }
+    this._counter -= 1;
+    if(this._counter == 0) {
+      for(let waiter of this._waiters.splice(0, this._waiters.length)) {
+        waiter();
+      }
+    } else {
+      await new Promise((accept) => {
+        this._waiters.push(accept);
+      });
+    }
+  }
+}
+
+const typename = "RetryTest";
+
+async function run(test: (con: Connection) => Promise<void>): Promise<void> {
+  const connection = await asyncConnect();
+
+  try {
+    await test(connection);
+  } finally {
+    await connection.close();
+  }
+}
+
+async function run2(
+  test: (con1: Connection, con2: Connection) => Promise<void>,
+): Promise<void> {
+  const connection = await asyncConnect();
+  try {
+    const connection2 = await asyncConnect();
+    try {
+      await test(connection, connection2);
+    } finally {
+      await connection2.close();
+    }
+  } finally {
+      await connection.close();
+  }
+}
+
+beforeAll(async () => {
+  await run(async (con) => {
+    await con.execute(`
+      CREATE TYPE ${typename} EXTENDING std::Object {
+        CREATE PROPERTY name -> std::str {
+          CREATE CONSTRAINT std::exclusive;
+        };
+        CREATE PROPERTY value -> std::int32 {
+          SET default := 0;
+        };
+      };
+    `);
+  });
+});
+
+afterAll(async () => {
+  await run(async (con) => {
+    await con.execute(`DROP TYPE ${typename};`);
+  });
+});
+
+test("retry: regular 01", async () => {
+  await run(async (con) => {
+    await con.retry(async (tx) => {
+      await tx.execute(`
+        INSERT ${typename} {
+          name := 'counter1'
+        };
+      `);
+    });
+  });
+});
+
+test("retry: conflict", async () => {
+  await run2(async (con, con2) => {
+    let iterations = 0;
+    let barrier = new Barrier(2);
+
+    async function transaction(con: Connection): Promise<void> {
+      return await con.retry(async (tx) => {
+        iterations += 1;
+
+        // This magic query makes the test more reliable for some
+        // reason. I guess this is because starting a transaction
+        // in EdgeDB (and/or Postgres) is accomplished somewhat
+        // lazily, i.e. only start transaction on the first query
+        // rather than on the `START TRANSACTION`.
+        await tx.query(`SELECT 1`);
+
+        // Start both transactions at the same initial data.
+        // One should succeed other should fail and retry.
+        // On next attempt, the latter should succeed
+        await barrier.ready();
+
+        return await tx.queryOne(`
+          SELECT (
+            INSERT ${typename} {
+              name := 'counter2',
+              value := 1,
+            } UNLESS CONFLICT ON .name
+            ELSE (
+              UPDATE ${typename}
+              SET { value := .value + 1 }
+            )
+          ).value
+        `);
+      });
+    }
+
+    let results = await Promise.all([transaction(con), transaction(con2)]);
+    results.sort();
+    expect(results).toEqual([1, 2]);
+    expect(iterations).toEqual(3);
+  });
+});
+

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -18,10 +18,7 @@
 
 import * as errors from "../src/errors";
 import {asyncConnect} from "./testbase";
-import {
-  Transaction,
-  TransactionState,
-} from "../src/transaction";
+import {Transaction, TransactionState} from "../src/transaction";
 import {Connection, IsolationLevel} from "../src/ifaces";
 
 class Barrier {
@@ -32,12 +29,12 @@ class Barrier {
     this._waiters = [];
   }
   async ready() {
-    if(this._counter == 0) {
+    if (this._counter == 0) {
       return;
     }
     this._counter -= 1;
-    if(this._counter == 0) {
-      for(let waiter of this._waiters.splice(0, this._waiters.length)) {
+    if (this._counter == 0) {
+      for (let waiter of this._waiters.splice(0, this._waiters.length)) {
         waiter();
       }
     } else {
@@ -61,7 +58,7 @@ async function run(test: (con: Connection) => Promise<void>): Promise<void> {
 }
 
 async function run2(
-  test: (con1: Connection, con2: Connection) => Promise<void>,
+  test: (con1: Connection, con2: Connection) => Promise<void>
 ): Promise<void> {
   const connection = await asyncConnect();
   try {
@@ -72,7 +69,7 @@ async function run2(
       await connection2.close();
     }
   } finally {
-      await connection.close();
+    await connection.close();
   }
 }
 
@@ -151,4 +148,3 @@ test("retry: conflict", async () => {
     expect(iterations).toEqual(3);
   });
 });
-

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -18,10 +18,7 @@
 
 import * as errors from "../src/errors";
 import {asyncConnect} from "./testbase";
-import {
-  Transaction,
-  TransactionState,
-} from "../src/transaction";
+import {Transaction, TransactionState} from "../src/transaction";
 import {Connection, IsolationLevel} from "../src/ifaces";
 
 const typename = "TransactionTest";
@@ -105,64 +102,64 @@ test("transaction interface errors", async () => {
     );
 
     async function borrow1(): Promise<void> {
-        await con.try_transaction(async (tx) => {
-            await con.execute("SELECT 7*9");
-        });
+      await con.try_transaction(async (tx) => {
+        await con.execute("SELECT 7*9");
+      });
     }
 
     await expect(borrow1()).rejects.toThrowError(
-        new errors.InterfaceError(
-            "Connection object is borrowed for the transaction. " +
-            "Use the methods on transaction object instead."
-        )
+      new errors.InterfaceError(
+        "Connection object is borrowed for the transaction. " +
+          "Use the methods on transaction object instead."
+      )
     );
 
     async function borrow2(): Promise<void> {
-        await con.try_transaction(async (tx) => {
-            await con.query("SELECT 7*9");
-        });
+      await con.try_transaction(async (tx) => {
+        await con.query("SELECT 7*9");
+      });
     }
     await expect(borrow2()).rejects.toThrowError(
-        new errors.InterfaceError(
-            "Connection object is borrowed for the transaction. " +
-            "Use the methods on transaction object instead."
-        )
+      new errors.InterfaceError(
+        "Connection object is borrowed for the transaction. " +
+          "Use the methods on transaction object instead."
+      )
     );
 
     async function borrow3(): Promise<void> {
-        await con.try_transaction(async (tx) => {
-            await con.queryOne("SELECT 7*9");
-        });
+      await con.try_transaction(async (tx) => {
+        await con.queryOne("SELECT 7*9");
+      });
     }
     await expect(borrow3()).rejects.toThrowError(
-        new errors.InterfaceError(
-            "Connection object is borrowed for the transaction. " +
-            "Use the methods on transaction object instead."
-        )
+      new errors.InterfaceError(
+        "Connection object is borrowed for the transaction. " +
+          "Use the methods on transaction object instead."
+      )
     );
 
     async function borrow4(): Promise<void> {
-        await con.try_transaction(async (tx) => {
-            await con.queryJSON("SELECT 7*9");
-        });
+      await con.try_transaction(async (tx) => {
+        await con.queryJSON("SELECT 7*9");
+      });
     }
     await expect(borrow4()).rejects.toThrowError(
-        new errors.InterfaceError(
-            "Connection object is borrowed for the transaction. " +
-            "Use the methods on transaction object instead."
-        )
+      new errors.InterfaceError(
+        "Connection object is borrowed for the transaction. " +
+          "Use the methods on transaction object instead."
+      )
     );
 
     async function borrow5(): Promise<void> {
-        await con.try_transaction(async (tx) => {
-            await con.queryOneJSON("SELECT 7*9");
-        });
+      await con.try_transaction(async (tx) => {
+        await con.queryOneJSON("SELECT 7*9");
+      });
     }
     await expect(borrow5()).rejects.toThrowError(
-        new errors.InterfaceError(
-            "Connection object is borrowed for the transaction. " +
-            "Use the methods on transaction object instead."
-        )
+      new errors.InterfaceError(
+        "Connection object is borrowed for the transaction. " +
+          "Use the methods on transaction object instead."
+      )
     );
   });
 });


### PR DESCRIPTION
Like in python PR edgedb/edgedb-python#146 this lacks documentations and also more robustness can be added later. But this provides correct future-proof API.