### PR TITLE
Custom codecs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "edgeql-js": "./dist/reflection/cli.js"
   },
   "devDependencies": {
+    "@js-temporal/polyfill": "^0.4.1",
     "@types/jest": "^24.0.11",
     "@types/node": "14",
     "get-stdin": "^7.0.0",
@@ -32,7 +33,6 @@
     "node-fetch": "2.6.7",
     "nodemon": "^2.0.13",
     "prettier": "^2.3.2",
-    "proposal-temporal": "^0.7.0",
     "ts-jest": "^26.5.2",
     "ts-node": "^10.0.0",
     "tslint": "^5.20.1",

--- a/src/codecs/datetime.ts
+++ b/src/codecs/datetime.ts
@@ -29,7 +29,6 @@ import {
   LocalDateToOrdinal,
 } from "../datatypes/datetime";
 import {ymd2ord} from "../datatypes/dateutil";
-import {decodeMicrosecondsToEdgeDBDateTime} from "../compat";
 
 /* PostgreSQL UTC epoch starts on "January 1, 2000", whereas
  * in JavaScript, the UTC epoch starts on "January 1, 1970" (the UNIX epoch).
@@ -54,16 +53,6 @@ export class DateTimeCodec extends ScalarCodec implements ICodec {
     const us = buf.readBigInt64();
     const ms = Number(us) / 1000.0;
     return new Date(ms + TIMESHIFT);
-  }
-}
-
-export class EdgeDBDateTimeCodec extends ScalarCodec implements ICodec {
-  encode(_buf: WriteBuffer, _object: any): void {
-    throw new Error("not implemented");
-  }
-
-  decode(buf: ReadBuffer): any {
-    return decodeMicrosecondsToEdgeDBDateTime(buf.readBigInt64());
   }
 }
 

--- a/src/codecs/numbers.ts
+++ b/src/codecs/numbers.ts
@@ -17,8 +17,8 @@
  */
 
 import {ReadBuffer, WriteBuffer} from "../primitives/buffer";
+import * as bi from "../primitives/bigint";
 import {ICodec, ScalarCodec} from "./ifaces";
-import {decodeInt64ToString} from "../compat";
 
 export class Int64Codec extends ScalarCodec implements ICodec {
   encode(buf: WriteBuffer, object: any): void {
@@ -34,13 +34,17 @@ export class Int64Codec extends ScalarCodec implements ICodec {
   }
 }
 
-export class Int64StringCodec extends ScalarCodec implements ICodec {
-  encode(_buf: WriteBuffer, _object: any): void {
-    throw new Error("not implemented");
+export class Int64BigintCodec extends ScalarCodec implements ICodec {
+  encode(buf: WriteBuffer, object: any): void {
+    if (!bi.isBigInt(object)) {
+      throw new Error(`a bigint was expected, got "${object}"`);
+    }
+    buf.writeInt32(8);
+    buf.writeBigInt64(object);
   }
 
   decode(buf: ReadBuffer): any {
-    return decodeInt64ToString(buf.readBuffer(8));
+    return buf.readBigInt64();
   }
 }
 

--- a/src/codecs/registry.ts
+++ b/src/codecs/registry.ts
@@ -24,7 +24,6 @@ import {NULL_CODEC_ID, KNOWN_TYPES, KNOWN_TYPENAMES} from "./consts";
 import {EMPTY_TUPLE_CODEC, EMPTY_TUPLE_CODEC_ID, TupleCodec} from "./tuple";
 import * as numerics from "./numerics";
 import * as numbers from "./numbers";
-import * as datecodecs from "./datetime";
 import {ArrayCodec} from "./array";
 import {NamedTupleCodec} from "./namedtuple";
 import {EnumCodec} from "./enum";
@@ -45,19 +44,13 @@ const CTYPE_NAMEDTUPLE = 5;
 const CTYPE_ARRAY = 6;
 const CTYPE_ENUM = 7;
 
-interface StringCodecSpec {
-  decimal?: boolean;
-  bigint?: boolean;
-  int64?: boolean;
-  datetime?: boolean;
-  local_datetime?: boolean;
+export interface CustomCodecSpec {
+  decimalString?: boolean;
+  int64Bigint?: boolean;
 }
 
 const DECIMAL_TYPEID = KNOWN_TYPENAMES.get("std::decimal")!;
-const BIGINT_TYPEID = KNOWN_TYPENAMES.get("std::bigint")!;
 const INT64_TYPEID = KNOWN_TYPENAMES.get("std::int64")!;
-const DATETIME_TYPEID = KNOWN_TYPENAMES.get("std::datetime")!;
-const LOCAL_DATETIME_TYPEID = KNOWN_TYPENAMES.get("cal::local_datetime")!;
 
 export class CodecsRegistry {
   private codecsBuildCache: LRU<uuid, ICodec>;
@@ -70,16 +63,10 @@ export class CodecsRegistry {
     this.customScalarCodecs = new Map();
   }
 
-  setStringCodecs({
-    decimal,
-    bigint,
-    int64,
-    datetime,
-    local_datetime,
-  }: StringCodecSpec = {}): void {
+  setCustomCodecs({decimalString, int64Bigint}: CustomCodecSpec = {}): void {
     // This is a private API and it will change in the future.
 
-    if (decimal) {
+    if (decimalString) {
       this.customScalarCodecs.set(
         DECIMAL_TYPEID,
         new numerics.DecimalStringCodec(DECIMAL_TYPEID)
@@ -88,40 +75,13 @@ export class CodecsRegistry {
       this.customScalarCodecs.delete(DECIMAL_TYPEID);
     }
 
-    if (bigint) {
-      this.customScalarCodecs.set(
-        BIGINT_TYPEID,
-        new numerics.BigIntStringCodec(BIGINT_TYPEID)
-      );
-    } else {
-      this.customScalarCodecs.delete(BIGINT_TYPEID);
-    }
-
-    if (int64) {
+    if (int64Bigint) {
       this.customScalarCodecs.set(
         INT64_TYPEID,
-        new numbers.Int64StringCodec(INT64_TYPEID)
+        new numbers.Int64BigintCodec(INT64_TYPEID)
       );
     } else {
       this.customScalarCodecs.delete(INT64_TYPEID);
-    }
-
-    if (datetime) {
-      this.customScalarCodecs.set(
-        DATETIME_TYPEID,
-        new datecodecs.EdgeDBDateTimeCodec(DATETIME_TYPEID)
-      );
-    } else {
-      this.customScalarCodecs.delete(DATETIME_TYPEID);
-    }
-
-    if (local_datetime) {
-      this.customScalarCodecs.set(
-        LOCAL_DATETIME_TYPEID,
-        new datecodecs.EdgeDBDateTimeCodec(LOCAL_DATETIME_TYPEID)
-      );
-    } else {
-      this.customScalarCodecs.delete(LOCAL_DATETIME_TYPEID);
     }
   }
 

--- a/src/codecs/registry.ts
+++ b/src/codecs/registry.ts
@@ -24,6 +24,7 @@ import {NULL_CODEC_ID, KNOWN_TYPES, KNOWN_TYPENAMES} from "./consts";
 import {EMPTY_TUPLE_CODEC, EMPTY_TUPLE_CODEC_ID, TupleCodec} from "./tuple";
 import * as numerics from "./numerics";
 import * as numbers from "./numbers";
+import * as datecodecs from "./datetime";
 import {ArrayCodec} from "./array";
 import {NamedTupleCodec} from "./namedtuple";
 import {EnumCodec} from "./enum";
@@ -45,12 +46,14 @@ const CTYPE_ARRAY = 6;
 const CTYPE_ENUM = 7;
 
 export interface CustomCodecSpec {
-  decimalString?: boolean;
-  int64Bigint?: boolean;
+  decimal_string?: boolean;
+  int64_bigint?: boolean;
+  datetime_localDatetime?: boolean;
 }
 
 const DECIMAL_TYPEID = KNOWN_TYPENAMES.get("std::decimal")!;
 const INT64_TYPEID = KNOWN_TYPENAMES.get("std::int64")!;
+const DATETIME_TYPEID = KNOWN_TYPENAMES.get("std::datetime")!;
 
 export class CodecsRegistry {
   private codecsBuildCache: LRU<uuid, ICodec>;
@@ -63,10 +66,14 @@ export class CodecsRegistry {
     this.customScalarCodecs = new Map();
   }
 
-  setCustomCodecs({decimalString, int64Bigint}: CustomCodecSpec = {}): void {
+  setCustomCodecs({
+    decimal_string,
+    int64_bigint,
+    datetime_localDatetime,
+  }: CustomCodecSpec = {}): void {
     // This is a private API and it will change in the future.
 
-    if (decimalString) {
+    if (decimal_string) {
       this.customScalarCodecs.set(
         DECIMAL_TYPEID,
         new numerics.DecimalStringCodec(DECIMAL_TYPEID)
@@ -75,13 +82,22 @@ export class CodecsRegistry {
       this.customScalarCodecs.delete(DECIMAL_TYPEID);
     }
 
-    if (int64Bigint) {
+    if (int64_bigint) {
       this.customScalarCodecs.set(
         INT64_TYPEID,
         new numbers.Int64BigintCodec(INT64_TYPEID)
       );
     } else {
       this.customScalarCodecs.delete(INT64_TYPEID);
+    }
+
+    if (datetime_localDatetime) {
+      this.customScalarCodecs.set(
+        DATETIME_TYPEID,
+        new datecodecs.LocalDateTimeCodec(DATETIME_TYPEID)
+      );
+    } else {
+      this.customScalarCodecs.delete(DATETIME_TYPEID);
     }
   }
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -16,9 +16,6 @@
  * limitations under the License.
  */
 
-import * as bi from "./primitives/bigint";
-import {ymd2ord, ord2ymd} from "./datatypes/dateutil";
-
 /* A compatibility layer for symbols/functions required in both
    browser and NodeJS environments.
 */
@@ -61,12 +58,12 @@ export function decodeInt64ToString(buf: Buffer): string {
     throw new Error("expected 8 bytes buffer");
   }
 
-let inp: number[] = Array.from(buf);
+  let inp: number[] = Array.from(buf);
 
   let negative = false;
   if (inp[0] & 0x80) {
     // A negative integer; invert all bits.
-    inp = inp.map((x) => x ^ 0xff);
+    inp = inp.map(x => x ^ 0xff);
     // Account for the two's compliment's `1`.
     inp[inp.length - 1]++;
 
@@ -109,56 +106,4 @@ let inp: number[] = Array.from(buf);
   }
 
   return negative ? `-${result}` : result;
-}
-
-export interface EdgeDBDateTime {
-  year: number;
-  month: number;
-  day: number;
-  hour: number;
-  minute: number;
-  second: number;
-  microsecond: number;
-}
-
-const DATESHIFT_ORD = ymd2ord(2000, 1, 1);
-
-export function decodeMicrosecondsToEdgeDBDateTime(
-  microseconds: bi.BigIntLike
-): EdgeDBDateTime {
-  const bigUsPerDay = bi.make(86_400_000_000);
-  const dayNumber = bi.div(microseconds, bigUsPerDay);
-
-  let timeUs = Number(bi.sub(microseconds, bi.mul(dayNumber, bigUsPerDay)));
-
-  let ord = Number(dayNumber) + DATESHIFT_ORD;
-
-  if (timeUs < 0) {
-    timeUs = 86_400_000_000 + timeUs;
-    ord -= 1;
-  }
-
-  const [_year, month, day] = ord2ymd(ord);
-
-  // EdgeDB doesn't have year zero
-  const year = _year <= 0 ? _year - 1 : _year;
-
-  const hour = Math.floor(timeUs / 3_600_000_000);
-  timeUs -= hour * 3_600_000_000;
-
-  const minute = Math.floor(timeUs / 60_000_000);
-  timeUs -= minute * 60_000_000;
-
-  const second = Math.floor(timeUs / 1000_000);
-  timeUs -= second * 1000_000;
-
-  return {
-    year,
-    month,
-    day,
-    hour,
-    minute,
-    second,
-    microsecond: timeUs,
-  };
 }

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -27,8 +27,6 @@ import {
   isLeapYear,
 } from "./dateutil";
 
-export type {EdgeDBDateTime} from "../compat";
-
 export const DATE_PRIVATE = Symbol.for("edgedb.datetime");
 
 export class LocalTime {

--- a/src/datatypes/datetime.ts
+++ b/src/datatypes/datetime.ts
@@ -29,12 +29,24 @@ import {
 
 export const DATE_PRIVATE = Symbol.for("edgedb.datetime");
 
+// Converts value to number, or if value is NaN returns 0
+// as defined in temporal spec:
+// https://tc39.es/proposal-temporal/#sec-temporal-tointegerwithoutrounding
+// Note: Split into two functions, since some places in the spec throw on
+// non-integers and others use rounding
 function toNumber(val: any): number {
   const n = Number(val);
   if (Number.isNaN(n)) {
     return 0;
   }
   return n;
+}
+
+function assertInteger(val: number): number {
+  if (!Number.isInteger(val)) {
+    throw new RangeError(`unsupported fractional value ${val}`);
+  }
+  return val;
 }
 
 export class LocalTime {
@@ -315,13 +327,6 @@ export class LocalDateTime extends LocalDate {
   [inspect.custom](_depth: number, _options: any): string {
     return `LocalDateTime [ ${this.toString()} ]`;
   }
-}
-
-function assertInteger(val: number): number {
-  if (!Number.isInteger(val)) {
-    throw new RangeError(`unsupported fractional value ${val}`);
-  }
-  return val;
 }
 
 interface DurationLike {

--- a/src/primitives/bigint.ts
+++ b/src/primitives/bigint.ts
@@ -2,6 +2,7 @@
 
 interface JSBI {
   BigInt(from: number | string | boolean | object): JSBI;
+  isBigInt(x: JSBI): boolean;
 
   toNumber(x: JSBI): number;
 
@@ -50,6 +51,7 @@ export function plugJSBI(jsbi: any): void {
   JSBI = jsbi as JSBI;
 }
 
+let _isBigInt;
 let _make;
 let _add;
 let _div;
@@ -62,6 +64,8 @@ let _lt;
 let _remainder;
 
 if (hasNativeBigInt) {
+  _isBigInt = (val: BigIntLike): boolean => typeof val === "bigint";
+
   _make = (val: string | number): BigIntLike => BigInt(val);
 
   _add = (op1: BigIntLike, op2: BigIntLike): BigIntLike =>
@@ -91,6 +95,11 @@ if (hasNativeBigInt) {
   _remainder = (op1: BigIntLike, op2: BigIntLike): BigIntLike =>
     ((op1 as bigint) % (op2 as bigint)) as BigIntLike;
 } else {
+  _isBigInt = (val: BigIntLike): boolean => {
+    const j: any = ensureJSBI();
+    return val instanceof j;
+  };
+
   _make = (val: string | number): BigIntLike => {
     const j = ensureJSBI();
     return j.BigInt(val);
@@ -150,6 +159,7 @@ function ensureJSBI(): JSBI {
   return JSBI;
 }
 
+export const isBigInt = _isBigInt;
 export const make = _make;
 export const add = _add;
 export const sub = _sub;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -215,7 +215,7 @@ test("fetch: bigint", async () => {
 
 test("fetch: decimal as string", async () => {
   const con = getClient();
-  setCustomCodecs(["decimalString"], con);
+  setCustomCodecs(["decimal_string"], con);
 
   const vals = [
     "0.001",
@@ -351,7 +351,7 @@ test("fetch: decimal as string", async () => {
 
 test("fetch: int64 as bigint", async () => {
   const con = getClient();
-  setCustomCodecs(["int64Bigint"], con);
+  setCustomCodecs(["int64_bigint"], con);
 
   const vals = [
     "0",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -715,7 +715,7 @@ test("fetch: duration", async () => {
 if (!isDeno) {
   test("fetch: duration fuzz", async () => {
     // @ts-ignore
-    const Temporal = require("proposal-temporal").Temporal;
+    const Temporal = require("@js-temporal/polyfill").Temporal;
 
     jest.setTimeout(10_000);
     const randint = (min: number, max: number) => {
@@ -729,7 +729,7 @@ if (!isDeno) {
       new Duration(0, 0, 0, 0, 0, 0, 0, -1),
       new Duration(0, 0, 0, 0, 0, 0, 0, 1),
       new Duration(0, 0, 0, 0, 0, 0, 0, -1),
-      new Duration(0, 0, 0, 0, 0, 0, 0, -752043.296),
+      new Duration(0, 0, 0, 0, 0, 0, 0, -752043),
       new Duration(0, 0, 0, 0, 0, 0, 0, 3542924),
       new Duration(0, 0, 0, 0, 0, 0, 0, 86400000),
       new Duration(0, 0, 0, 0, 0, 0, 0, -86400000),

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {Temporal} from "proposal-temporal";
+import {Temporal} from "@js-temporal/polyfill";
 import {
   Duration,
   LocalDate,
@@ -145,11 +145,12 @@ test("types: Duration", async () => {
 
     const args = Array(10)
       .fill(0)
-      .map(
-        () =>
+      .map(() =>
+        Math.round(
           Math.random() *
-          (i < 100 ? Number.MAX_VALUE : Number.MAX_SAFE_INTEGER) *
-          sign
+            (i < 100 ? Number.MAX_VALUE : Number.MAX_SAFE_INTEGER) *
+            sign
+        )
       );
 
     const duration = new Duration(...args);
@@ -168,5 +169,49 @@ test("types: Duration", async () => {
     expect(duration.sign).toBe(temporalDuration.sign);
     expect(duration.blank).toBe(temporalDuration.blank);
     expect(duration.toString()).toBe(temporalDuration.toString());
+  }
+
+  expect(() => Duration.from({})).toThrow(TypeError);
+  expect(() => Temporal.Duration.from({})).toThrow(TypeError);
+  for (const durationStr of [
+    "",
+    "P",
+    "PT",
+    "P3WT",
+    "P3.5D",
+    "P1.2Y",
+    "P2.3M",
+    "P3.4W",
+    "PT1.2H3M",
+    "PT1.2H3S",
+    "PT1.2M5.6S",
+    "PT-5M",
+  ]) {
+    expect(() => Duration.from(durationStr)).toThrow(RangeError);
+    expect(() => Temporal.Duration.from(durationStr)).toThrow(RangeError);
+  }
+
+  for (const durationLike of [
+    "PT0S",
+    "Pt3.4H",
+    "-pT5.2345M",
+    "PT123.45678S",
+    "P1Y2M3W4DT5h6m7s",
+    "-P1Y2M3W4DT5h6m7s",
+  ]) {
+    const duration = Duration.from(durationLike);
+    const temporalDuration = Temporal.Duration.from(durationLike);
+
+    expect(duration.years).toBe(temporalDuration.years);
+    expect(duration.months).toBe(temporalDuration.months);
+    expect(duration.weeks).toBe(temporalDuration.weeks);
+    expect(duration.days).toBe(temporalDuration.days);
+    expect(duration.hours).toBe(temporalDuration.hours);
+    expect(duration.minutes).toBe(temporalDuration.minutes);
+    expect(duration.seconds).toBe(temporalDuration.seconds);
+    expect(duration.milliseconds).toBe(temporalDuration.milliseconds);
+    expect(duration.microseconds).toBe(temporalDuration.microseconds);
+    expect(duration.nanoseconds).toBe(temporalDuration.nanoseconds);
+    expect(duration.sign).toBe(temporalDuration.sign);
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,6 +661,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@js-temporal/polyfill@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@js-temporal/polyfill@npm:0.4.1"
+  dependencies:
+    jsbi: ^4.1.0
+    tslib: ^2.3.1
+  checksum: 0d7523918fe89353501e1d8c75ec2548f790765b55f6c9cdab5c9336025e93566adff8d9aca69b163becad51c155f9557a89cc352c5eb3e00ed037efdeede53e
+  languageName: node
+  linkType: hard
+
 "@npmcli/fs@npm:^1.0.0":
   version: 1.0.0
   resolution: "@npmcli/fs@npm:1.0.0"
@@ -1268,13 +1278,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.48":
-  version: 1.6.51
-  resolution: "big-integer@npm:1.6.51"
-  checksum: 3d444173d1b2e20747e2c175568bedeebd8315b0637ea95d75fd27830d3b8e8ba36c6af40374f36bdaea7b5de376dcada1b07587cb2a79a928fccdb6e6e3c518
-  languageName: node
-  linkType: hard
-
 "binary-extensions@npm:^2.0.0":
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
@@ -1444,16 +1447,6 @@ __metadata:
     normalize-url: ^4.1.0
     responselike: ^1.0.2
   checksum: b510b237b18d17e89942e9ee2d2a077cb38db03f12167fd100932dfa8fc963424bfae0bfa1598df4ae16c944a5484e43e03df8f32105b04395ee9495e9e4e9f1
-  languageName: node
-  linkType: hard
-
-"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "call-bind@npm:1.0.2"
-  dependencies:
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.0.2
-  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
   languageName: node
   linkType: hard
 
@@ -1905,15 +1898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "define-properties@npm:1.1.3"
-  dependencies:
-    object-keys: ^1.0.12
-  checksum: da80dba55d0cd76a5a7ab71ef6ea0ebcb7b941f803793e4e0257b384cb772038faa0c31659d244e82c4342edef841c1a1212580006a05a5068ee48223d787317
-  languageName: node
-  linkType: hard
-
 "define-property@npm:^0.2.5":
   version: 0.2.5
   resolution: "define-property@npm:0.2.5"
@@ -2020,6 +2004,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "edgedb@workspace:."
   dependencies:
+    "@js-temporal/polyfill": ^0.4.1
     "@types/jest": ^24.0.11
     "@types/node": 14
     get-stdin: ^7.0.0
@@ -2027,7 +2012,6 @@ __metadata:
     node-fetch: 2.6.7
     nodemon: ^2.0.13
     prettier: ^2.3.2
-    proposal-temporal: ^0.7.0
     ts-jest: ^26.5.2
     ts-node: ^10.0.0
     tslint: ^5.20.1
@@ -2098,45 +2082,6 @@ __metadata:
   dependencies:
     is-arrayish: ^0.2.1
   checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
-  languageName: node
-  linkType: hard
-
-"es-abstract@npm:^1.18.0-next.1":
-  version: 1.19.1
-  resolution: "es-abstract@npm:1.19.1"
-  dependencies:
-    call-bind: ^1.0.2
-    es-to-primitive: ^1.2.1
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.1.1
-    get-symbol-description: ^1.0.0
-    has: ^1.0.3
-    has-symbols: ^1.0.2
-    internal-slot: ^1.0.3
-    is-callable: ^1.2.4
-    is-negative-zero: ^2.0.1
-    is-regex: ^1.1.4
-    is-shared-array-buffer: ^1.0.1
-    is-string: ^1.0.7
-    is-weakref: ^1.0.1
-    object-inspect: ^1.11.0
-    object-keys: ^1.1.1
-    object.assign: ^4.1.2
-    string.prototype.trimend: ^1.0.4
-    string.prototype.trimstart: ^1.0.4
-    unbox-primitive: ^1.0.1
-  checksum: b6be8410672c5364db3fb01eb786e30c7b4bb32b4af63d381c08840f4382c4a168e7855cd338bf59d4f1a1a1138f4d748d1fd40ec65aaa071876f9e9fbfed949
-  languageName: node
-  linkType: hard
-
-"es-to-primitive@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "es-to-primitive@npm:1.2.1"
-  dependencies:
-    is-callable: ^1.1.4
-    is-date-object: ^1.0.1
-    is-symbol: ^1.0.2
-  checksum: 4ead6671a2c1402619bdd77f3503991232ca15e17e46222b0a41a5d81aebc8740a77822f5b3c965008e631153e9ef0580540007744521e72de8e33599fca2eed
   languageName: node
   linkType: hard
 
@@ -2492,17 +2437,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.0, get-intrinsic@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "get-intrinsic@npm:1.1.1"
-  dependencies:
-    function-bind: ^1.1.1
-    has: ^1.0.3
-    has-symbols: ^1.0.1
-  checksum: a9fe2ca8fa3f07f9b0d30fb202bcd01f3d9b9b6b732452e79c48e79f7d6d8d003af3f9e38514250e3553fdc83c61650851cb6870832ac89deaaceb08e3721a17
-  languageName: node
-  linkType: hard
-
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
@@ -2532,16 +2466,6 @@ __metadata:
   dependencies:
     pump: ^3.0.0
   checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
-  languageName: node
-  linkType: hard
-
-"get-symbol-description@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "get-symbol-description@npm:1.0.0"
-  dependencies:
-    call-bind: ^1.0.2
-    get-intrinsic: ^1.1.1
-  checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
   languageName: node
   linkType: hard
 
@@ -2624,13 +2548,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-bigints@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "has-bigints@npm:1.0.1"
-  checksum: 44ab55868174470065d2e0f8f6def1c990d12b82162a8803c679699fa8a39f966e336f2a33c185092fe8aea7e8bf2e85f1c26add5f29d98f2318bd270096b183
-  languageName: node
-  linkType: hard
-
 "has-flag@npm:^3.0.0":
   version: 3.0.0
   resolution: "has-flag@npm:3.0.0"
@@ -2642,22 +2559,6 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
-  languageName: node
-  linkType: hard
-
-"has-symbols@npm:^1.0.1, has-symbols@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "has-symbols@npm:1.0.2"
-  checksum: 2309c426071731be792b5be43b3da6fb4ed7cbe8a9a6bcfca1862587709f01b33d575ce8f5c264c1eaad09fca2f9a8208c0a2be156232629daa2dd0c0740976b
-  languageName: node
-  linkType: hard
-
-"has-tostringtag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "has-tostringtag@npm:1.0.0"
-  dependencies:
-    has-symbols: ^1.0.2
-  checksum: cc12eb28cb6ae22369ebaad3a8ab0799ed61270991be88f208d508076a1e99abe4198c965935ce85ea90b60c94ddda73693b0920b58e7ead048b4a391b502c1c
   languageName: node
   linkType: hard
 
@@ -2886,17 +2787,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "internal-slot@npm:1.0.3"
-  dependencies:
-    get-intrinsic: ^1.1.0
-    has: ^1.0.3
-    side-channel: ^1.0.4
-  checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
-  languageName: node
-  linkType: hard
-
 "ip@npm:^1.1.5":
   version: 1.1.5
   resolution: "ip@npm:1.1.5"
@@ -2929,15 +2819,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-bigint@npm:^1.0.1":
-  version: 1.0.4
-  resolution: "is-bigint@npm:1.0.4"
-  dependencies:
-    has-bigints: ^1.0.1
-  checksum: c56edfe09b1154f8668e53ebe8252b6f185ee852a50f9b41e8d921cb2bed425652049fbe438723f6cb48a63ca1aa051e948e7e401e093477c99c84eba244f666
-  languageName: node
-  linkType: hard
-
 "is-binary-path@npm:~2.1.0":
   version: 2.1.0
   resolution: "is-binary-path@npm:2.1.0"
@@ -2947,27 +2828,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-boolean-object@npm:^1.1.0":
-  version: 1.1.2
-  resolution: "is-boolean-object@npm:1.1.2"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: c03b23dbaacadc18940defb12c1c0e3aaece7553ef58b162a0f6bba0c2a7e1551b59f365b91e00d2dbac0522392d576ef322628cb1d036a0fe51eb466db67222
-  languageName: node
-  linkType: hard
-
 "is-buffer@npm:^1.1.5":
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 4a186d995d8bbf9153b4bd9ff9fd04ae75068fe695d29025d25e592d9488911eeece84eefbd8fa41b8ddcc0711058a71d4c466dcf6f1f6e1d83830052d8ca707
-  languageName: node
-  linkType: hard
-
-"is-callable@npm:^1.1.4, is-callable@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "is-callable@npm:1.2.4"
-  checksum: 1a28d57dc435797dae04b173b65d6d1e77d4f16276e9eff973f994eadcfdc30a017e6a597f092752a083c1103cceb56c91e3dadc6692fedb9898dfaba701575f
   languageName: node
   linkType: hard
 
@@ -3006,15 +2870,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.0
   checksum: e705e6816241c013b05a65dc452244ee378d1c3e3842bd140beabe6e12c0d700ef23c91803f971aa7b091fb0573c5da8963af34a2b573337d87bc3e1f53a4e6d
-  languageName: node
-  linkType: hard
-
-"is-date-object@npm:^1.0.1":
-  version: 1.0.5
-  resolution: "is-date-object@npm:1.0.5"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: baa9077cdf15eb7b58c79398604ca57379b2fc4cf9aa7a9b9e295278648f628c9b201400c01c5e0f7afae56507d741185730307cbe7cad3b9f90a77e5ee342fc
   languageName: node
   linkType: hard
 
@@ -3121,26 +2976,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-negative-zero@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "is-negative-zero@npm:2.0.1"
-  checksum: a46f2e0cb5e16fdb8f2011ed488979386d7e68d381966682e3f4c98fc126efe47f26827912baca2d06a02a644aee458b9cba307fb389f6b161e759125db7a3b8
-  languageName: node
-  linkType: hard
-
 "is-npm@npm:^5.0.0":
   version: 5.0.0
   resolution: "is-npm@npm:5.0.0"
   checksum: 9baff02b0c69a3d3c79b162cb2f9e67fb40ef6d172c16601b2e2471c21e9a4fa1fc9885a308d7bc6f3a3cd2a324c27fa0bf284c133c3349bb22571ab70d041cc
-  languageName: node
-  linkType: hard
-
-"is-number-object@npm:^1.0.4":
-  version: 1.0.6
-  resolution: "is-number-object@npm:1.0.6"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: c697704e8fc2027fc41cb81d29805de4e8b6dc9c3efee93741dbf126a8ecc8443fef85adbc581415ae7e55d325e51d0a942324ae35c829131748cce39cba55f3
   languageName: node
   linkType: hard
 
@@ -3190,23 +3029,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "is-regex@npm:1.1.4"
-  dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
-  languageName: node
-  linkType: hard
-
-"is-shared-array-buffer@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "is-shared-array-buffer@npm:1.0.1"
-  checksum: 2ffb92533e64e2876e6cfe6906871d28400b6f1a53130fe652ec8007bc0e5044d05e7af8e31bdc992fbba520bd92938cfbeedd0f286be92f250c7c76191c4d90
-  languageName: node
-  linkType: hard
-
 "is-stream@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-stream@npm:1.1.0"
@@ -3221,37 +3043,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-string@npm:^1.0.5, is-string@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "is-string@npm:1.0.7"
-  dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: 323b3d04622f78d45077cf89aab783b2f49d24dc641aa89b5ad1a72114cfeff2585efc8c12ef42466dff32bde93d839ad321b26884cf75e5a7892a938b089989
-  languageName: node
-  linkType: hard
-
-"is-symbol@npm:^1.0.2, is-symbol@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "is-symbol@npm:1.0.4"
-  dependencies:
-    has-symbols: ^1.0.2
-  checksum: 92805812ef590738d9de49d677cd17dfd486794773fb6fa0032d16452af46e9b91bb43ffe82c983570f015b37136f4b53b28b8523bfb10b0ece7a66c31a54510
-  languageName: node
-  linkType: hard
-
 "is-typedarray@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
   checksum: 3508c6cd0a9ee2e0df2fa2e9baabcdc89e911c7bd5cf64604586697212feec525aa21050e48affb5ffc3df20f0f5d2e2cf79b08caa64e1ccc9578e251763aef7
-  languageName: node
-  linkType: hard
-
-"is-weakref@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "is-weakref@npm:1.0.1"
-  dependencies:
-    call-bind: ^1.0.0
-  checksum: fdafb7b955671dd2f9658ff47c86e4025c0650fc68a3542a40e5a75898a763b1abd6b1e1f9f13207eed49541cdd76af67d73c44989ea358b201b70274cf8f6c1
   languageName: node
   linkType: hard
 
@@ -3861,6 +3656,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
+  languageName: node
+  linkType: hard
+
+"jsbi@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "jsbi@npm:4.3.0"
+  checksum: 27c4f178eb7fd9d1756144066fdebc62f4a0176e877f55e646e8ce84075c13551bd575a316b9959ccdcca9d5dc05a81c9907cfa09f0cfeb43c9777797e36b0e9
   languageName: node
   linkType: hard
 
@@ -4576,38 +4378,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.11.0, object-inspect@npm:^1.9.0":
-  version: 1.11.0
-  resolution: "object-inspect@npm:1.11.0"
-  checksum: 8c64f89ce3a7b96b6925879ad5f6af71d498abc217e136660efecd97452991216f375a7eb47cb1cb50643df939bf0c7cc391567b7abc6a924d04679705e58e27
-  languageName: node
-  linkType: hard
-
-"object-keys@npm:^1.0.12, object-keys@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "object-keys@npm:1.1.1"
-  checksum: b363c5e7644b1e1b04aa507e88dcb8e3a2f52b6ffd0ea801e4c7a62d5aa559affe21c55a07fd4b1fd55fc03a33c610d73426664b20032405d7b92a1414c34d6a
-  languageName: node
-  linkType: hard
-
 "object-visit@npm:^1.0.0":
   version: 1.0.1
   resolution: "object-visit@npm:1.0.1"
   dependencies:
     isobject: ^3.0.0
   checksum: b0ee07f5bf3bb881b881ff53b467ebbde2b37ebb38649d6944a6cd7681b32eedd99da9bd1e01c55facf81f54ed06b13af61aba6ad87f0052982995e09333f790
-  languageName: node
-  linkType: hard
-
-"object.assign@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "object.assign@npm:4.1.2"
-  dependencies:
-    call-bind: ^1.0.0
-    define-properties: ^1.1.3
-    has-symbols: ^1.0.1
-    object-keys: ^1.1.1
-  checksum: d621d832ed7b16ac74027adb87196804a500d80d9aca536fccb7ba48d33a7e9306a75f94c1d29cbfa324bc091bfc530bc24789568efdaee6a47fcfa298993814
   languageName: node
   linkType: hard
 
@@ -4897,16 +4673,6 @@ __metadata:
     kleur: ^3.0.3
     sisteransi: ^1.0.5
   checksum: d8fd1fe63820be2412c13bfc5d0a01909acc1f0367e32396962e737cb2fc52d004f3302475d5ce7d18a1e8a79985f93ff04ee03007d091029c3f9104bffc007d
-  languageName: node
-  linkType: hard
-
-"proposal-temporal@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "proposal-temporal@npm:0.7.0"
-  dependencies:
-    big-integer: ^1.6.48
-    es-abstract: ^1.18.0-next.1
-  checksum: ed3391478ed72f4fd0a5c767f1fad49d71cbf945a64408e7a15ae431392485c33a2c14d69b64d4f5fbdde3bce4624be263a8435d631432a10a5f84bdeccd5cd2
   languageName: node
   linkType: hard
 
@@ -5319,17 +5085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "side-channel@npm:1.0.4"
-  dependencies:
-    call-bind: ^1.0.0
-    get-intrinsic: ^1.0.2
-    object-inspect: ^1.9.0
-  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
-  languageName: node
-  linkType: hard
-
 "signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2":
   version: 3.0.5
   resolution: "signal-exit@npm:3.0.5"
@@ -5573,26 +5328,6 @@ __metadata:
     is-fullwidth-code-point: ^3.0.0
     strip-ansi: ^6.0.1
   checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
-  languageName: node
-  linkType: hard
-
-"string.prototype.trimend@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "string.prototype.trimend@npm:1.0.4"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-  checksum: 17e5aa45c3983f582693161f972c1c1fa4bbbdf22e70e582b00c91b6575f01680dc34e83005b98e31abe4d5d29e0b21fcc24690239c106c7b2315aade6a898ac
-  languageName: node
-  linkType: hard
-
-"string.prototype.trimstart@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "string.prototype.trimstart@npm:1.0.4"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-  checksum: 3fb06818d3cccac5fa3f5f9873d984794ca0e9f6616fae6fcc745885d9efed4e17fe15f832515d9af5e16c279857fdbffdfc489ca4ed577811b017721b30302f
   languageName: node
   linkType: hard
 
@@ -5893,6 +5628,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "tslib@npm:2.3.1"
+  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
+  languageName: node
+  linkType: hard
+
 "tslint-config-prettier@npm:^1.18.0":
   version: 1.18.0
   resolution: "tslint-config-prettier@npm:1.18.0"
@@ -6022,18 +5764,6 @@ typescript@^4.5.2:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 02cf0f190f0cb6d216558d8db9c3a968feeab4965c340a351e5e6e84a42a3946e5e200a9538b6e427af9d17e4f713254dd0707d5fd6f238ce93f0aee1986ab57
-  languageName: node
-  linkType: hard
-
-"unbox-primitive@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "unbox-primitive@npm:1.0.1"
-  dependencies:
-    function-bind: ^1.1.1
-    has-bigints: ^1.0.1
-    has-symbols: ^1.0.2
-    which-boxed-primitive: ^1.0.2
-  checksum: 89d950e18fb45672bc6b3c961f1e72c07beb9640c7ceed847b571ba6f7d2af570ae1a2584cfee268b9d9ea1e3293f7e33e0bc29eaeb9f8e8a0bab057ff9e6bba
   languageName: node
   linkType: hard
 
@@ -6264,19 +5994,6 @@ typescript@^4.5.2:
     tr46: ^2.1.0
     webidl-conversions: ^6.1.0
   checksum: a87abcc6cefcece5311eb642858c8fdb234e51ec74196bfacf8def2edae1bfbffdf6acb251646ed6301f8cee44262642d8769c707256125a91387e33f405dd1e
-  languageName: node
-  linkType: hard
-
-"which-boxed-primitive@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "which-boxed-primitive@npm:1.0.2"
-  dependencies:
-    is-bigint: ^1.0.1
-    is-boolean-object: ^1.1.0
-    is-number-object: ^1.0.4
-    is-string: ^1.0.5
-    is-symbol: ^1.0.3
-  checksum: 53ce774c7379071729533922adcca47220228405e1895f26673bbd71bdf7fb09bee38c1d6399395927c6289476b5ae0629863427fd151491b71c4b6cb04f3a5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Update to latest temporal polyfill for tests
- Add `from` method to `Duration` type according to temporal spec: https://tc39.es/proposal-temporal/#sec-temporal.duration.from
- Re-organise custom codecs:
  - drop `bigint` -> `string` codec: not needed since bigint's are supported pretty much everywhere and we can polyfill when they aren't
  - change `int64` -> `string` to `int64` -> `bigint`: so we can add encode codec
  - drop `local_datetime` codec and change `datetime` codec to decode into a `LocalDatetime`: datetime types now fit into `Date` type (https://github.com/edgedb/edgedb/pull/2252), except `datetime` needs `local_datetime` codec because `Date` doesn't have microsecond precision
- Add encode codec for decimal strings