### PR TITLE
Fix Deno to run without `--unstable`. Add a test that that's possible.

### DIFF
--- a/src/adapter.deno.ts
+++ b/src/adapter.deno.ts
@@ -1,13 +1,16 @@
 import {process} from "https://deno.land/std@0.95.0/node/process.ts";
 import {Buffer} from "https://deno.land/std@0.95.0/node/buffer.ts";
 import * as crypto from "https://deno.land/std@0.95.0/node/crypto.ts";
-import * as fs from "https://deno.land/std@0.95.0/node/fs.ts";
 import {Sha256, HmacSha256} from "https://deno.land/std@0.95.0/hash/sha256.ts";
 import path from "https://deno.land/std@0.95.0/node/path.ts";
 import EventEmitter from "https://deno.land/std@0.95.0/node/events.ts";
 import util from "https://deno.land/std@0.95.0/node/util.ts";
 
-export {Buffer, path, process, util, fs, crypto};
+export {Buffer, path, process, util, crypto};
+
+export function readFileUtf8Sync(path: string): string {
+  return Deno.readTextFileSync(path);
+}
 
 export async function randomBytes(size: number): Promise<Buffer> {
   const buf = new Uint8Array(size);
@@ -45,6 +48,28 @@ export function homeDir(): string {
 
 export function hrTime(): number {
   return performance.now();
+}
+
+// TODO: replace this with
+//       `import * as fs from "https://deno.land/std@0.95.0/node/fs.ts";`
+//       when the 'fs' compat module does not require '--unstable' flag.
+export namespace fs {
+  export function existsSync(fn: string | URL): boolean {
+    fn = fn instanceof URL ? path.fromFileUrl(fn) : fn;
+    try {
+      Deno.lstatSync(fn);
+      return true;
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  export function realpathSync(path: string): string {
+    return Deno.realPathSync(path);
+  }
 }
 
 // TODO: when 'net.Socket' is implemented in deno node compatibility library

--- a/src/adapter.node.ts
+++ b/src/adapter.node.ts
@@ -7,6 +7,10 @@ import * as net from "net";
 
 export {path, net, crypto, fs, existsSync, realpathSync};
 
+export function readFileUtf8Sync(fn: string): string {
+  return fs.readFileSync(fn, {encoding: "utf8"});
+}
+
 export async function randomBytes(size: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     crypto.randomBytes(size, (err, buf) => {

--- a/src/con_utils.ts
+++ b/src/con_utils.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {path, homeDir, crypto, fs} from "./adapter.node";
+import {path, homeDir, crypto, fs, readFileUtf8Sync} from "./adapter.node";
 import * as errors from "./errors";
 import {readCredentialsFile} from "./credentials";
 
@@ -160,11 +160,7 @@ function parseConnectDsnAndArgs({
       }
       const stashDir = stashPath(dir);
       if (fs.existsSync(stashDir)) {
-        dsn = fs
-          .readFileSync(path.join(stashDir, "instance-name"), {
-            encoding: "utf8",
-          })
-          .trim();
+        dsn = readFileUtf8Sync(path.join(stashDir, "instance-name")).trim();
       } else {
         throw new errors.ClientConnectionError(
           "Found `edgedb.toml` but the project is not initialized. " +

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,4 +1,4 @@
-import {fs} from "./adapter.node";
+import {readFileUtf8Sync} from "./adapter.node";
 
 export interface Credentials {
   host?: string;
@@ -10,7 +10,7 @@ export interface Credentials {
 
 export function readCredentialsFile(file: string): Credentials {
   try {
-    const data: string = fs.readFileSync(file, {encoding: "utf8"});
+    const data: string = readFileUtf8Sync(file);
     return validateCredentials(JSON.parse(data));
   } catch (e) {
     throw Error(`cannot read credentials file ${file}: ${e}`);

--- a/test/deno.test.ts
+++ b/test/deno.test.ts
@@ -17,11 +17,17 @@
  */
 
 import {execFile} from "child_process";
+import * as fs from "fs";
 
 test("run deno test", async () => {
   jest.setTimeout(60_000);
 
-  return new Promise<void>((resolve, reject) => {
+  if (!fs.existsSync("test/deno")) {
+    console.warn("skipping deno tests; run `yarn `compileForDeno`");
+    return;
+  }
+
+  return await new Promise<void>((resolve, reject) => {
     execFile(
       "deno",
       [
@@ -41,7 +47,32 @@ test("run deno test", async () => {
           console.error(stderr);
           reject(error);
         }
-        console.log(stdout);
+        resolve();
+      }
+    );
+  });
+});
+
+test("deno check", async () => {
+  jest.setTimeout(60_000);
+
+  if (!fs.existsSync("test/deno")) {
+    console.warn("skipping deno tests; run `yarn `compileForDeno`");
+    return;
+  }
+
+  return await new Promise<void>((resolve, reject) => {
+    execFile(
+      "deno",
+      ["eval", 'import * as edgedb from "./edgedb-deno/mod.ts"'],
+      {
+        env: process.env,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          console.error(stderr);
+          reject(error);
+        }
         resolve();
       }
     );

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -38,7 +38,11 @@ export default async () => {
     if (m) {
       const runtimeData = JSON.parse(m[1]);
       process.env._JEST_EDGEDB_PORT = runtimeData.port;
-      process.env._JEST_EDGEDB_HOST = runtimeData.runstate_dir;
+
+      // Use runtimeData.runstate_dir instead of 127.0.0.1 to force
+      // testing on the UNIX socket. Deno, however, has problems with
+      // that, hence the TCP address.
+      process.env._JEST_EDGEDB_HOST = "127.0.0.1";
       if (ok) {
         err = null;
         ok([runtimeData.runstate_dir, parseInt(runtimeData.port, 10)]);


### PR DESCRIPTION
While there, fix Deno (and our test suite) to connect to a TCP socket,
as Deno doesn't work well with Unix sockets on macOS.