### PR TITLE
Skip tests for README/docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - master
       - ci
+    paths-ignore:
+      - "README.md"
+      - "docs/**"
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - "README.md"
+      - "docs/**"
 
 jobs:
   test:


### PR DESCRIPTION
Skips running tests for `README.md` and anything under `docs/`.

[This has a side-effect of not passing PR status checks due to the workflow being added and then skipped due to the path filter](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks).

P.S. Now that I pull requested, should we also ignore `.github/` (or stricter like `.github/ISSUE_TEMPLATE/`)?