### PR TITLE
🏷️ use Executor type for client in generated query

### DIFF
--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -208,10 +208,10 @@ function generateFiles(params: {
   for (const i of params.types.imports) {
     imports[i] = true;
   }
-  const tsImports = {Client: true, ...imports};
+  const tsImports = {Executor: true, ...imports};
 
   const hasArgs = params.types.args && params.types.args !== "null";
-  const tsImpl = `async function ${functionName}(client: Client${
+  const tsImpl = `async function ${functionName}(client: Executor${
     hasArgs ? `, args: ${params.types.args}` : ""
   }): Promise<${params.types.result}> {
   return client.${method}(\`${params.types.query
@@ -227,7 +227,7 @@ function generateFiles(params: {
   });
 }`;
 
-  const dtsImpl = `function ${functionName}(client: Client${
+  const dtsImpl = `function ${functionName}(client: Executor${
     hasArgs ? `, args: ${params.types.args}` : ""
   }): Promise<${params.types.result}>;`;
 


### PR DESCRIPTION
fixes #499 

A naive attempt to fix typing issue in generated query.

Both Transaction and Client conforms to Executor interface, so Executor should be used as the type for client in generated query function.

The same way it's done in query builder.

I didn't test the code.