### PR TITLE
Use byteToHex to decode uuid

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           server-version: ${{ matrix.edgedb-version }}
 
       - name: Run query builder tests
-        if: ${{ matrix.node-version >= 14 && matrix.edgedb-version == 'nightly' }}  # change to stable once 2.0 lands
+        if: ${{ matrix.node-version >= 14 }}
         working-directory: qb
         run: |
           yarn test:ci

--- a/qb/playground.ts
+++ b/qb/playground.ts
@@ -46,9 +46,8 @@ for (let i = 0; i < 256; ++i) {
   byteToHex.push((i + 0x100).toString(16).slice(1));
 }
 
-export function parseWithByteToHex(buffer: Buffer) {
-  const arr = new Uint8Array(buffer);
-
+export function parseWithByteToHex(buf: Buffer) {
+  const arr = new Uint8Array(buf);
   return (
     byteToHex[arr[0]] +
     byteToHex[arr[1]] +
@@ -73,8 +72,42 @@ export function parseWithByteToHex(buffer: Buffer) {
   ).toLowerCase();
 }
 
+export function parseWithByteToHex2(arr: Buffer) {
+  return (
+    byteToHex[arr[0]] +
+    byteToHex[arr[1]] +
+    byteToHex[arr[2]] +
+    byteToHex[arr[3]] +
+    "-" +
+    byteToHex[arr[4]] +
+    byteToHex[arr[5]] +
+    "-" +
+    byteToHex[arr[6]] +
+    byteToHex[arr[7]] +
+    "-" +
+    byteToHex[arr[8]] +
+    byteToHex[arr[9]] +
+    "-" +
+    byteToHex[arr[10]] +
+    byteToHex[arr[11]] +
+    byteToHex[arr[12]] +
+    byteToHex[arr[13]] +
+    byteToHex[arr[14]] +
+    byteToHex[arr[15]]
+  );
+}
+
 async function run() {
-  const RUNS = 1000000;
+  const d = await setupTests();
+  const res = await d.client.queryRequiredSingle<string>(
+    `SELECT uuid_generate_v1mc();`
+  );
+  const uuidRegex =
+    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+  console.log(`is uuid`);
+  console.log(uuidRegex.test(res));
+
+  const RUNS = 1;
   console.time("without-dashes");
   for (let i = 0; i < RUNS; i++) {
     const testBuffer = new ReadBuffer(
@@ -114,11 +147,20 @@ async function run() {
   console.time("with-dashes-bytetohex");
   for (let i = 0; i < RUNS; i++) {
     const testBuffer = new ReadBuffer(
-      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+      Buffer.from("A42599e903dc48e3abb7501b7f8543f5", "hex")
     );
     parseWithByteToHex(testBuffer.readBuffer(16));
   }
   console.timeEnd("with-dashes-bytetohex");
+
+  console.time("with-dashes-bytetohex2");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("A42599E903dc48e3aBB7501b7f8543f5", "hex")
+    );
+    parseWithByteToHex2(testBuffer.readBuffer(16));
+  }
+  console.timeEnd("with-dashes-bytetohex2");
 }
 
 run();

--- a/qb/playground.ts
+++ b/qb/playground.ts
@@ -1,43 +1,125 @@
 // tslint:disable:no-console
 import {setupTests} from "./test/setupTeardown";
 import e from "./dbschema/edgeql-js";
-import {LocalDate, Range} from "edgedb";
+import {Range} from "edgedb";
+import {ReadBuffer} from "../src/primitives/buffer";
+
+function parseWithoutDashes(buffer: ReadBuffer) {
+  return buffer.readBuffer(16).toString("hex");
+}
+
+function parseWithDashes(buffer: ReadBuffer) {
+  return `${buffer.readBuffer(4).toString("hex")}-${buffer
+    .readBuffer(2)
+    .toString("hex")}-${buffer.readBuffer(2).toString("hex")}-${buffer
+    .readBuffer(2)
+    .toString("hex")}-${buffer.readBuffer(6).toString("hex")}`;
+}
+
+function parseWithDashesInterpolation(buffer: ReadBuffer) {
+  const buf = buffer.readBuffer(16).toString("hex");
+  return `${buf.slice(0, 8)}-${buf.slice(8, 12)}-${buf.slice(
+    12,
+    16
+  )}-${buf.slice(16, 20)}-${buf.slice(20)}`;
+}
+
+function parseWithDashesStringAddition(buffer: ReadBuffer) {
+  const buf = buffer.readBuffer(16).toString("hex");
+
+  return (
+    buf.slice(0, 8) +
+    "-" +
+    buf.slice(8, 12) +
+    "-" +
+    buf.slice(12, 16) +
+    "-" +
+    buf.slice(16, 20) +
+    "-" +
+    buf.slice(20)
+  );
+}
+
+const byteToHex: string[] = [];
+
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 0x100).toString(16).slice(1));
+}
+
+export function parseWithByteToHex(buffer: Buffer) {
+  const arr = new Uint8Array(buffer);
+
+  return (
+    byteToHex[arr[0]] +
+    byteToHex[arr[1]] +
+    byteToHex[arr[2]] +
+    byteToHex[arr[3]] +
+    "-" +
+    byteToHex[arr[4]] +
+    byteToHex[arr[5]] +
+    "-" +
+    byteToHex[arr[6]] +
+    byteToHex[arr[7]] +
+    "-" +
+    byteToHex[arr[8]] +
+    byteToHex[arr[9]] +
+    "-" +
+    byteToHex[arr[10]] +
+    byteToHex[arr[11]] +
+    byteToHex[arr[12]] +
+    byteToHex[arr[13]] +
+    byteToHex[arr[14]] +
+    byteToHex[arr[15]]
+  ).toLowerCase();
+}
 
 async function run() {
-  const {client, data} = await setupTests();
-  const query = e.range(Range.empty());
+  const RUNS = 1000000;
+  console.time("without-dashes");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+    );
+    parseWithoutDashes(testBuffer);
+  }
+  console.timeEnd("without-dashes");
 
-  console.log(query.toEdgeQL());
-  const result = await query.run(client);
-  console.log(result.lower);
-  console.log(result.upper);
-  console.log(result.isEmpty);
-  console.log(result.incLower);
-  console.log(result.incUpper);
+  console.time("with-dashes-readbuffer");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+    );
+    parseWithDashes(testBuffer);
+  }
+  console.timeEnd("with-dashes-readbuffer");
 
-  e.range(e.cast(e.int64, e.set()), e.cast(e.int64, e.set()));
-  console.log(
-    e.range(new LocalDate(1970, 1, 1), new LocalDate(2022, 1, 1)).toEdgeQL()
-  );
+  console.time("with-dashes-string-manip");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+    );
+    parseWithDashesInterpolation(testBuffer);
+  }
+  console.timeEnd("with-dashes-string-manip");
 
-  console.log(`~~~~~~~~~~~~~~~~~~~~~~~~~~~`);
-  console.log(JSON.stringify(result, null, 2));
+  console.time("with-dashes-string-addition");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+    );
+    parseWithDashesStringAddition(testBuffer);
+  }
+  console.timeEnd("with-dashes-string-addition");
+
+  console.time("with-dashes-bytetohex");
+  for (let i = 0; i < RUNS; i++) {
+    const testBuffer = new ReadBuffer(
+      Buffer.from("a42599e903dc48e3abb7501b7f8543f5", "hex")
+    );
+    parseWithByteToHex(testBuffer.readBuffer(16));
+  }
+  console.timeEnd("with-dashes-bytetohex");
 }
 
 run();
 export {};
-
-interface App {
-  [k: string]: unknown;
-}
-interface App {
-  test: string;
-}
-
-const arg: App = {
-  test: "asdf",
-};
-function test(arg: App) {
-  arg.test;
-}
-const arg2: {} = "asdf";

--- a/qb/test/params.test.ts
+++ b/qb/test/params.test.ts
@@ -194,7 +194,7 @@ test("all param types", async () => {
     json: '{"name": "test"}',
     str: "test str",
     bytes: Buffer.from("buffer"),
-    uuid: "d476ccc23e7b11ecaf130f07004006ce",
+    uuid: "d476ccc2-3e7b-11ec-af13-0f07004006ce",
     datetime: new Date(),
     duration: new edgedb.Duration(0, 0, 0, 0, 1),
     local_date: new edgedb.LocalDate(2021, 11, 25),

--- a/src/codecs/uuid.ts
+++ b/src/codecs/uuid.ts
@@ -35,11 +35,42 @@ function UUIDBufferFromString(uuid: string): Buffer {
   return buf;
 }
 
+const byteToHex: string[] = [];
+
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 0x100).toString(16).slice(1));
+}
+export function bytesToHex(buffer: Buffer) {
+  const arr = new Uint8Array(buffer);
+
+  return (
+    byteToHex[arr[0]] +
+    byteToHex[arr[1]] +
+    byteToHex[arr[2]] +
+    byteToHex[arr[3]] +
+    "-" +
+    byteToHex[arr[4]] +
+    byteToHex[arr[5]] +
+    "-" +
+    byteToHex[arr[6]] +
+    byteToHex[arr[7]] +
+    "-" +
+    byteToHex[arr[8]] +
+    byteToHex[arr[9]] +
+    "-" +
+    byteToHex[arr[10]] +
+    byteToHex[arr[11]] +
+    byteToHex[arr[12]] +
+    byteToHex[arr[13]] +
+    byteToHex[arr[14]] +
+    byteToHex[arr[15]]
+  ).toLowerCase();
+}
+
 export class UUIDCodec extends ScalarCodec implements ICodec {
   encode(buf: WriteBuffer, object: any): void {
     if (typeof object === "string") {
-      const val = <string>object;
-      const ubuf = UUIDBufferFromString(val);
+      const ubuf = UUIDBufferFromString(object);
       buf.writeInt32(16);
       buf.writeBuffer(ubuf);
     } else {
@@ -50,6 +81,6 @@ export class UUIDCodec extends ScalarCodec implements ICodec {
   }
 
   decode(buf: ReadBuffer): any {
-    return buf.readBuffer(16).toString("hex");
+    return bytesToHex(buf.readBuffer(16));
   }
 }

--- a/src/codecs/uuid.ts
+++ b/src/codecs/uuid.ts
@@ -40,31 +40,29 @@ const byteToHex: string[] = [];
 for (let i = 0; i < 256; ++i) {
   byteToHex.push((i + 0x100).toString(16).slice(1));
 }
-export function bytesToHex(buffer: Buffer) {
-  const arr = new Uint8Array(buffer);
-
+export function bytesToHex(buf: Buffer) {
   return (
-    byteToHex[arr[0]] +
-    byteToHex[arr[1]] +
-    byteToHex[arr[2]] +
-    byteToHex[arr[3]] +
+    byteToHex[buf[0]] +
+    byteToHex[buf[1]] +
+    byteToHex[buf[2]] +
+    byteToHex[buf[3]] +
     "-" +
-    byteToHex[arr[4]] +
-    byteToHex[arr[5]] +
+    byteToHex[buf[4]] +
+    byteToHex[buf[5]] +
     "-" +
-    byteToHex[arr[6]] +
-    byteToHex[arr[7]] +
+    byteToHex[buf[6]] +
+    byteToHex[buf[7]] +
     "-" +
-    byteToHex[arr[8]] +
-    byteToHex[arr[9]] +
+    byteToHex[buf[8]] +
+    byteToHex[buf[9]] +
     "-" +
-    byteToHex[arr[10]] +
-    byteToHex[arr[11]] +
-    byteToHex[arr[12]] +
-    byteToHex[arr[13]] +
-    byteToHex[arr[14]] +
-    byteToHex[arr[15]]
-  ).toLowerCase();
+    byteToHex[buf[10]] +
+    byteToHex[buf[11]] +
+    byteToHex[buf[12]] +
+    byteToHex[buf[13]] +
+    byteToHex[buf[14]] +
+    byteToHex[buf[15]]
+  );
 }
 
 export class UUIDCodec extends ScalarCodec implements ICodec {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1194,7 +1194,7 @@ test("fetch: uuid", async () => {
     res = await con.querySingle(
       "SELECT <uuid>'759637d8-6635-11e9-b9d4-098002d459d5'"
     );
-    expect(res).toBe("759637d8663511e9b9d4098002d459d5");
+    expect(res).toBe("759637d8-6635-11e9-b9d4-098002d459d5");
   } finally {
     await con.close();
   }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1160,7 +1160,9 @@ test("fetch: object implicit fields", async () => {
       limit 1
     `);
 
-    expect(JSON.stringify(res)).toMatch(/^\{"id":"([\w\d]{32})"\}$/);
+    expect(JSON.stringify(res)).toMatch(
+      /^\{"id":"([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)"\}$/
+    );
 
     res = await con.querySingle(`
       select schema::Function
@@ -1189,7 +1191,8 @@ test("fetch: uuid", async () => {
   try {
     res = await con.querySingle("SELECT schema::ObjectType.id LIMIT 1");
     expect(typeof res).toBe("string");
-    expect(res.length).toBe(32);
+    expect(res.length).toBe(36);
+    expect(res.replace(/\-/g, "").length).toBe(32);
 
     res = await con.querySingle(
       "SELECT <uuid>'759637d8-6635-11e9-b9d4-098002d459d5'"

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1198,6 +1198,13 @@ test("fetch: uuid", async () => {
       "SELECT <uuid>'759637d8-6635-11e9-b9d4-098002d459d5'"
     );
     expect(res).toBe("759637d8-6635-11e9-b9d4-098002d459d5");
+
+    res = await con.queryRequiredSingle<string>(
+      `SELECT uuid_generate_v1mc();`
+    );
+    const uuidRegex =
+      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+    expect(uuidRegex.test(res)).toEqual(true);
   } finally {
     await con.close();
   }

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -59,7 +59,7 @@ if (getEdgeDBVersion().major >= 2) {
           currentTags := global currentTags,
         }`)
       ).toEqual({
-        userId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        userId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         currentTags: null,
       });
 
@@ -81,7 +81,7 @@ if (getEdgeDBVersion().major >= 2) {
           currentTags := global currentTags,
         }`)
       ).toEqual({
-        userId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        userId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
         currentTags: ["a", "b", "c"],
       });
 


### PR DESCRIPTION
Did some simple benchmarking on UUID parsing, see `qb/playground.ts` to see the various implementation.

I landed on an implementation from https://github.com/uuidjs/uuid/blob/main/src/stringify.js that's actually 22% faster than what we have currently and adds hyphens properly.

```
without-dashes: 821.39ms // current
with-dashes-bytetohex: 634.192ms // new
with-dashes-readbuffer: 1.714s
with-dashes-string-manip: 841.354ms
with-dashes-string-addition: 875.214ms
``` 
