### PR TITLE
Improve the docs and fix number to string

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,8 +59,8 @@ as strings, the driver API is all you need.
     const result = await client.query(query)
     console.log(result); // "Hello world!"
   }
-  
-  run()
+
+  run();
 
 If you're not using TypeScript, you can skip straight to :ref:`the Driver docs
 <edgedb-js-examples>`.
@@ -87,7 +87,7 @@ users—it's awesome.
     const result = await query.run(client)
     console.log(result); // "Hello world!"
   }
-    
+
   run()
 
 As you can see, you still use the ``edgedb`` module to instantiate a client,
@@ -104,7 +104,7 @@ need an ORM to write strongly typed queries.
 
   const client = edgedb.createClient();
 
-  const q1 = await e.str("Hello" + "world!").run(client);
+  const q1 = await e.select("Hello world!").run(client);
   // string
 
   const q2 = await e.set(1, 2, 3).run(client);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,8 @@ as strings, the driver API is all you need.
     const result = await client.query(query)
     console.log(result); // "Hello world!"
   }
+  
+  run()
 
 If you're not using TypeScript, you can skip straight to :ref:`the Driver docs
 <edgedb-js-examples>`.
@@ -85,6 +87,8 @@ users—it's awesome.
     const result = await query.run(client)
     console.log(result); // "Hello world!"
   }
+    
+  run()
 
 As you can see, you still use the ``edgedb`` module to instantiate a client,
 but you use the auto-generated query builder to write and execute your queries.
@@ -100,8 +104,8 @@ need an ORM to write strongly typed queries.
 
   const client = edgedb.createClient();
 
-  const q1 = await e.str("Hello world!").run(client);
-  // number
+  const q1 = await e.str("Hello" + "world!").run(client);
+  // string
 
   const q2 = await e.set(1, 2, 3).run(client);
   // number[]


### PR DESCRIPTION
I was reading the docs and I wanted to fix
```ts
  const q1 = await e.str("Hello world!").run(client);
  // number
```
since the inferred type is actually the string literal `"Hello world!"`. But I thought that writing `"Hello world!"` instead of `number` seems confusing. So I thought that maybe using an addition so that the inferred type is `string` is a better idea.

Also I've added `run()` at the end of the code since I was expecting the code to run something by itself without me having to write `run()` afterwards. But this is debatable so I can undone the change.