### PR TITLE
Various querybuilder fixes

### DIFF
--- a/qb/dbschema/default.esdl
+++ b/qb/dbschema/default.esdl
@@ -24,7 +24,9 @@ module default {
   type Movie {
     property genre -> Genre;
     property rating -> float64;
-    required property title -> str;
+    required property title -> str {
+      constraint exclusive;
+    };
     required property release_year -> int16 {
       default := <int16>datetime_get(datetime_current(), 'year');
     }

--- a/qb/dbschema/migrations/00003.edgeql
+++ b/qb/dbschema/migrations/00003.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m13wjddw5v2qop66go76ghzefhhr3pa6ojc336sjyff6ticrbrynla
+    ONTO m17u5iclyhikkz2ww5mwvqouwdo3k2o7pfaov32pai6asffsecvoca
+{
+  ALTER TYPE default::Movie {
+      ALTER PROPERTY title {
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+};

--- a/qb/test/select.test.ts
+++ b/qb/test/select.test.ts
@@ -921,21 +921,19 @@ test("polymorphic field in nested shape", async () => {
   }));
 
   const result = await query.run(client);
-  expect(JSON.parse(JSON.stringify(result))).toEqual([
-    {
-      title: data.the_avengers.title,
-      characters: [
-        {
-          name: data.cap.name,
-          secret_identity: data.cap.secret_identity,
-        },
-        {
-          name: data.iron_man.name,
-          secret_identity: data.iron_man.secret_identity,
-        },
-      ],
-    },
-  ]);
+  expect(JSON.parse(JSON.stringify(result))).toEqual({
+    title: data.the_avengers.title,
+    characters: [
+      {
+        name: data.cap.name,
+        secret_identity: data.cap.secret_identity,
+      },
+      {
+        name: data.iron_man.name,
+        secret_identity: data.iron_man.secret_identity,
+      },
+    ],
+  });
 
   tc.assert<
     tc.IsExact<
@@ -946,7 +944,7 @@ test("polymorphic field in nested shape", async () => {
           name: string;
           secret_identity: string | null;
         }[];
-      }[]
+      } | null
     >
   >(true);
 });

--- a/src/reflection/generators/generateObjectTypes.ts
+++ b/src/reflection/generators/generateObjectTypes.ts
@@ -265,6 +265,10 @@ export const generateObjectTypes = (params: GeneratorParams) => {
       t`type ${ref} = $.ObjectType<${quote(type.name)}, ${ref}λShape, null>;`,
     ]);
 
+    if (type.name === "std::Object") {
+      body.writeln([t`export `, dts`declare `, t`type $Object = ${ref}`]);
+    }
+
     /////////
     // generate runtime type
     /////////

--- a/src/syntax/genMock/modules/std.ts
+++ b/src/syntax/genMock/modules/std.ts
@@ -14,6 +14,8 @@ declare const number: scalarTypeWithConstructor<
   ScalarType<"std::number", number>
 >;
 
+export type $Object = ObjectType<"std::Object", any, null>;
+
 export type $FreeObject = ObjectType<"std::FreeObject", any, null>;
 declare const FreeObject: $expr_PathNode<
   TypeSet<$FreeObject, Cardinality.Many>,

--- a/src/syntax/literal.ts
+++ b/src/syntax/literal.ts
@@ -23,7 +23,8 @@ export function literal<T extends BaseType>(
   }) as any;
 }
 
-const nameMapping = new Map([
+const nameMapping = new Map<string, string>([
+  ...([...spec.values()].map(type => [type.name, type.id]) as any),
   ["std::number", "00000000-0000-0000-0000-0000000001ff"],
 ]);
 

--- a/src/syntax/path.ts
+++ b/src/syntax/path.ts
@@ -231,6 +231,7 @@ export function $getScopedExpr<T extends ExpressionRoot>(
     scopedExpr = $expressionify({
       ...expr,
       __cardinality__: Cardinality.One,
+      __scopedFrom__: expr,
     });
     scopeRoots.add(scopedExpr);
     if (uncached) {

--- a/src/syntax/toEdgeQL.ts
+++ b/src/syntax/toEdgeQL.ts
@@ -436,7 +436,7 @@ function renderEdgeQL(
 
   function renderWithBlockExpr(
     varExpr: SomeExpression,
-    noImplicitDetached?: boolean
+    _noImplicitDetached?: boolean
   ) {
     const withBlockElement = ctx.withVars.get(varExpr)!;
     let renderedExpr = renderEdgeQL(
@@ -446,7 +446,7 @@ function renderEdgeQL(
         renderWithVar: varExpr,
       },
       !withBlockElement.scopedExpr,
-      noImplicitDetached
+      _noImplicitDetached
     );
     if (ctx.linkProps.has(expr)) {
       renderedExpr = `SELECT ${renderedExpr} {\n${ctx.linkProps


### PR DESCRIPTION
- Fix bug @colinhacks found during launch livestream where expressions get wrongly double counted when `select`ing a non basic path object and `select` contains nested shapes, causing expressions to be hoisted out of their parent scope.
- Fix bug in `toEdgeQL` causing this issue: #242 + fix cardinality/element type in other `insert unless conflict` cases
- Fix broken code gen when `default` module is empty (reported here: https://discord.com/channels/841451783728529451/849374705210490900/942414500567588954)