### PR TITLE
Implement reading project config

### DIFF
--- a/src/adapter.deno.ts
+++ b/src/adapter.deno.ts
@@ -1,16 +1,17 @@
 import {process} from "https://deno.land/std@0.95.0/node/process.ts";
 import {Buffer} from "https://deno.land/std@0.95.0/node/buffer.ts";
+import * as crypto from "https://deno.land/std@0.95.0/node/crypto.ts";
+import * as fs from "https://deno.land/std@0.95.0/node/fs.ts";
 import {Sha256, HmacSha256} from "https://deno.land/std@0.95.0/hash/sha256.ts";
-import {createHash} from "https://deno.land/std@0.95.0/hash/mod.ts";
 import path from "https://deno.land/std@0.95.0/node/path.ts";
 import EventEmitter from "https://deno.land/std@0.95.0/node/events.ts";
 import util from "https://deno.land/std@0.95.0/node/util.ts";
 
-export {Buffer, path, process, util, createHash};
+export {Buffer, path, process, util, fs, crypto};
 
 export async function randomBytes(size: number): Promise<Buffer> {
   const buf = new Uint8Array(size);
-  const rand = crypto.getRandomValues(buf);
+  const rand = globalThis.crypto.getRandomValues(buf);
 
   return Buffer.from(rand);
 }
@@ -27,18 +28,6 @@ export function HMAC(key: Buffer, ...msgs: Buffer[]): Buffer {
     hm.update(msg);
   }
   return Buffer.from(hm.arrayBuffer());
-}
-
-export function realpathSync(path: string): string {
-  return Deno.realPathSync(path);
-}
-
-export function existsSync(path: string): string {
-  return Deno.existsSync(path);
-}
-
-export function readFileUtf8Sync(path: string): string {
-  return Deno.readTextFileSync(path);
 }
 
 export function homeDir(): string {

--- a/src/adapter.deno.ts
+++ b/src/adapter.deno.ts
@@ -1,11 +1,12 @@
 import {process} from "https://deno.land/std@0.95.0/node/process.ts";
 import {Buffer} from "https://deno.land/std@0.95.0/node/buffer.ts";
 import {Sha256, HmacSha256} from "https://deno.land/std@0.95.0/hash/sha256.ts";
+import {createHash} from "https://deno.land/std@0.95.0/hash/mod.ts";
 import path from "https://deno.land/std@0.95.0/node/path.ts";
 import EventEmitter from "https://deno.land/std@0.95.0/node/events.ts";
 import util from "https://deno.land/std@0.95.0/node/util.ts";
 
-export {Buffer, path, process, util};
+export {Buffer, path, process, util, createHash};
 
 export async function randomBytes(size: number): Promise<Buffer> {
   const buf = new Uint8Array(size);
@@ -26,6 +27,14 @@ export function HMAC(key: Buffer, ...msgs: Buffer[]): Buffer {
     hm.update(msg);
   }
   return Buffer.from(hm.arrayBuffer());
+}
+
+export function realpathSync(path: string): string {
+  return Deno.realPathSync(path);
+}
+
+export function existsSync(path: string): string {
+  return Deno.existsSync(path);
 }
 
 export function readFileUtf8Sync(path: string): string {

--- a/src/adapter.node.ts
+++ b/src/adapter.node.ts
@@ -1,12 +1,11 @@
 import * as crypto from "crypto";
-import {createHash} from "crypto";
 import * as fs from "fs";
 import {existsSync, realpathSync} from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as net from "net";
 
-export {path, net, createHash, existsSync, realpathSync};
+export {path, net, crypto, fs, existsSync, realpathSync};
 
 export async function randomBytes(size: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {
@@ -32,10 +31,6 @@ export function HMAC(key: Buffer, ...msgs: Buffer[]): Buffer {
     hm.update(msg);
   }
   return hm.digest();
-}
-
-export function readFileUtf8Sync(filepath: string): string {
-  return fs.readFileSync(filepath, {encoding: "utf-8"});
 }
 
 export const homeDir = os.homedir;

--- a/src/adapter.node.ts
+++ b/src/adapter.node.ts
@@ -1,10 +1,12 @@
 import * as crypto from "crypto";
+import {createHash} from "crypto";
 import * as fs from "fs";
+import {existsSync, realpathSync} from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as net from "net";
 
-export {path, net};
+export {path, net, createHash, existsSync, realpathSync};
 
 export async function randomBytes(size: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {

--- a/src/con_utils.ts
+++ b/src/con_utils.ts
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 
-import {path, homeDir} from "./adapter.node";
+import {path, homeDir, createHash} from "./adapter.node";
+import {readFileUtf8Sync, existsSync, realpathSync} from "./adapter.node";
+import * as errors from "./errors";
 import {readCredentialsFile} from "./credentials";
 
 const EDGEDB_PORT = 5656;
@@ -92,6 +94,19 @@ export function parseConnectArguments(
   };
 }
 
+function stashPath(projectDir: string): string {
+  let projectPath = realpathSync(projectDir);
+  if (process.platform === "win32" && !projectPath.startsWith("\\\\")) {
+    projectPath = "\\\\?\\" + projectPath;
+  }
+  const hasher = createHash("sha1");
+  hasher.update(projectPath);
+  const hash = hasher.digest("hex");
+  const baseName = path.basename(projectPath);
+  const dirName = baseName + "-" + hash;
+  return path.join(homeDir(), ".edgedb", "projects", dirName);
+}
+
 function parseConnectDsnAndArgs({
   dsn,
   host,
@@ -123,6 +138,39 @@ function parseConnectDsnAndArgs({
     );
     serverSettings = server_settings;
   }
+
+  if (
+    !(
+      dsn ||
+      host ||
+      port ||
+      process.env.EDGEDB_HOST ||
+      process.env.EDGEDB_PORT
+    )
+  ) {
+    if (process.env.EDGEDB_INSTANCE) {
+      dsn = process.env.EDGEDB_INSTANCE;
+    } else {
+      const dir = process.cwd();
+      if (!existsSync(path.join(dir, "edgedb.toml"))) {
+        throw new errors.ClientConnectionError(
+          "no `edgedb.toml` found and no connection options specified" +
+            " either via arguments to connect API or via environment" +
+            " variables EDGEDB_HOST/EDGEDB_PORT or EDGEDB_INSTANCE"
+        );
+      }
+      const stashDir = stashPath(dir);
+      if (existsSync(stashDir)) {
+        dsn = readFileUtf8Sync(path.join(stashDir, "instance-name")).trim();
+      } else {
+        throw new errors.ClientConnectionError(
+          "Found `edgedb.toml` but the project is not initialized. " +
+            "Run `edgedb project init`."
+        );
+      }
+    }
+  }
+
   if (dsn && /^edgedb(?:admin)?:\/\//.test(dsn)) {
     // Comma-separated hosts and empty hosts cannot always be parsed
     // correctly with new URL(), so if we detect them, we need to replace the

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,4 +1,4 @@
-import {readFileUtf8Sync} from "./adapter.node";
+import {fs} from "./adapter.node";
 
 export interface Credentials {
   host?: string;
@@ -10,7 +10,7 @@ export interface Credentials {
 
 export function readCredentialsFile(file: string): Credentials {
   try {
-    const data = readFileUtf8Sync(file);
+    const data: string = fs.readFileSync(file, {encoding: "utf8"});
     return validateCredentials(JSON.parse(data));
   } catch (e) {
     throw Error(`cannot read credentials file ${file}: ${e}`);


### PR DESCRIPTION
Details:
1. Uses current directory for project dir
2. Does not search of the ancestor directories (unlike CLI tool)
3. Now crashes if `edgedb.toml` not found and no parameters specified

Also includes implementation of `EDGEDB_INSTANCE` env var support