### PR TITLE
Validate that the correct ALPN protocol was selected.

### DIFF
--- a/src/adapter.deno.ts
+++ b/src/adapter.deno.ts
@@ -196,5 +196,9 @@ export namespace tls {
     checkServerIdentity?: (a: string, b: any) => Error | undefined;
   }
 
-  export class TLSSocket extends net.Socket {}
+  export class TLSSocket extends net.Socket {
+    get alpnProtocol(): string {
+      throw new Error("deno does not support ALPN");
+    }
+  }
 }


### PR DESCRIPTION
This required me some digging into nodejs source as 'sock.alpnProtocol'
was set to 'null' when checked on the "connect" event. Apparently we
need to use the "secureConnect" event when dealing with TLS sockets.
Fix that and add protocol validation.