### PR TITLE
Fix implicit any on toEdgeQL.ts

### DIFF
--- a/src/syntax/toEdgeQL.ts
+++ b/src/syntax/toEdgeQL.ts
@@ -640,7 +640,7 @@ function renderEdgeQL(
       ctx
     )})`;
   } else if (expr.__kind__ === ExpressionKind.Select) {
-    const lines = [];
+    const lines: string[] = [];
     if (isObjectType(expr.__element__)) {
       lines.push(
         `SELECT${
@@ -688,7 +688,7 @@ function renderEdgeQL(
       }
     }
 
-    const modifiers = [];
+    const modifiers: string[] = [];
 
     if (expr.__modifiers__.filter) {
       modifiers.push(`FILTER ${renderEdgeQL(expr.__modifiers__.filter, ctx)}`);


### PR DESCRIPTION
Fixes an issue where the generated client would not play nicely with `noImplicitAny: false`.
This probably is also a Typescript compiler bug, I would expect `noImplicitAny: false` to do quite the opposite (not care about the implicit anys).
However I saw that the same variables were typed in other places of the code, so this change is probably justified.

This can be reproduced with the following repository: https://gitlab.com/tdolsen/edgedb-testing, thanks to tdolsen on the Discord.