### PR TITLE
Fix usage of bigint polyfill

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -121,11 +121,11 @@ export interface EdgeDBDateTime {
 }
 
 const DATESHIFT_ORD = ymd2ord(2000, 1, 1);
-const bigUsPerDay = bi.make(86_400_000_000);
 
 export function decodeMicrosecondsToEdgeDBDateTime(
   microseconds: bi.BigIntLike
 ): EdgeDBDateTime {
+  const bigUsPerDay = bi.make(86_400_000_000);
   const dayNumber = bi.div(microseconds, bigUsPerDay);
 
   let timeUs = Number(bi.sub(microseconds, bi.mul(dayNumber, bigUsPerDay)));


### PR DESCRIPTION
> Safari crashes on my machine with "Error: JSBI library is required to polyfill BigInt"
https://github.com/edgedb/ui/pull/172#issuecomment-765772515

Fixes bug introduced in #68. A bigint constant was being assigned in the main body of the module, so in browsers without native BigInt the polyfill was being called when the module was loaded, and so before `plugJSBI` could be called to inject the BigInt polyfill.