### PR TITLE
Update codegen and /syntax to use `import type` where only the type import is needed

### DIFF
--- a/qb/package.json
+++ b/qb/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --detectOpenHandles --forceExit",
-    "test:ci": "ts-node test/testRunner.ts",
+    "test:ci": "ts-node --project ../tsconfig.json test/testRunner.ts",
     "generate": "edgeql-js",
     "play": "ts-node playground.ts --project tsconfig.json --trace-warnings",
     "play:dev": "nodemon -e ts -w . -x ts-node playground.ts --project tsconfig.json --trace-warnings",

--- a/qb/test/cardinality.test.ts
+++ b/qb/test/cardinality.test.ts
@@ -1,4 +1,4 @@
-import {$} from "edgedb";
+import type {$} from "edgedb";
 import {tc} from "./setupTeardown";
 
 test("multiply$.Cardinality", () => {

--- a/qb/test/collections.test.ts
+++ b/qb/test/collections.test.ts
@@ -1,7 +1,7 @@
 import {Client, $} from "edgedb";
 import e, {$infer} from "../dbschema/edgeql-js";
 
-import {$VersionStageλEnum} from "../dbschema/edgeql-js/modules/sys";
+import type {$VersionStageλEnum} from "../dbschema/edgeql-js/modules/sys";
 import {tc} from "./setupTeardown";
 
 import {setupTests, teardownTests, TestData} from "./setupTeardown";

--- a/qb/test/delete.test.ts
+++ b/qb/test/delete.test.ts
@@ -1,4 +1,4 @@
-import * as edgedb from "edgedb";
+import type * as edgedb from "edgedb";
 
 import e, {Cardinality} from "../dbschema/edgeql-js";
 import {setupTests, teardownTests, tc} from "./setupTeardown";

--- a/qb/test/detached.test.ts
+++ b/qb/test/detached.test.ts
@@ -1,4 +1,4 @@
-import * as edgedb from "edgedb";
+import type * as edgedb from "edgedb";
 import e from "../dbschema/edgeql-js";
 import {setupTests, tc, teardownTests, TestData} from "./setupTeardown";
 

--- a/qb/test/functions.test.ts
+++ b/qb/test/functions.test.ts
@@ -1,7 +1,7 @@
 import superjson from "superjson";
 import {$} from "edgedb";
 import e, {literalToTypeSet} from "../dbschema/edgeql-js";
-import {$expr_Function} from "edgedb/dist/reflection";
+import type {$expr_Function} from "edgedb/dist/reflection";
 import {tc} from "./setupTeardown";
 import {$str, number} from "../dbschema/edgeql-js/modules/std";
 import * as castMaps from "../dbschema/edgeql-js/castMaps";

--- a/qb/test/insert.test.ts
+++ b/qb/test/insert.test.ts
@@ -1,6 +1,6 @@
-import {Client} from "edgedb";
-import {Villain} from "../dbschema/edgeql-js/modules/default";
-import {InsertShape} from "../dbschema/edgeql-js/syntax/insert";
+import type {Client} from "edgedb";
+import type {Villain} from "../dbschema/edgeql-js/modules/default";
+import type {InsertShape} from "../dbschema/edgeql-js/syntax/insert";
 import e, {Cardinality} from "../dbschema/edgeql-js";
 import {setupTests, teardownTests, TestData, tc} from "./setupTeardown";
 

--- a/qb/test/operators.test.ts
+++ b/qb/test/operators.test.ts
@@ -1,7 +1,7 @@
 import superjson from "superjson";
 import {$, Client} from "edgedb";
 import e from "../dbschema/edgeql-js";
-import {$expr_Operator} from "edgedb/dist/reflection";
+import type {$expr_Operator} from "edgedb/dist/reflection";
 import {TestData, setupTests, teardownTests} from "./setupTeardown";
 
 let client: Client;

--- a/qb/test/testRunner.ts
+++ b/qb/test/testRunner.ts
@@ -2,7 +2,7 @@ import {spawn} from "child_process";
 import path from "path";
 
 import createClient from "../../src/index.node";
-import {ConnectConfig} from "../../src/conUtils";
+import type {ConnectConfig} from "../../src/conUtils";
 import {
   generateStatusFileName,
   getServerCommand,

--- a/qb/test/update.test.ts
+++ b/qb/test/update.test.ts
@@ -1,4 +1,4 @@
-import * as edgedb from "edgedb";
+import type * as edgedb from "edgedb";
 
 import e from "../dbschema/edgeql-js";
 import {setupTests, tc, teardownTests, TestData} from "./setupTeardown";

--- a/qb/test/with.test.ts
+++ b/qb/test/with.test.ts
@@ -1,4 +1,4 @@
-import {$} from "edgedb";
+import type {$} from "edgedb";
 import e from "../dbschema/edgeql-js";
 import {tc} from "./setupTeardown";
 

--- a/qb/tsconfig.json
+++ b/qb/tsconfig.json
@@ -13,6 +13,10 @@
     "baseUrl": ".",
     "declaration": true,
     "preserveSymlinks": true,
+    // Svelte doesn't correctly compile if imports of the generated /modules
+    // aren't imported as 'import type' in other parts of the generated
+    // querybuilder, so set this option to ensure we always do that
+    "importsNotUsedAsValues": "error",
     "paths": {}
   },
   "include": [

--- a/src/reflection/generators/generateCastMaps.ts
+++ b/src/reflection/generators/generateCastMaps.ts
@@ -18,7 +18,7 @@ export const generateCastMaps = (params: GeneratorParams) => {
 
   const f = dir.getPath("castMaps");
   f.addStarImport("edgedb", "edgedb");
-  f.addImport({$: true}, "edgedb", false, ["ts", "dts"]);
+  f.addImport({$: true}, "edgedb", false, ["ts", "dts"], true);
 
   const reverseTopo = Array.from(types)
     .reverse() // reverse topological order

--- a/src/syntax/casting.ts
+++ b/src/syntax/casting.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ArrayType,
   BaseType,
   BaseTypeTuple,
@@ -16,7 +16,10 @@ import {
   TupleType,
   TypeSet,
 } from "../reflection";
-import {scalarCastableFrom, scalarAssignableBy} from "@generated/castMaps";
+import type {
+  scalarCastableFrom,
+  scalarAssignableBy,
+} from "@generated/castMaps";
 
 export type anonymizeObject<T extends ObjectType> = ObjectType<
   string,

--- a/src/syntax/collections.ts
+++ b/src/syntax/collections.ts
@@ -21,7 +21,7 @@ import {
   typeutil,
 } from "../reflection";
 import {$expressionify} from "./path";
-import {getCardsFromExprs} from "./set";
+import type {getCardsFromExprs} from "./set";
 import {
   literalToScalarType,
   literalToTypeSet,

--- a/src/syntax/insert.ts
+++ b/src/syntax/insert.ts
@@ -19,7 +19,7 @@ import {cast} from "./cast";
 import {set} from "./set";
 import {literal} from "./literal";
 import {$getTypeByName} from "./literal";
-import {$expr_PathNode} from "../reflection/path";
+import type {$expr_PathNode} from "../reflection/path";
 import type {$Object} from "@generated/modules/std";
 
 export type pointerIsOptional<T extends PropertyDesc | LinkDesc> =

--- a/src/syntax/literal.ts
+++ b/src/syntax/literal.ts
@@ -7,7 +7,7 @@ import {
   makeType,
   ScalarType,
 } from "../reflection";
-import {$expr_Literal} from "../reflection/literal";
+import type {$expr_Literal} from "../reflection/literal";
 import {$expressionify} from "./path";
 import {spec} from "@generated/__spec__";
 

--- a/src/syntax/path.ts
+++ b/src/syntax/path.ts
@@ -9,7 +9,7 @@ import {
   PropertyDesc,
   Cardinality,
 } from "../reflection";
-import {
+import type {
   PathParent,
   $expr_PathLeaf,
   $expr_PathNode,

--- a/src/syntax/query.ts
+++ b/src/syntax/query.ts
@@ -1,4 +1,4 @@
-import * as edgedb from "edgedb";
+import type * as edgedb from "edgedb";
 import {Cardinality, ExpressionKind} from "../reflection";
 import {jsonifyComplexParams} from "./params";
 import {select} from "./select";

--- a/src/syntax/select.ts
+++ b/src/syntax/select.ts
@@ -36,7 +36,7 @@ import type {
   ExpressionRoot,
   PathParent,
 } from "../reflection/path";
-import {anonymizeObject} from "./casting";
+import type {anonymizeObject} from "./casting";
 import type {$expr_Operator} from "../reflection/funcops";
 import {$expressionify, $getScopedExpr} from "./path";
 import {$getTypeByName, literal} from "./literal";

--- a/src/syntax/set.ts
+++ b/src/syntax/set.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ArrayType,
   BaseTypeTuple,
   BaseType,

--- a/src/syntax/syntax.ts
+++ b/src/syntax/syntax.ts
@@ -1,4 +1,4 @@
-import {TypeSet, setToTsType} from "../reflection";
+import type {TypeSet, setToTsType} from "../reflection";
 
 export * from "./literal";
 export * from "./path";

--- a/src/syntax/with.ts
+++ b/src/syntax/with.ts
@@ -1,8 +1,8 @@
 import {Expression, ExpressionKind, TypeSet} from "../reflection";
-import {$expr_Select} from "./select";
-import {$expr_For} from "./for";
-import {$expr_Insert} from "./insert";
-import {$expr_Update} from "./update";
+import type {$expr_Select} from "./select";
+import type {$expr_For} from "./for";
+import type {$expr_Insert} from "./insert";
+import type {$expr_Update} from "./update";
 import {$expressionify} from "./path";
 
 export type $expr_Alias<Expr extends TypeSet = TypeSet> = Expression<{


### PR DESCRIPTION
Fixes #268

It seems Sveltekit cannot identify imports that only import types without the explicit `import type` syntax, and so imports of the stdlib types from `modules/std` in castmaps, etc. cause the circular import problem (Previously seen here: https://github.com/edgedb/edgedb-js/commit/a8e32965c0d4fc93ef22d1d962ce1da492abd262 and https://github.com/edgedb/edgedb-js/pull/225/commits/96039d1e4bf12638ed002d12100b3fbfa65fe746).