### PR TITLE
Fix getSharedParentScalar declaration

### DIFF
--- a/src/reflection/generators/generateCastMaps.ts
+++ b/src/reflection/generators/generateCastMaps.ts
@@ -172,8 +172,8 @@ export const generateCastMaps = (params: GeneratorParams) => {
     )}`,
     r` {`,
   ]);
-  f.writeln([r`  a = (a`, t` as any`, r`).__casttype__ ?? a;`]);
-  f.writeln([r`  b = (b`, t` as any`, r`).__casttype__ ?? b;`]);
+  f.writeln([r`  a = (a`, ts` as any`, r`).__casttype__ ?? a;`]);
+  f.writeln([r`  b = (b`, ts` as any`, r`).__casttype__ ?? b;`]);
   f.addExport("getSharedParentScalar");
   f.writeBuf(runtimeMap);
 


### PR DESCRIPTION
Currently the declaration for `getSharedParentScalar` has a function body included, this PR should get rid of it in the declaration file.
```ts
declare function getSharedParentScalar<A extends $.ScalarType, B extends $.ScalarType>(a: A, b: B): A | B
 as any
 as any
```