### PR TITLE
Fix Date handling for interface helper types

### DIFF
--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -187,11 +187,11 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
 
 export namespace helper {
   export type propertyKeys<T> = {
-    [k in keyof T]: NonNullable<T[k]> extends object ? never : k;
+    [k in keyof T]: NonNullable<T[k]> extends Date ? k : NonNullable<T[k]> extends object ? never : k;
   }[keyof T];
 
   export type linkKeys<T> = {
-    [k in keyof T]: NonNullable<T[k]> extends object ? k : never;
+    [k in keyof T]: NonNullable<T[k]> extends Date ? never : NonNullable<T[k]> extends object ? k : never;
   }[keyof T];
 
   export type Props<T> = Pick<T, propertyKeys<T>>;


### PR DESCRIPTION
The propertyKeys<T> and linkKeys<T> were incorrectly treating Date properties as links because Dates are objects.

```ts
// Current
helper.Props<{ date: Date; someLink: SomeLink }> === {}
helper.Links<{ date: Date; someLink: SomeLink }> === { date: Date; someLink: SomeLink }

// Updated
helper.Props<{ date: Date; someLink: SomeLink }> === { date: Date; }
helper.Links<{ date: Date; someLink: SomeLink }> === { someLink: SomeLink }
```