### PR TITLE
Add an example for using the query builder in a transaction

### DIFF
--- a/docs/querybuilder.rst
+++ b/docs/querybuilder.rst
@@ -195,6 +195,7 @@ We can also run the same query as above, built with the query builder, in a
 transaction.
 
 .. code-block:: typescript
+
     const query = e.select(e.datetime_current());
     client.transaction(async tx => {
       const result = await query.run(tx);

--- a/docs/querybuilder.rst
+++ b/docs/querybuilder.rst
@@ -174,22 +174,6 @@ Now we have everything we need to write and execute our first query!
     }
     run();
 
-We can also run queries built with the querybuilder in a transaction.
-
-.. code-block:: typescript
-
-    // script.ts
-    import {createClient} from "edgedb";
-    import e from "./dbschema/edgeql-js";
-
-    const client = createClient();
-
-    const query = e.select(e.datetime_current());
-    client.transaction(async tx => {
-      const result = await query.run(tx);
-      console.log(result);
-    });
-
 We use the ``e`` object to construct queries. The goal of the query builder is
 to provide an API that is as close as possible to EdgeQL itself. So
 ``select datetime_current()`` becomes ``e.select(e.datetime_current())``. This
@@ -203,6 +187,19 @@ current timestamp (as computed by the database).
 
   $ npx tsx script.ts
   2022-05-10T03:11:27.205Z
+
+In a transaction
+^^^^^^^^^^^^^^^^
+
+We can also run the same query as above, built with the query builder, in a
+transaction.
+
+.. code-block:: typescript
+    const query = e.select(e.datetime_current());
+    client.transaction(async tx => {
+      const result = await query.run(tx);
+      console.log(result);
+    });
 
 Configuration
 -------------

--- a/docs/querybuilder.rst
+++ b/docs/querybuilder.rst
@@ -174,6 +174,22 @@ Now we have everything we need to write and execute our first query!
     }
     run();
 
+We can also run queries built with the querybuilder in a transaction.
+
+.. code-block:: typescript
+
+    // script.ts
+    import {createClient} from "edgedb";
+    import e from "./dbschema/edgeql-js";
+
+    const client = createClient();
+
+    const query = e.select(e.datetime_current());
+    client.transaction(async tx => {
+      const result = await query.run(tx);
+      console.log(result);
+    });
+
 We use the ``e`` object to construct queries. The goal of the query builder is
 to provide an API that is as close as possible to EdgeQL itself. So
 ``select datetime_current()`` becomes ``e.select(e.datetime_current())``. This

--- a/docs/querybuilder.rst
+++ b/docs/querybuilder.rst
@@ -193,8 +193,8 @@ We can also run queries built with the querybuilder in a transaction.
 We use the ``e`` object to construct queries. The goal of the query builder is
 to provide an API that is as close as possible to EdgeQL itself. So
 ``select datetime_current()`` becomes ``e.select(e.datetime_current())``. This
-query is then executed with the ``.run()`` method which accepts a *client* as
-its first input.
+query is then executed with the ``.run()`` method which accepts a *client* or a
+*transaction* as its first input.
 
 Run that script with the ``tsx`` like so. It should print the
 current timestamp (as computed by the database).


### PR DESCRIPTION
A user created a repo comparing a task model implementation in Knex and EdgeDB. User was under the impression it was not possible to use the querybuilder with transactions. This is part of an effort to better communicate that it is possible.

See https://discord.com/channels/841451783728529451/1038780233458909324/1039094288354652180

Companion to https://github.com/edgedb/edgedb/pull/4640