### PR TITLE
Add Deno compilation target for Query Builder

### DIFF
--- a/src/adapter.deno.ts
+++ b/src/adapter.deno.ts
@@ -93,6 +93,15 @@ export namespace fs {
     return _fs.ensureDir(path);
   }
 
+  export async function readdir(path: string): Promise<string[]> {
+    // deno uses async iterables while node expects an array
+    const output: string[] = []
+    for await (const dir of Deno.readDir(path.replace("file:/", "/"))) {
+      output.push(dir)
+    }
+    return output
+  }
+
   export function writeFile(path: string, contents: string): Promise<void> {
     return Deno.writeTextFile(path, contents);
   }

--- a/src/reflection/generators/generateCastMaps.ts
+++ b/src/reflection/generators/generateCastMaps.ts
@@ -16,9 +16,10 @@ export const generateCastMaps = (params: GeneratorParams) => {
   const {dir, types, casts, typesByName} = params;
   const {implicitCastMap} = casts;
 
+  const edgedb = params.isDeno ? "https://deno.land/x/edgedb/mod.ts" : "edgedb"
   const f = dir.getPath("castMaps");
-  f.addStarImport("edgedb", "edgedb");
-  f.addImport({$: true}, "edgedb", false, ["ts", "dts"], true);
+  f.addStarImport("edgedb", edgedb);
+  f.addImport({$: true}, edgedb, params.isDeno, ["ts", "dts"], true);
 
   const reverseTopo = Array.from(types)
     .reverse() // reverse topological order

--- a/src/reflection/generators/generateFunctionTypes.ts
+++ b/src/reflection/generators/generateFunctionTypes.ts
@@ -31,6 +31,7 @@ export const generateFunctionTypes = ({
   functions,
   types,
   casts,
+  isDeno
 }: GeneratorParams) => {
   generateFuncopTypes(
     dir,
@@ -54,7 +55,8 @@ export const generateFunctionTypes = ({
       code.writeln([r`__name__: ${quote(funcName)},`]);
       code.writeln([r`__args__: positionalArgs,`]);
       code.writeln([r`__namedargs__: namedArgs,`]);
-    }
+    },
+    isDeno
   );
 };
 
@@ -98,7 +100,8 @@ export function generateFuncopTypes<F extends FuncopDef>(
     code: CodeBuilder,
     funcopName: string,
     funcopDefs: F[]
-  ) => void
+  ) => void,
+  isDeno: boolean
 ) {
   const typeSpecificities = getTypesSpecificity(types, casts);
   const implicitCastableRootTypes = getImplicitCastableRootTypes(casts);
@@ -113,7 +116,7 @@ export function generateFuncopTypes<F extends FuncopDef>(
 
     const {mod, name} = splitName(funcName);
 
-    const code = dir.getModule(mod);
+    const code = dir.getModule(mod, isDeno);
 
     code.registerRef(funcName, funcDefs[0].id);
     code.addRefsDefaultExport(getRef(funcName, {prefix: ""}), name);

--- a/src/reflection/generators/generateObjectTypes.ts
+++ b/src/reflection/generators/generateObjectTypes.ts
@@ -125,7 +125,7 @@ export const getStringRepresentation: (
 };
 
 export const generateObjectTypes = (params: GeneratorParams) => {
-  const {dir, types} = params;
+  const {dir, types, isDeno} = params;
 
   const plainTypesCode = dir.getPath("types");
   plainTypesCode.addStarImport("edgedb", "edgedb", false, undefined, true);
@@ -195,7 +195,7 @@ export const generateObjectTypes = (params: GeneratorParams) => {
 
     const {mod, name} = splitName(type.name);
 
-    const body = dir.getModule(mod);
+    const body = dir.getModule(mod, isDeno);
 
     body.registerRef(type.name, type.id);
 

--- a/src/reflection/generators/generateOperatorTypes.ts
+++ b/src/reflection/generators/generateOperatorTypes.ts
@@ -22,6 +22,7 @@ export function generateOperatorFunctions({
   operators,
   types,
   casts,
+  isDeno
 }: GeneratorParams) {
   generateFuncopTypes(
     dir,
@@ -45,7 +46,8 @@ export function generateOperatorFunctions({
       code.writeln([r`__name__: ${quote(opDefs[0].originalName)},`]);
       code.writeln([r`__opkind__: kind,`]);
       code.writeln([r`__args__: positionalArgs,`]);
-    }
+    },
+    isDeno
   );
 }
 
@@ -60,12 +62,14 @@ export function generateOperators({
   operators,
   types,
   casts,
+  isDeno
 }: GeneratorParams) {
   const typeSpecificities = getTypesSpecificity(types, casts);
   const implicitCastableRootTypes = getImplicitCastableRootTypes(casts);
   const code = dir.getPath("operators");
+  const edgedb = isDeno ? "https://deno.land/x/edgedb/mod.ts" : "edgedb"
 
-  code.addImport({$: true}, "edgedb");
+  code.addImport({$: true}, edgedb);
   code.addStarImport("_", "./imports", true);
 
   const overloadsBuf = new CodeBuffer();

--- a/src/reflection/generators/generateRuntimeSpec.ts
+++ b/src/reflection/generators/generateRuntimeSpec.ts
@@ -3,9 +3,10 @@ import type {GeneratorParams} from "../generate";
 
 export const generateRuntimeSpec = (params: GeneratorParams) => {
   const {dir, types} = params;
+  const edgedb = params.isDeno ? "https://deno.land/x/edgedb/mod.ts" : "edgedb"
 
   const spec = dir.getPath("__spec__");
-  spec.addImport({$: true}, "edgedb");
+  spec.addImport({$: true}, edgedb);
   spec.writeln([
     dts`declare `,
     `const spec`,

--- a/src/reflection/generators/generateScalars.ts
+++ b/src/reflection/generators/generateScalars.ts
@@ -13,7 +13,7 @@ import type {GeneratorParams} from "../generate";
 import {nonCastableTypes, typeMapping} from "../queries/getTypes";
 
 export const generateScalars = (params: GeneratorParams) => {
-  const {dir, types, casts, scalars} = params;
+  const {dir, types, casts, scalars, isDeno} = params;
   for (const type of types.values()) {
     if (type.kind !== "scalar") {
       continue;
@@ -21,7 +21,7 @@ export const generateScalars = (params: GeneratorParams) => {
 
     const {mod, name: _name} = splitName(type.name);
 
-    const sc = dir.getModule(mod);
+    const sc = dir.getModule(mod, isDeno);
 
     sc.registerRef(type.name, type.id);
 

--- a/src/reflection/generators/generateSetImpl.ts
+++ b/src/reflection/generators/generateSetImpl.ts
@@ -3,27 +3,7 @@ import {GeneratorParams} from "../generate";
 import {getImplicitCastableRootTypes} from "../util/functionUtils";
 import {getStringRepresentation} from "./generateObjectTypes";
 
-export const generateSetImpl = ({dir, types, casts}: GeneratorParams) => {
-  const code = dir.getPath("syntax/setImpl");
-
-  const implicitCastableRootTypes = getImplicitCastableRootTypes(casts);
-
-  code.addImport(
-    {
-      TypeKind: true,
-      ExpressionKind: true,
-      Cardinality: true,
-      cardinalityUtil: true,
-      $mergeObjectTypes: true,
-    },
-    "edgedb/dist/reflection/index",
-    true
-  );
-  code.addStarImport("castMaps", "../castMaps", true, ["ts", "js", "dts"]);
-  code.addImport({$expressionify: true}, "./path", true, ["ts", "js"]);
-
-  code.writeln([
-    t`import type {
+const nodeLiteral = () => t`import type {
   ArrayType,
   TypeSet,
   BaseType,
@@ -40,8 +20,56 @@ import type {
   getCardsFromExprs,
   getSharedParentPrimitiveVariadic,
   LooseTypeSet,
-} from "./set";`,
-  ]);
+} from "./set";`;
+
+const denoLiteral = () => t`import type {
+  ArrayType,
+  TypeSet,
+  BaseType,
+  ObjectTypeSet,
+  PrimitiveTypeSet,
+  AnyTupleType,
+  getPrimitiveBaseType,
+} from "https://deno.land/x/edgedb/_src/reflection/index.ts";
+import type {
+  $expr_Set,
+  mergeObjectTypesVariadic,
+  getTypesFromExprs,
+  getTypesFromObjectExprs,
+  getCardsFromExprs,
+  getSharedParentPrimitiveVariadic,
+  LooseTypeSet,
+} from "./set.ts";`;
+
+export const generateSetImpl = ({
+  dir,
+  types,
+  casts,
+  isDeno,
+}: GeneratorParams) => {
+  const code = dir.getPath("syntax/setImpl");
+
+  const implicitCastableRootTypes = getImplicitCastableRootTypes(casts);
+
+  const fromPath = isDeno
+    ? "https://deno.land/x/edgedb/_src/reflection/index"
+    : "edgedb/dist/reflection/index";
+
+  code.addImport(
+    {
+      TypeKind: true,
+      ExpressionKind: true,
+      Cardinality: true,
+      cardinalityUtil: true,
+      $mergeObjectTypes: true,
+    },
+    fromPath,
+    true
+  );
+  code.addStarImport("castMaps", "../castMaps", true, ["ts", "js", "dts"]);
+  code.addImport({$expressionify: true}, "./path", true, ["ts", "js"]);
+
+  code.writeln([isDeno ? denoLiteral() : nodeLiteral()]);
   code.addImport({getSharedParent: true}, "./set", true, ["ts", "js"]);
 
   code.nl();


### PR DESCRIPTION
This PR adds support for a `--target deno` via the query builder cli. 
The cli itself still requires the use of `npx` due to the `syntax` folder not being compatible with deno as of yet.

TODO:
- [x] resolve conflicts
- [ ] link repro project (due to the changes to the Deno compiler the use of an import map is required in the interim until a new release is cut for https://deno.land/x/edgedb)

- add compiling deno version number
- add missing deno adapter fn readdir
- refactor estimateCompilationTarget and getProjectRoot
- add deno compatible compilation to query builder
