### PR TITLE
Disable session config queries

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -97,7 +97,7 @@ const NO_TRANSACTION_CAPABILITIES_BYTES = Buffer.from([
   255,
   255,
   255,
-  255 & ~Capabilities.TRANSACTION,
+  255 & ~Capabilities.TRANSACTION & ~Capabilities.SESSION_CONFIG,
 ]);
 
 const OLD_ERROR_CODES = new Map([

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1450,42 +1450,42 @@ test("query(Required)Single cardinality", async () => {
   client.close();
 });
 
-test("querySingle wrong cardinality", async () => {
-  const con = getClient();
-  try {
-    await con
-      .queryRequiredSingleJSON("set module default")
-      .then(() => {
-        throw new Error("an exception was expected");
-      })
-      .catch((e) => {
-        expect(e.toString()).toMatch(
-          /queryRequiredSingleJSON\(\) returned no data/
-        );
-      });
+// test("querySingle wrong cardinality", async () => {
+//   const con = getClient();
+//   try {
+//     await con
+//       .queryRequiredSingleJSON("set module default")
+//       .then(() => {
+//         throw new Error("an exception was expected");
+//       })
+//       .catch((e) => {
+//         expect(e.toString()).toMatch(
+//           /queryRequiredSingleJSON\(\) returned no data/
+//         );
+//       });
 
-    await con
-      .queryRequiredSingle("set module default")
-      .then(() => {
-        throw new Error("an exception was expected");
-      })
-      .catch((e) => {
-        expect(e.toString()).toMatch(
-          /queryRequiredSingle\(\) returned no data/
-        );
-      });
+//     await con
+//       .queryRequiredSingle("set module default")
+//       .then(() => {
+//         throw new Error("an exception was expected");
+//       })
+//       .catch((e) => {
+//         expect(e.toString()).toMatch(
+//           /queryRequiredSingle\(\) returned no data/
+//         );
+//       });
 
-    await con.querySingleJSON("set module default").then((res) => {
-      expect(res).toBe("null");
-    });
+//     await con.querySingleJSON("set module default").then((res) => {
+//       expect(res).toBe("null");
+//     });
 
-    await con.querySingle("set module default").then((res) => {
-      expect(res).toBe(null);
-    });
-  } finally {
-    await con.close();
-  }
-});
+//     await con.querySingle("set module default").then((res) => {
+//       expect(res).toBe(null);
+//     });
+//   } finally {
+//     await con.close();
+//   }
+// });
 
 test("transaction state cleanup", async () => {
   // concurrency 1 to ensure we reuse the underlying connection


### PR DESCRIPTION
Due to clients being opaque pools of connections it is no longer
possible to have session-level configuration controlled with EdgeQL.
Future edgedb-js versions will have a proper high-level API to define
session-level configuration.