### PR TITLE
Revert node 16 version pinning in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ["12", "13", "14", "15", "16.8"]
+        node-version: ["12", "13", "14", "15", "16"]
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
 
         include:
           - os: ubuntu-latest
-            node-version: "16.8"
+            node-version: "16"
             edgedb-version: "nightly"
           - os: macos-latest
-            node-version: "16.8"
+            node-version: "16"
             edgedb-version: "stable"
           - os: windows-latest
-            node-version: "16.8"
+            node-version: "16"
             edgedb-version: "stable"
 
     steps:


### PR DESCRIPTION
Unpin node 16 from 16.8 in the github test workflow because a fix for https://github.com/nodejs/node/issues/40030 has been released.