### PR TITLE
Make createClient accept only one argument.

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -11,23 +11,29 @@ Client
 ======
 
 .. js:function:: createClient( \
-        dsnOrInstanceName: string | undefined, \
-        options?: ConnectOptions \
+        options: string | ConnectOptions | null
     ): Client
 
     Creates a new :js:class:`Client` instance.
 
-    :param string dsnOrInstanceName:
-        If this parameter does not start with ``edgedb://`` then this is
-        a :ref:`name of an instance <ref_reference_connection_instance_name>`.
+    :param options:
+        This is an optional parameter. When it is not specified the client
+        will connect to the current EdgeDB Project instance.
 
-        Otherwise it specifies a single string in the connection URI format:
-        ``edgedb://user:password@host:port/database?option=value``.
+        If this parameter is a string it can represent either a
+        DSN or an instance name:
 
-        See the :ref:`Connection Parameters <ref_reference_connection>`
-        docs for full details.
+        * when the string does not start with ``edgedb://`` it is a
+          :ref:`name of an instance <ref_reference_connection_instance_name>`;
 
-    :param options: Connection and client options object.
+        * otherwise it specifies a single string in the connection URI format:
+          ``edgedb://user:password@host:port/database?option=value``.
+
+          See the :ref:`Connection Parameters <ref_reference_connection>`
+          docs for full details.
+
+        Alternatively the parameter can be a ``ConnectOptions`` config;
+        see the documentation of valid options below.
 
     :param string options.dsn:
         Specifies the DSN of the instance.

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -20,6 +20,8 @@ export {createClient} from "./pool";
 import {createClient} from "./pool";
 export default createClient;
 
+export {connect, createPool} from "./pool";
+
 export {RawConnection as _RawConnection} from "./client";
 
 export type {Connection, Client} from "./ifaces";

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -794,7 +794,7 @@ class ClientImpl {
 
 export type ConnectOptions = ConnectConfig & ClientOptions;
 
-export function createClient(
+function _createClientWithLegacyArgs(
   dsnOrInstanceName?: string | ConnectOptions | null,
   options?: ConnectOptions | null
 ): Client {
@@ -814,6 +814,16 @@ export function createClient(
   }
 }
 
+export function createClient(
+  options?: string | ConnectOptions | null
+): Client {
+  if (typeof options === "string") {
+    return ClientShell.create(options);
+  } else {
+    return ClientShell.create(undefined, options);
+  }
+}
+
 /**
  * @deprecated
  */
@@ -825,7 +835,7 @@ export function connect(
   console.warn(
     `The 'connect()' API is deprecated, use 'createClient()' instead`
   );
-  return createClient(dsnOrInstanceName, {
+  return _createClientWithLegacyArgs(dsnOrInstanceName, {
     concurrency: 1,
     ...options,
   }).ensureConnected();
@@ -853,7 +863,7 @@ export function createPool(
       ? [dsnOrInstanceName, options]
       : [undefined, {...dsnOrInstanceName, ...options}];
 
-  return createClient(dsn, {
+  return _createClientWithLegacyArgs(dsn, {
     ...opts?.connectOptions,
     concurrency: opts?.maxSize,
   }).ensureConnected();

--- a/test/createClient.test.ts
+++ b/test/createClient.test.ts
@@ -104,9 +104,7 @@ test("unref idle connections", async () => {
     `const {createClient} = require('./dist/src/index.node');
 
 (async () => {
-  const client = createClient(undefined, ${JSON.stringify(
-    getConnectOptions()
-  )});
+  const client = createClient(${JSON.stringify(getConnectOptions())});
 
   await client.query('select 1');
 

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -7,7 +7,7 @@ import * as readline from "readline";
 import {ConnectConfig} from "../src/con_utils";
 import {Connection} from "../src/ifaces";
 
-import connect from "../src/index.node";
+import {connect} from "../src/index.node";
 import {promisify} from "util";
 
 type PromiseCallback = () => void;

--- a/test/testbase.ts
+++ b/test/testbase.ts
@@ -52,5 +52,5 @@ export function getConnectOptions(): ConnectOptions {
 }
 
 export function getClient(opts: ConnectOptions = {}): Client {
-  return createClient(undefined, _getOpts(opts));
+  return createClient(_getOpts(opts));
 }


### PR DESCRIPTION
Requiring users to call `createClient(undefined, {...})` to set
custom connection options seems cumbersome. Since this is a new
API we can simplify the signature.