### PR TITLE
Fix getTsType generation on CJS

### DIFF
--- a/src/reflection/generators/generateCastMaps.ts
+++ b/src/reflection/generators/generateCastMaps.ts
@@ -271,7 +271,7 @@ export const generateCastMaps = (params: GeneratorParams) => {
   ]);
 
   f.writeln([
-    dts`declare`,
+    dts`declare `,
     t`type getTsType<T extends $.BaseType> = T extends $.ScalarType`,
   ]);
   f.writeln([


### PR DESCRIPTION
Currently there is a broken declaration for `getTsType` when generating for CJS via `--target cjs`, this PR should fix that.
```ts
declaretype getTsType<T extends $.BaseType> = T extends $.ScalarType
  ? T extends _std.$decimal | _std.$json | _std.$uuid
    ? never
    : T["__tstype__"]
  : never;
```