### PR TITLE
Fix `e.group` codegen when grouping a nested `e.select`

### DIFF
--- a/src/syntax/toEdgeQL.ts
+++ b/src/syntax/toEdgeQL.ts
@@ -1045,7 +1045,7 @@ function renderEdgeQL(
     const selectStatement: string[] = [];
     const groupStatement: string[] = [];
 
-    const groupTarget = renderEdgeQL(expr.__scope__, ctx);
+    const groupTarget = renderEdgeQL(expr.__scope__, ctx, false);
     groupStatement.push(`GROUP ${groupTarget}`);
 
     // render scoped withvars in using


### PR DESCRIPTION
Reported on discord: https://discord.com/channels/841451783728529451/1022077368984150016