### PR TITLE
Fix implicit any on toEdgeQL.ts (take #2)

### DIFF
--- a/src/syntax/toEdgeQL.ts
+++ b/src/syntax/toEdgeQL.ts
@@ -640,7 +640,7 @@ function renderEdgeQL(
       ctx
     )})`;
   } else if (expr.__kind__ === ExpressionKind.Select) {
-    const lines = [];
+    const lines: string[] = [];
     if (isObjectType(expr.__element__)) {
       lines.push(
         `SELECT${
@@ -688,7 +688,7 @@ function renderEdgeQL(
       }
     }
 
-    const modifiers = [];
+    const modifiers: string[] = [];
 
     if (expr.__modifiers__.filter) {
       modifiers.push(`FILTER ${renderEdgeQL(expr.__modifiers__.filter, ctx)}`);


### PR DESCRIPTION
Original PR: #273.
I accidentally got rid of the fork.

---

As found out by **tdolsen** and @jaclarke, the generated Typescript client does not play nicely with `noImplicitAny` set to `false`.
This PR should properly type the places where implicit anys exist.

This probably is also a Typescript bug, I would expect `noImplicitAny` set as `false` to do quite the opposite.
However I saw that the same variables were typed in other places of the code, so this change is probably justified.

Reproduction repository: https://gitlab.com/tdolsen/edgedb-testing/-/tree/de0ce6035350bd1dc8bc6bc7208da8e5a6acc8ac