### PR TITLE
Decode scalar type names into codec

### DIFF
--- a/src/codecs/ifaces.ts
+++ b/src/codecs/ifaces.ts
@@ -74,7 +74,7 @@ export abstract class ScalarCodec extends Codec {
   }
 
   /** @internal */
-  setTypeName(typeName: string) {
+  setTypeName(typeName: string): void {
     this.typeName = typeName;
   }
 

--- a/src/codecs/ifaces.ts
+++ b/src/codecs/ifaces.ts
@@ -66,10 +66,16 @@ export abstract class Codec {
 
 export abstract class ScalarCodec extends Codec {
   private derivedFromTid: uuid | null = null;
+  private typeName: string | null = null;
 
   constructor(tid: uuid, derivedFromTid: uuid | null = null) {
     super(tid);
     this.derivedFromTid = derivedFromTid;
+  }
+
+  /** @internal */
+  setTypeName(typeName: string) {
+    this.typeName = typeName;
   }
 
   derive(tid: uuid): Codec {
@@ -86,6 +92,10 @@ export abstract class ScalarCodec extends Codec {
   }
 
   getKnownTypeName(): string {
+    if (this.typeName) {
+      return this.typeName;
+    }
+
     if (this.derivedFromTid) {
       return KNOWN_TYPES.get(this.derivedFromTid)!;
     }

--- a/src/codecs/registry.ts
+++ b/src/codecs/registry.ts
@@ -256,7 +256,11 @@ export class CodecsRegistry {
             const ann_length = frb.readUInt32();
             if (t === 0xff) {
               const typeName = frb.readBuffer(ann_length).toString("utf8");
-              KNOWN_TYPES.set(tid, typeName);
+              const codec =
+                this.codecs.get(tid) ?? this.codecsBuildCache.get(tid);
+              if (codec instanceof ScalarCodec) {
+                codec.setTypeName(typeName);
+              }
             } else {
               frb.discard(ann_length);
             }

--- a/src/codecs/registry.ts
+++ b/src/codecs/registry.ts
@@ -254,7 +254,12 @@ export class CodecsRegistry {
         default: {
           if (t >= 0x7f && t <= 0xff) {
             const ann_length = frb.readUInt32();
-            frb.discard(ann_length);
+            if (t === 0xff) {
+              const typeName = frb.readBuffer(ann_length).toString("utf8");
+              KNOWN_TYPES.set(tid, typeName);
+            } else {
+              frb.discard(ann_length);
+            }
             return null;
           } else {
             throw new Error(


### PR DESCRIPTION
Decodes the scalar type name annotation (https://www.edgedb.com/docs/internals/protocol/typedesc#scalar-type-name-annotation) into KNOWN_TYPES, so `ScalarCodec.getKnownTypeName()` returns the name of enum types.

https://github.com/edgedb/edgedb-js/blob/319857f06b651ea2dc047842ad968b2705990bdd/src/codecs/ifaces.ts#L88-L94

@1st1 `getKnownTypeName` returns the name for the `derivedFromTid` if it exists first. I'm not sure when derived types occur, so I'm not sure if this behaviour is correct? Shouldn't it check the typename of this type first, then for the derived type?