### PR TITLE
Fix set impl function body ending up in declaration files

### DIFF
--- a/src/reflection/generators/generateSetImpl.ts
+++ b/src/reflection/generators/generateSetImpl.ts
@@ -166,17 +166,17 @@ import type {
     __element__: exprs
       .map(expr => expr.__element__`,
     ts` as any`,
-    `)
+    r`)
       .reduce(getSharedParent),
     __cardinality__: cardinalityUtil.mergeCardinalitiesVariadic(
       exprs.map(expr => expr.__cardinality__)`,
     ts` as any`,
-    `
+    r`
     ),
     __exprs__: exprs,
   })`,
     ts` as any`,
-    `;
+    r`;
 
 }`,
   ]);


### PR DESCRIPTION
The code generation for **CJS** and **ESM** generates invalid syntax for declaration files.

// dbschema/edgeql-js/syntax/setImpl.d.ts
```
declare function set<Expr extends TypeSet<BaseType> | castMaps.scalarLiterals>(
  ...exprs: Expr[]
): $expr_Set<
  TypeSet<
    getPrimitiveBaseType<castMaps.literalToTypeSet<Expr>["__element__"]>,
    Cardinality.Many
  >
>;
)
      .reduce(getSharedParent),
    __cardinality__: cardinalityUtil.mergeCardinalitiesVariadic(
      exprs.map(expr => expr.__cardinality__)
    ),
    __exprs__: exprs,
  });

}
```

This PR should fix the function body ending up in the declaration file.