### PR TITLE
Add option to implicitly fetch typenames

### DIFF
--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -206,6 +206,23 @@ export class WriteMessageBuffer {
     return this;
   }
 
+  writeHeaders(headers: [number, Buffer | string][]): this {
+    if (this.messagePos < 0) {
+      throw new BufferError("cannot writeHeaders: no current message");
+    }
+    this.buffer.writeUInt16(headers.length);
+    for (const [code, value] of headers) {
+      this.buffer.writeUInt16(code);
+      if (Buffer.isBuffer(value)) {
+        this.buffer.writeUInt32(value.byteLength);
+        this.buffer.writeBuffer(value);
+      } else {
+        this.buffer.writeString(value);
+      }
+    }
+    return this;
+  }
+
   writeChar(ch: char): this {
     if (this.messagePos < 0) {
       throw new BufferError("cannot writeChar: no current message");

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -206,7 +206,7 @@ export class WriteMessageBuffer {
     return this;
   }
 
-  writeHeaders(headers: [number, Buffer | string][]): this {
+  writeHeaders(headers: Array<[number, Buffer | string]>): this {
     if (this.messagePos < 0) {
       throw new BufferError("cannot writeHeaders: no current message");
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -932,7 +932,7 @@ export class ConnectionImpl implements Executor {
     const wb = new WriteMessageBuffer();
 
     wb.beginMessage(chars.$P)
-      .writeHeaders(options?.headers ?? {})
+      .writeHeaders(options?.headers ?? null)
       .writeChar(asJson ? chars.$j : chars.$b)
       .writeChar(expectOne ? chars.$o : chars.$m)
       .writeString("") // statement name

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,8 @@ import {
   IConnectionProxied,
   onConnectionClose,
   TransactionOptions,
+  ParseOptions,
+  PrepareMessageHeaders,
 } from "./ifaces";
 import * as scram from "./scram";
 
@@ -924,12 +926,13 @@ export class ConnectionImpl implements Executor {
     query: string,
     asJson: boolean,
     expectOne: boolean,
-    alwaysDescribe: boolean
+    alwaysDescribe: boolean,
+    options?: ParseOptions
   ): Promise<[number, ICodec, ICodec, Buffer | null, Buffer | null]> {
     const wb = new WriteMessageBuffer();
 
     wb.beginMessage(chars.$P)
-      .writeInt16(0) // no headers
+      .writeHeaders(options?.headers ?? {})
       .writeChar(asJson ? chars.$j : chars.$b)
       .writeChar(expectOne ? chars.$o : chars.$m)
       .writeString("") // statement name
@@ -1475,8 +1478,11 @@ export class RawConnection extends ConnectionImpl {
   // Note that this class, while exported, is not documented.
   // Its API is subject to change.
 
-  public async rawParse(query: string): Promise<[Buffer, Buffer]> {
-    const result = await this._parse(query, false, false, true);
+  public async rawParse(
+    query: string,
+    headers?: PrepareMessageHeaders
+  ): Promise<[Buffer, Buffer]> {
+    const result = await this._parse(query, false, false, true, {headers});
     return [result[3]!, result[4]!];
   }
 

--- a/src/ifaces.ts
+++ b/src/ifaces.ts
@@ -131,3 +131,24 @@ export const onConnectionClose = Symbol("onConnectionClose");
 export interface IConnectionProxied extends Connection {
   [onConnectionClose](): void;
 }
+
+export const HeaderCodes = {
+  implicitLimit: 0xff01,
+  implicitTypenames: 0xff02,
+  implicitTypeids: 0xff03,
+  allowCapabilities: 0xff04,
+};
+
+export type MessageHeaders = {
+  [key in keyof typeof HeaderCodes]?: string | Buffer;
+};
+
+export interface PrepareMessageHeaders {
+  implicitLimit?: string;
+  implicitTypenames?: "true";
+  implicitTypeids?: "true";
+}
+
+export interface ParseOptions {
+  headers?: PrepareMessageHeaders;
+}


### PR DESCRIPTION
Implicit typenames were removed by default in protocol version 0.9 (https://github.com/edgedb/edgedb/pull/2019). We need an api option to enable them (and implicit limits would be useful) for studio.

Todo:
- [x] Add `writeHeaders` method (https://github.com/edgedb/edgedb-python/blob/a7cc6c3811d41aeac0163de6580ab46d5e0b6b46/edgedb/protocol/protocol.pyx#L169)
- [x] Add api to set headers on `Prepare` and `OptimisticExecute` (https://www.edgedb.com/docs/internals/protocol/messages#prepare)