### PR TITLE
Support raw data for multi properties. Fix enum assignment expressions.

### DIFF
--- a/qb/playground.ts
+++ b/qb/playground.ts
@@ -1,20 +1,42 @@
 // tslint:disable:no-console
 import * as edgedb from "edgedb";
-import type {$Movie} from "./dbschema/edgeql-js/modules/default";
+import type {$Movie, Bag} from "./dbschema/edgeql-js/modules/default";
 import type {pointersToSelectShape} from "./dbschema/edgeql-js/syntax/select";
 import {setupTests} from "./test/setupTeardown";
 
-import e from "./dbschema/edgeql-js";
+import e, {orScalarLiteral} from "./dbschema/edgeql-js";
+import {
+  assignableBy,
+  pointerToAssignmentExpression,
+} from "dbschema/edgeql-js/syntax/casting";
 
-export function someFunc<A, B extends string | number>(arg: A, opt?: B) {
-  return {arg, opt};
+function func<T extends string, U extends [T, ...T[]]>(arg: U) {
+  return arg;
 }
-const result = someFunc("asdf", 1234);
-result;
-export type someFunc = {asdf: number};
+const reuslt = func(["asdf", "qwer"]);
 
 async function run() {
   const {client} = await setupTests();
+
+  type askldjf = assignableBy<typeof e["Genre"]>;
+
+  const strings = ["asdf"];
+  const query = e.insert(e.Bag, {
+    stringsMulti: ["asdf"],
+    stringsArr: strings,
+    stringMultiArr: [strings],
+  });
+  // type alksdjf = pointerToAssignmentExpression<
+  //   typeof e["Bag"]["__element__"]["__pointers__"]["stringsArr"]
+  // >;
+  const final = e.select(query, () => ({
+    id: true,
+    stringsMulti: true,
+    stringsArr: true,
+    stringMultiArr: true,
+  }));
+  console.log(query.toEdgeQL());
+  console.log(JSON.stringify(await final.run(client), null, 2));
 }
 
 run();

--- a/qb/test/insert.test.ts
+++ b/qb/test/insert.test.ts
@@ -186,7 +186,28 @@ test("insert type enforcement", async () => {
 
 test("optional sequence fields", async () => {
   const query = e.insert(e.Bag, {
-    stringsMulti: "asdf",
+    stringsMulti: ["asdf"],
   });
   await query.run(client);
+});
+
+test("complex raw data in inserts", async () => {
+  const strings = ["aaa", "bbb"];
+  const query = e.insert(e.Bag, {
+    stringsArr: strings,
+    stringsMulti: strings as ["aaa", "bbb"],
+    stringMultiArr: [strings],
+  });
+  const final = e.select(query, () => ({
+    id: true,
+    stringsMulti: true,
+    stringsArr: true,
+    stringMultiArr: true,
+  }));
+  const result = await final.run(client);
+  expect(result).toMatchObject({
+    stringsMulti: strings,
+    stringsArr: strings,
+    stringMultiArr: [strings],
+  });
 });

--- a/qb/test/insert.test.ts
+++ b/qb/test/insert.test.ts
@@ -186,7 +186,7 @@ test("insert type enforcement", async () => {
 
 test("optional sequence fields", async () => {
   const query = e.insert(e.Bag, {
-    stringsMulti: ["asdf"],
+    stringsMulti: "asdf",
   });
   await query.run(client);
 });
@@ -209,5 +209,10 @@ test("complex raw data in inserts", async () => {
     stringsMulti: strings,
     stringsArr: strings,
     stringMultiArr: [strings],
+  });
+
+  e.insert(e.Bag, {
+    // @ts-expect-error
+    stringsMulti: strings,
   });
 });

--- a/qb/test/update.test.ts
+++ b/qb/test/update.test.ts
@@ -35,7 +35,15 @@ test("update", async () => {
   e.update(e.Bag, () => ({
     set: {
       stringsMulti: {
-        "+=": ["new string"] as ["new string"],
+        "+=": ["new string"],
+      },
+    },
+  })).toEdgeQL();
+
+  e.update(e.Bag, () => ({
+    set: {
+      stringsMulti: {
+        "+=": "new string",
       },
     },
   })).toEdgeQL();

--- a/qb/test/update.test.ts
+++ b/qb/test/update.test.ts
@@ -35,7 +35,7 @@ test("update", async () => {
   e.update(e.Bag, () => ({
     set: {
       stringsMulti: {
-        "+=": "new string",
+        "+=": ["new string"] as ["new string"],
       },
     },
   })).toEdgeQL();

--- a/src/syntax/insert.ts
+++ b/src/syntax/insert.ts
@@ -12,12 +12,12 @@ import {
   $scopify,
   stripSet,
   TypeSet,
-  ScalarType,
-  scalarTypeWithConstructor,
 } from "../reflection";
 import type {pointerToAssignmentExpression} from "./casting";
 import {$expressionify, $getScopedExpr} from "./path";
 import {cast} from "./cast";
+import {set} from "./set";
+import {literal} from "./literal";
 import {$getTypeByName} from "./literal";
 import {$expr_PathNode} from "../reflection/path";
 import type {$Object} from "@generated/modules/std";
@@ -177,10 +177,15 @@ export function $normaliseInsertShape(
           } shape key: '${key}'`
         );
       }
+      const isMulti =
+        pointer.cardinality === Cardinality.AtLeastOne ||
+        pointer.cardinality === Cardinality.Many;
       const wrappedVal =
         val === null
           ? cast(pointer.target, null)
-          : (pointer.target as scalarTypeWithConstructor<ScalarType>)(val);
+          : isMulti && Array.isArray(val)
+          ? set(...val.map(v => (literal as any)(pointer.target, v)))
+          : (literal as any)(pointer.target, val);
       newShape[key] = setModify
         ? ({[setModify]: wrappedVal} as any)
         : wrappedVal;

--- a/src/syntax/update.ts
+++ b/src/syntax/update.ts
@@ -46,15 +46,16 @@ export type UpdateShape<Root extends ObjectTypeSet> = typeutil.stripNever<
   ? Shape extends ObjectTypePointers
     ? {
         [k in keyof Shape]?:
-          | (pointerToAssignmentExpression<Shape[k]> extends infer S
-              ?
-                  | S
-                  | (Shape[k]["cardinality"] extends
-                      | Cardinality.Many
-                      | Cardinality.AtLeastOne
-                      ? {"+=": S} | {"-=": S}
-                      : never)
-              : never)
+          | (
+              | pointerToAssignmentExpression<Shape[k]>
+              | (Shape[k]["cardinality"] extends
+                  | Cardinality.Many
+                  | Cardinality.AtLeastOne
+                  ?
+                      | {"+=": pointerToAssignmentExpression<Shape[k], true>}
+                      | {"-=": pointerToAssignmentExpression<Shape[k], true>}
+                  : never)
+            )
           | (pointerIsOptional<Shape[k]> extends true
               ? undefined | null
               : never);


### PR DESCRIPTION
- Improve assignment expressions for `multi` properties
- Fix enum assignment expressions

Closes #260 and  #259 

Remaining issue: you can't pass `string[]` into `e.array()`. This is minor for now, we can merge without it since using `e.array` for literals is rarely necessary.