### PR TITLE
Fix all properties shorthand (`['*']`) inside polymorphic queries

### DIFF
--- a/docs/select.rst
+++ b/docs/select.rst
@@ -483,6 +483,12 @@ In the query builder, this is represented with the ``e.is`` function.
 The ``release_year`` and ``num_seasons`` properties are nullable to reflect the
 fact that they will only occur in certain objects.
 
+.. note::
+
+  In EdgeQL it is not valid to select the ``id`` property in a polymorphic
+  field. So for convenience when using the ``['*']`` all properties shorthand
+  with ``e.is``, the ``id`` property will be filtered out of the polymorphic
+  shape object.
 
 Detached
 --------

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -379,13 +379,14 @@ export function is<
   expr: Expr,
   shape: Shape
 ): {
-  [k in Exclude<keyof Shape, SelectModifierNames>]: $expr_PolyShapeElement<
-    Expr,
-    normaliseElement<Shape[k]>
-  >;
+  [k in Exclude<
+    keyof Shape,
+    SelectModifierNames | "id"
+  >]: $expr_PolyShapeElement<Expr, normaliseElement<Shape[k]>>;
 } {
   const mappedShape: any = {};
   for (const [key, value] of Object.entries(shape)) {
+    if (key === "id") continue;
     mappedShape[key] = {
       __kind__: ExpressionKind.PolyShapeElement,
       __polyType__: expr,
@@ -753,6 +754,7 @@ export type objectTypeToSelectShape<T extends ObjectType = ObjectType> =
               T["__pointers__"][k]["target"],
               cardutil.assignable<T["__pointers__"][k]["cardinality"]>
             >
+          | $expr_PolyShapeElement
       : T["__pointers__"][k] extends LinkDesc
       ? linkDescToSelectElement<T["__pointers__"][k]>
       : any;

--- a/packages/generate/test/select.test.ts
+++ b/packages/generate/test/select.test.ts
@@ -285,6 +285,48 @@ test("computables in polymorphics", () => {
   >(true);
 });
 
+test("parent type props in polymorphic", () => {
+  const q = e.select(e.Person, () => ({
+    ...e.is(e.Hero, {
+      // name is prop of Person
+      name: true,
+      secret_identity: true
+    }),
+    ...e.is(e.Villain, {nemesis: {name: true}})
+  }));
+
+  tc.assert<
+    tc.IsExact<
+      $infer<typeof q>,
+      {
+        name: string | null;
+        secret_identity: string | null;
+        nemesis: {name: string} | null;
+      }[]
+    >
+  >(true);
+});
+
+test("* in polymorphic", async () => {
+  const q = e.select(e.Person, () => ({
+    ...e.is(e.Hero, e.Hero["*"])
+  }));
+
+  // 'id' is filtered out since it is not valid in a polymorphic expr
+  tc.assert<
+    tc.IsExact<
+      $infer<typeof q>,
+      {
+        name: string | null;
+        number_of_movies: number | null;
+        secret_identity: string | null;
+      }[]
+    >
+  >(true);
+
+  await q.run(client);
+});
+
 test("shape type name", () => {
   const name = e.select(e.Hero).__element__.__name__;
   tc.assert<tc.IsExact<typeof name, "default::Hero">>(true);


### PR DESCRIPTION
Polymorphic queries such as this are currently broken:
```
e.select(e.Content, () => ({
  ...e.is(e.Movie, e.Movie['*'])
}))
```
This PR fixes these queries by allowing fields that exists on the parent type to contain polymorphic element expressions. `e.is` now also filters out `id` fields in the shape object, since these are invalid in EdgeQL, and this seems more convenient than forcing users to filter it out themselves (especially when using `['*']`). This shouldn't be a breaking change, as these queries previously didn't generate valid edgeql, so would have always failed at runtime anyway.