### PR TITLE
Deprecate access to single connections

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -527,6 +527,8 @@ Pool
 
     .. js:method:: acquire()
 
+        **Deprecated**: use the query methods on ``Pool`` instead.
+
         Acquire a connection proxy, which provides access to an open database
         connection. The proxy must be released to return the connection to the
         pool.
@@ -546,10 +548,14 @@ Pool
 
     .. js:method:: release(conn: Connection)
 
+        **Deprecated**: use the query methods on ``Pool`` instead.
+
         Release a previously acquired connection proxy, to return it to the
         pool.
 
     .. js:method:: run<T>(action: func)
+
+        **Deprecated**: use the query methods on ``Pool`` instead.
 
         Acquire a connection and use it to run the given action that accepts
         a connection, and return *T*, which is any type returned by the user's

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -437,12 +437,22 @@ class PoolShell implements Pool {
   }
 
   async acquire(): Promise<PoolConnection> {
+    // tslint:disable-next-line: no-console
+    console.warn(
+      "The `acquire()` method is deprecated and is scheduled to be " +
+        "removed. Use the query methods on Pool() instead."
+    );
     return await this.impl.acquire(this.options);
   }
   /**
    * Release a database connection back to the pool.
    */
   async release(connection: Connection): Promise<void> {
+    // tslint:disable-next-line: no-console
+    console.warn(
+      "The `release()` method is deprecated and is scheduled to be " +
+        "removed. Use the query methods on Pool() instead."
+    );
     await this.impl.release(connection);
   }
 
@@ -451,6 +461,11 @@ class PoolShell implements Pool {
    * value. The connection is released once done.
    */
   async run<T>(action: (connection: Connection) => Promise<T>): Promise<T> {
+    // tslint:disable-next-line: no-console
+    console.warn(
+      "The `run()` method is deprecated and is scheduled to be " +
+        "removed. Use the query methods on Pool() instead."
+    );
     const conn = await this.acquire();
 
     try {


### PR DESCRIPTION
The client APIs are moving toward a pool first approach. This is the first step in that direction.