### PR TITLE
Update `e.set` to accept an array of values and a type + prevent arrays from being spread into `e.set`

### DIFF
--- a/packages/generate/src/syntax/insert.ts
+++ b/packages/generate/src/syntax/insert.ts
@@ -247,9 +247,7 @@ export function $normaliseInsertShape(
       val === null
         ? cast(pointer.target, null)
         : isMulti && Array.isArray(val)
-        ? val.length === 0
-          ? cast(pointer.target, null)
-          : set(...val.map(v => (literal as any)(pointer.target, v)))
+        ? (set as any)(pointer.target, val)
         : (literal as any)(pointer.target, val);
     newShape[key] = setModify
       ? ({[setModify]: wrappedVal} as any)

--- a/packages/generate/test/sets.test.ts
+++ b/packages/generate/test/sets.test.ts
@@ -198,3 +198,62 @@ test("array", async () => {
     e.set(e.array([e.int16(5)]), e.array(["asdf"]) as any)
   ).toThrow();
 });
+
+test("set from array", () => {
+  const uuids = ["abc", e.uuid("def"), "ghi"];
+
+  // @ts-expect-error
+  expect(() => e.set(...uuids)).toThrow();
+
+  const s1 = e.set(e.uuid, uuids);
+
+  tc.assert<tc.IsExact<typeof s1["__element__"]["__name__"], "std::uuid">>(
+    true
+  );
+  tc.assert<tc.IsExact<typeof s1["__cardinality__"], $.Cardinality.Many>>(
+    true
+  );
+  expect(s1["__element__"]["__name__"]).toEqual("std::uuid");
+  expect(s1["__cardinality__"]).toEqual($.Cardinality.Many);
+  expect(s1.toEdgeQL()).toEqual(
+    `{ <std::uuid>"abc", <std::uuid>"def", <std::uuid>"ghi" }`
+  );
+
+  const strs = ["abc", "def"] as const;
+  const s2 = e.set(...strs);
+  tc.assert<tc.IsExact<typeof s2["__element__"]["__name__"], "std::str">>(
+    true
+  );
+  tc.assert<
+    tc.IsExact<typeof s2["__cardinality__"], $.Cardinality.AtLeastOne>
+  >(true);
+  expect(s2["__element__"]["__name__"]).toEqual("std::str");
+  expect(s2["__cardinality__"]).toEqual($.Cardinality.AtLeastOne);
+
+  const emptyNums = [] as number[];
+  const s3 = e.set(e.int32, emptyNums);
+  tc.assert<tc.IsExact<typeof s3["__element__"]["__name__"], "std::number">>(
+    true
+  );
+  tc.assert<tc.IsExact<typeof s3["__cardinality__"], $.Cardinality.Many>>(
+    true
+  );
+  expect(s3["__element__"]["__name__"]).toEqual("std::int32");
+  expect(s3["__cardinality__"]).toEqual($.Cardinality.Many);
+  expect(s3.toEdgeQL()).toEqual(`<std::int32>{}`);
+
+  const bools = [true];
+
+  // @ts-expect-error
+  e.set(e.int32, bools);
+
+  const s4 = e.set(e.bool, bools);
+  tc.assert<tc.IsExact<typeof s4["__element__"]["__name__"], "std::bool">>(
+    true
+  );
+  tc.assert<tc.IsExact<typeof s4["__cardinality__"], $.Cardinality.Many>>(
+    true
+  );
+  expect(s4["__element__"]["__name__"]).toEqual("std::bool");
+  expect(s4["__cardinality__"]).toEqual($.Cardinality.Many);
+});


### PR DESCRIPTION
Current behaviour of `e.set` is buggy when spreading an array of values into it, since at runtime it's not possible to tell if an array was spread or the values where passed statically. This causes a mis-match in the cardinality determined statically by typescript and at runtime. If the array happens to be empty, it also causes a runtime error, as the type of the empty set cannot be determined. Eg:

```ts
const strs = ['abc']; // has type string[]

e.set(...strs); // ts infers cardinality as Many since 'strs' could have any length

e.set('abc'); // ts infers cardinality as One

// at runtime both above appear the same, so cardinality cannot be correctly determined for both
```

This PR prevents arrays from being spread into `e.set` (unless it's a tuple, eg. `const strs = ['abc'] as const`), and instead allows the array to be passed directly, along with a type expr, so the empty array case can be handled. The addition of a type arg also means it's no longer necessary to wrap each item of the array for non js primitive types:
```ts
const uuids: string[] = [/* some array of uuid strings */];

e.set(e.uuid, uuids);
```