### PR TITLE
Add OptionalType to typesystem

### DIFF
--- a/qb/test/params.test.ts
+++ b/qb/test/params.test.ts
@@ -21,7 +21,8 @@ test("simple params", () => {
   expect(query.toEdgeQL()).toEqual(`SELECT {
   str := (<std::str>$str),
   nums := (std::array_unpack((<array<std::int64>>$numArr))),
-  x := (("true" IF <OPTIONAL std::bool>$optBool ELSE "false"))
+  optBool := (<OPTIONAL std::bool>$optBool),
+  x := (("true" IF <std::bool>$bool ELSE "false"))
 }`);
 
   expect(() => e.select(query).toEdgeQL()).toThrow();

--- a/qb/test/params.test.ts
+++ b/qb/test/params.test.ts
@@ -1,0 +1,36 @@
+import {typeutil} from "../../src/reflection";
+import e from "../generated/example";
+
+test("simple params", () => {
+  const query = e.withParams(
+    {
+      str: e.str,
+      numArr: e.array(e.int64),
+      optBool: e.optional(e.bool),
+    },
+    (params) =>
+      e.select({
+        str: params.str,
+        nums: e.array_unpack(params.numArr),
+        x: e.if_else(e.str("true"), params.optBool, e.str("false")),
+      })
+  );
+
+  expect(query.toEdgeQL()).toEqual(`SELECT {
+  str := (<std::str>$str),
+  nums := (std::array_unpack((<array<std::int64>>$numArr))),
+  x := (("true" IF <OPTIONAL std::bool>$optBool ELSE "false"))
+}`);
+
+  expect(() => e.select(query).toEdgeQL()).toThrow();
+
+  type paramsType = typeof query["__paramststype__"];
+  const f1: typeutil.assertEqual<
+    paramsType,
+    {
+      str: string;
+      numArr: number[];
+      optBool: boolean | null;
+    }
+  > = true;
+});

--- a/qb/test/params.test.ts
+++ b/qb/test/params.test.ts
@@ -7,12 +7,14 @@ test("simple params", () => {
       str: e.str,
       numArr: e.array(e.int64),
       optBool: e.optional(e.bool),
+      bool: e.bool,
     },
     (params) =>
       e.select({
         str: params.str,
         nums: e.array_unpack(params.numArr),
-        x: e.if_else(e.str("true"), params.optBool, e.str("false")),
+        optBool: params.optBool,
+        x: e.if_else(e.str("true"), params.bool, e.str("false")),
       })
   );
 
@@ -30,7 +32,8 @@ test("simple params", () => {
     {
       str: string;
       numArr: number[];
-      optBool: boolean | null;
+      optBool: boolean | undefined;
+      bool: boolean;
     }
   > = true;
 });

--- a/src/reflection/enums.ts
+++ b/src/reflection/enums.ts
@@ -8,6 +8,7 @@ export enum Cardinality {
 
 export enum TypeKind {
   scalar = "scalar",
+  optional = "optional",
   enum = "enum",
   object = "object",
   namedtuple = "namedtuple",
@@ -32,7 +33,6 @@ export enum ExpressionKind {
   With = "With",
   WithParams = "WithParams",
   Param = "Param",
-  OptionalParam = "OptionalParam",
 }
 
 export enum SelectModifierKind {

--- a/src/reflection/enums.ts
+++ b/src/reflection/enums.ts
@@ -30,6 +30,9 @@ export enum ExpressionKind {
   TypeIntersection = "TypeIntersection",
   Alias = "Alias",
   With = "With",
+  WithParams = "WithParams",
+  Param = "Param",
+  OptionalParam = "OptionalParam",
 }
 
 export enum SelectModifierKind {

--- a/src/reflection/typesystem.ts
+++ b/src/reflection/typesystem.ts
@@ -46,6 +46,28 @@ export interface EnumType<
 }
 
 //////////////////
+// OPTIONAL TYPES
+//////////////////
+export type OptionalArg = ScalarType | EnumType;
+
+export interface OptionalType<Element extends OptionalArg = OptionalArg> {
+  __kind__: TypeKind.optional;
+  __tstype__: Element["__tstype__"] | undefined;
+  __name__: `OPTIONAL ${Element["__name__"]}`;
+  __element__: Element;
+}
+
+export function optional<Element extends OptionalArg>(
+  element: Element
+): OptionalType<Element> {
+  return {
+    __kind__: TypeKind.optional,
+    __name__: `OPTIONAL ${element.__name__}`,
+    __element__: element,
+  } as any;
+}
+
+//////////////////
 // OBJECT TYPES
 //////////////////
 // export type SomeObjectType = ObjectType;
@@ -429,6 +451,7 @@ export type shapeToTsType<T extends ObjectTypeShape> = string extends keyof T
 export type MaterialType =
   | ScalarType
   | EnumType
+  | OptionalType
   | ObjectType
   | TupleType
   | NamedTupleType
@@ -443,4 +466,4 @@ export type NonArrayMaterialType =
 
 export type AnyTupleType = TupleType | NamedTupleType;
 
-export type ParamType = ScalarType | ArrayType<ScalarType>;
+export type ParamType = ScalarType | ArrayType<ScalarType> | OptionalType;

--- a/src/reflection/typesystem.ts
+++ b/src/reflection/typesystem.ts
@@ -442,3 +442,5 @@ export type NonArrayMaterialType =
   | NamedTupleType;
 
 export type AnyTupleType = TupleType | NamedTupleType;
+
+export type ParamType = ScalarType | ArrayType<ScalarType>;

--- a/src/syntax/params.ts
+++ b/src/syntax/params.ts
@@ -1,0 +1,107 @@
+import {
+  Expression,
+  ExpressionKind,
+  BaseExpression,
+  ParamType,
+  Cardinality,
+} from "reflection";
+import {$expressionify} from "./path";
+
+export type $expr_OptionalParam<Type extends ParamType = ParamType> = {
+  __kind__: ExpressionKind.OptionalParam;
+  __type__: Type;
+};
+
+export function optional<Type extends ParamType>(
+  type: Type
+): $expr_OptionalParam<Type> {
+  return {
+    __kind__: ExpressionKind.OptionalParam,
+    __type__: type,
+  };
+}
+
+export type $expr_WithParams<
+  Params extends {
+    [key: string]: ParamType | $expr_OptionalParam;
+  } = {},
+  Expr extends BaseExpression = BaseExpression
+> = Expression<{
+  __kind__: ExpressionKind.WithParams;
+  __element__: Expr["__element__"];
+  __cardinality__: Expr["__cardinality__"];
+  __expr__: Expr;
+  __paramststype__: paramsToParamTypes<Params>;
+}>;
+
+type paramsToParamTypes<
+  Params extends {
+    [key: string]: ParamType | $expr_OptionalParam;
+  }
+> = {
+  [key in keyof Params]: Params[key] extends $expr_OptionalParam
+    ? Params[key]["__type__"]["__tstype__"] | null
+    : Params[key] extends ParamType
+    ? Params[key]["__tstype__"]
+    : never;
+};
+
+export type $expr_Param<
+  Name extends string | number | symbol = string,
+  Type extends ParamType = ParamType,
+  Optional extends boolean = boolean
+> = Expression<{
+  __kind__: ExpressionKind.Param;
+  __element__: Type;
+  __cardinality__: Optional extends true
+    ? Cardinality.AtMostOne
+    : Cardinality.One;
+  __name__: Name;
+}>;
+
+type paramsToParamExprs<
+  Params extends {
+    [key: string]: ParamType | $expr_OptionalParam;
+  }
+> = {
+  [key in keyof Params]: Params[key] extends $expr_OptionalParam
+    ? $expr_Param<key, Params[key]["__type__"], true>
+    : Params[key] extends ParamType
+    ? $expr_Param<key, Params[key], false>
+    : never;
+};
+
+export function withParams<
+  Params extends {
+    [key: string]: ParamType | $expr_OptionalParam;
+  } = {},
+  Expr extends BaseExpression = BaseExpression
+>(
+  params: Params,
+  expr: (params: paramsToParamExprs<Params>) => Expr
+): $expr_WithParams<Params, Expr> {
+  const paramExprs: {[key: string]: $expr_Param} = {};
+  for (const [key, param] of Object.entries(params)) {
+    paramExprs[key] = $expressionify({
+      __kind__: ExpressionKind.Param,
+      __element__:
+        param.__kind__ === ExpressionKind.OptionalParam
+          ? param.__type__
+          : param,
+      __cardinality__:
+        param.__kind__ === ExpressionKind.OptionalParam
+          ? Cardinality.AtMostOne
+          : Cardinality.One,
+      __name__: key,
+    });
+  }
+
+  const returnExpr = expr(paramExprs as any);
+
+  return $expressionify({
+    __kind__: ExpressionKind.WithParams,
+    __element__: returnExpr.__element__,
+    __cardinality__: returnExpr.__cardinality__,
+    __expr__: returnExpr,
+  }) as any;
+}

--- a/src/syntax/syntax.ts
+++ b/src/syntax/syntax.ts
@@ -6,6 +6,7 @@ export * from "./set";
 export * from "./cast";
 export * from "./select";
 export * from "./collections";
+export * from "./types";
 export * from "./funcops";
 export * from "./for";
 export * from "./with";

--- a/src/syntax/syntax.ts
+++ b/src/syntax/syntax.ts
@@ -9,6 +9,7 @@ export * from "./collections";
 export * from "./funcops";
 export * from "./for";
 export * from "./with";
+export * from "./params";
 export * from "./toEdgeQL";
 
 export type $infer<A extends TypeSet> = setToTsType<A>;

--- a/src/syntax/toEdgeQL.ts
+++ b/src/syntax/toEdgeQL.ts
@@ -492,9 +492,7 @@ UNION (${renderEdgeQL(expr.__expr__ as any, ctx)})`
     }
     return forVar;
   } else if (expr.__kind__ === ExpressionKind.Param) {
-    return `<${
-      expr.__cardinality__ === Cardinality.AtMostOne ? "OPTIONAL " : ""
-    }${expr.__element__.__name__}>$${expr.__name__}`;
+    return `<${expr.__element__.__name__}>$${expr.__name__}`;
   } else {
     util.assertNever(
       expr,

--- a/src/syntax/types.ts
+++ b/src/syntax/types.ts
@@ -1,0 +1,1 @@
+export {optional} from "../reflection";

--- a/src/syntax/with.ts
+++ b/src/syntax/with.ts
@@ -1,7 +1,7 @@
-import {BaseExpression, ExpressionKind, MaterialTypeSet} from "../reflection";
+import {BaseExpression, ExpressionKind} from "reflection";
 import {$expr_Select} from "./select";
 import {$expr_For} from "./for";
-import {toEdgeQL} from "./toEdgeQL";
+import {$expressionify} from "./path";
 
 export type $expr_Alias<Expr extends BaseExpression = BaseExpression> =
   BaseExpression<{
@@ -15,13 +15,12 @@ export type $expr_Alias<Expr extends BaseExpression = BaseExpression> =
 export function alias<Expr extends BaseExpression>(
   expr: Expr
 ): $expr_Alias<Expr> {
-  return {
+  return $expressionify({
     __kind__: ExpressionKind.Alias,
     __element__: expr.__element__,
     __cardinality__: expr.__cardinality__,
     __expr__: expr,
-    toEdgeQL,
-  };
+  });
 }
 
 type WithableExpression = $expr_Select | $expr_For; // insert | update | delete
@@ -39,14 +38,13 @@ function _with<Refs extends BaseExpression[], Expr extends WithableExpression>(
   refs: Refs,
   expr: Expr
 ): $expr_With<Refs, Expr> {
-  return {
+  return $expressionify({
     __kind__: ExpressionKind.With,
     __element__: expr.__element__,
     __cardinality__: expr.__cardinality__,
     __refs__: refs,
     __expr__: expr,
-    toEdgeQL,
-  };
+  });
 }
 
 export {_with as with};


### PR DESCRIPTION
I think this is a preferable solution to having separate `Param` and `OptionalParam` expressions. Having a generic `e.optional` type operator will also be useful for casting, etc. It's possible this will cause some issues with overloads...for instance `e.optional(e.bool)` couldn't be passed into `e.if_else` (but I think that's actually desirable, since the boolean argument doesn't appear to be `OPTIONAL` in the reference?).

The root of the `e.if_else` issue is that `e.optional(e.str)` isn't a `ScalarType` anymore. If this becomes an issue, we could try this approach instead, where `e.optional` still returns a `ScalarType`: https://github.com/edgedb/edgedb-js/pull/151/files 
