### PR TITLE
Fix duration test

### DIFF
--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -697,9 +697,9 @@ test("fetch: duration", async () => {
         .padStart(len, "0");
     }
 
-    return `${duration.sign === -1 ? "-" : ""}${fmt(duration.hours)}:${fmt(
-      duration.minutes
-    )}:${fmt(duration.seconds)}${(
+    return `${duration.sign === -1 ? "-" : ""}${Math.abs(
+      duration.hours
+    )}:${fmt(duration.minutes)}:${fmt(duration.seconds)}${(
       "." +
       fmt(duration.milliseconds, 3) +
       fmt(duration.microseconds, 3)


### PR DESCRIPTION
Was broken by `sql_standard` setting in edgedb (edgedb/edgedb#2245)