### PR TITLE
Retry mutating queries on transaction serialization errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -178,8 +178,9 @@ export class ClientConnectionHolder {
         if (
           err instanceof errors.EdgeDBError &&
           err.hasTag(errors.SHOULD_RETRY) &&
-          // query is readonly
-          conn.getQueryCapabilities(query, asJson, expectOne) === 0
+          // query is readonly or it's a transaction serialization error
+          (conn.getQueryCapabilities(query, asJson, expectOne) === 0
+           || err instanceof errors.TransactionConflictError)
         ) {
           const rule = this.options.retryOptions.getRuleForException(err);
           if (iteration + 1 >= rule.attempts) {


### PR DESCRIPTION
The `TransactionConflictError` class of errors is not only safe to
retry, it's _expected_ to be retried, so do that.