### PR TITLE
Fix generator to compile with TypeScript strict configs

### DIFF
--- a/packages/generate/src/edgeql-js/generateOperatorTypes.ts
+++ b/packages/generate/src/edgeql-js/generateOperatorTypes.ts
@@ -300,23 +300,23 @@ export function generateOperators({
     if (typeof args[0] === "string" && overloadDefs.Prefix[args[0]]) {
       op = args[0];
       params = [args[1]];
-      defs = overloadDefs.Prefix[op];
+      defs = overloadDefs.Prefix[op]!;
     } else if (typeof args[1] === "string" && overloadDefs.Postfix[args[1]]) {
       op = args[1];
       params = [args[0]];
-      defs = overloadDefs.Postfix[op];
+      defs = overloadDefs.Postfix[op]!;
     }
   } else if (args.length === 3) {
     if (typeof args[1] === "string") {
       op = args[1];
       params = [args[0], args[2]];
-      defs = overloadDefs.Infix[op];
+      defs = overloadDefs.Infix[op]!;
     }
   } else if (args.length === 5) {
     if (typeof args[1] === "string" && typeof args[3] === "string") {
       op = \`\${args[1]}_\${args[3]}\`;
       params = [args[0], args[2], args[4]];
-      defs = overloadDefs.Ternary[op];
+      defs = overloadDefs.Ternary[op]!;
     }
   }
 

--- a/packages/generate/src/syntax/cardinality.ts
+++ b/packages/generate/src/syntax/cardinality.ts
@@ -160,7 +160,7 @@ export namespace cardutil {
   >(cards: Cards): mergeCardinalitiesVariadic<Cards> {
     if (cards.length === 0) throw new Error("Empty tuple not allowed");
     if (cards.length === 1) return cards[0] as any;
-    const [first, second, ...rest] = cards;
+    const [first, second, ...rest] = cards as unknown as [Cardinality, Cardinality, ...Cardinality[]];
     if (cards.length === 2) return mergeCardinalities(first, second) as any;
     return mergeCardinalitiesVariadic([
       mergeCardinalities(first, second),

--- a/packages/generate/src/syntax/collections.ts
+++ b/packages/generate/src/syntax/collections.ts
@@ -154,8 +154,8 @@ export function array(arg: any) {
       ),
       __element__: {
         __kind__: TypeKind.array,
-        __name__: `array<${items[0].__element__.__name__}>`,
-        __element__: items[0].__element__
+        __name__: `array<${items[0]!.__element__.__name__}>`,
+        __element__: items[0]!.__element__
       } as any,
       __items__: items
     });
@@ -282,8 +282,9 @@ export function tuple(input: any) {
     const exprShape: NamedTupleLiteralShape = {};
     const typeShape: NamedTupleShape = {};
     for (const [key, val] of Object.entries(input)) {
-      exprShape[key] = literalToTypeSet(val);
-      typeShape[key] = exprShape[key].__element__;
+      const typeSet = literalToTypeSet(val)
+      exprShape[key] = typeSet;
+      typeShape[key] = typeSet.__element__;
     }
     const name = `tuple<${Object.entries(exprShape)
       .map(([key, val]) => `${key}: ${val.__element__.__name__}`)

--- a/packages/generate/src/syntax/funcops.ts
+++ b/packages/generate/src/syntax/funcops.ts
@@ -187,7 +187,7 @@ function _tryOverload(
   let needsAnytypeReplacement = false;
 
   for (let i = 0; i < funcDef.args.length; i++) {
-    const argDef = funcDef.args[i];
+    const argDef = funcDef.args[i]!;
     const arg = args[i];
 
     if (arg === undefined) {
@@ -256,28 +256,28 @@ function _tryOverload(
   if (funcName === "if_else") {
     cardinality = cardutil.multiplyCardinalities(
       cardutil.orCardinalities(
-        positionalArgs[0].__cardinality__,
-        positionalArgs[2].__cardinality__
+        positionalArgs[0]!.__cardinality__,
+        positionalArgs[2]!.__cardinality__
       ),
-      positionalArgs[1].__cardinality__
+      positionalArgs[1]!.__cardinality__
     );
   } else if (funcName === "std::assert_exists") {
     cardinality = cardutil.overrideLowerBound(
-      positionalArgs[0].__cardinality__,
+      positionalArgs[0]!.__cardinality__,
       "One"
     );
   } else if (funcName === "union") {
     cardinality = cardutil.mergeCardinalities(
-      positionalArgs[0].__cardinality__,
-      positionalArgs[1].__cardinality__
+      positionalArgs[0]!.__cardinality__,
+      positionalArgs[1]!.__cardinality__
     );
   } else if (funcName === "??") {
     cardinality = cardutil.orCardinalities(
-      positionalArgs[0].__cardinality__,
-      positionalArgs[1].__cardinality__
+      positionalArgs[0]!.__cardinality__,
+      positionalArgs[1]!.__cardinality__
     );
   } else if (funcName === "distinct") {
-    cardinality = positionalArgs[0].__cardinality__;
+    cardinality = positionalArgs[0]!.__cardinality__;
   } else {
     cardinality =
       funcDef.returnTypemod === "SetOfType"
@@ -337,7 +337,7 @@ function getDescendantNames(typeSpec: introspect.Types, typeId: string) {
         .flatMap(type =>
           type.is_abstract
             ? getDescendantNames(typeSpec, type.id)
-            : [nameRemapping[type.name], type.name]
+            : [nameRemapping[type.name]!, type.name]
         )
     )
   ];
@@ -403,7 +403,7 @@ function compareType(
     // shape comparison
     for (const ptr of type.pointers) {
       if (objectArg.__pointers__[ptr.name]) {
-        const argPtr = objectArg.__pointers__[ptr.name];
+        const argPtr = objectArg.__pointers__[ptr.name]!;
         const ptrTarget = typeSpec.get(ptr.target_id);
         if (
           ptrTarget.name !== argPtr.target.__name__ ||
@@ -431,13 +431,13 @@ function compareType(
       if (keys.length === type.tuple_elements.length) {
         let anytype: BaseType | undefined;
         for (let i = 0; i < keys.length; i++) {
-          if (keys[i] !== type.tuple_elements[i].name) {
+          if (keys[i] !== type.tuple_elements[i]!.name) {
             return {match: false};
           }
           const {match: m, anytype: a} = compareType(
             typeSpec,
-            type.tuple_elements[i].target_id,
-            (items as any)[keys[i]]
+            type.tuple_elements[i]!.target_id,
+            (items as any)[keys[i]!]
           );
           if (!m) {
             return {match: false};

--- a/packages/generate/src/syntax/group.ts
+++ b/packages/generate/src/syntax/group.ts
@@ -196,7 +196,7 @@ const groupFunc: groupFunc = (expr, getter) => {
   const groupSet = tuple(modifiers.by);
 
   // only one key in object returned from makeGroupingSet
-  const key = Object.keys(groupSet)[0];
+  const key = Object.keys(groupSet)[0]!;
   const grouping = groupSet[key] as any as GroupingSet;
   const keyShape: any = {};
   const keyPointers: any = {};

--- a/packages/generate/src/syntax/hydrate.ts
+++ b/packages/generate/src/syntax/hydrate.ts
@@ -175,7 +175,7 @@ export function makeType<T extends BaseType>(
     });
     return obj;
   } else if (type.kind === "tuple") {
-    if (type.tuple_elements[0].name === "0") {
+    if (type.tuple_elements[0]!.name === "0") {
       // unnamed tuple
       obj.__kind__ = TypeKind.tuple;
 
@@ -259,7 +259,7 @@ export function $mergeObjectTypes<A extends ObjectType, B extends ObjectType>(
       for (const [akey, aitem] of Object.entries(a.__pointers__)) {
         if (!b.__pointers__[akey]) continue;
 
-        const bitem = b.__pointers__[akey];
+        const bitem = b.__pointers__[akey]!;
         if (aitem.cardinality !== bitem.cardinality) continue;
         // names must reflect full type
         if (aitem.target.__name__ !== bitem.target.__name__) continue;

--- a/packages/generate/src/syntax/insert.ts
+++ b/packages/generate/src/syntax/insert.ts
@@ -209,7 +209,7 @@ export function $normaliseInsertShape(
         val.__element__.__kind__ === TypeKind.range &&
         val.__element__.__element__.__name__ === "std::number"
       ) {
-        newShape[key] = (literal as any)(pointer.target, val.__value__);
+        newShape[key] = (literal as any)(pointer?.target, val.__value__);
       } else {
         newShape[key] = _val;
       }
@@ -222,6 +222,10 @@ export function $normaliseInsertShape(
       throw new Error(
         `Cannot assign plain data to link property '${key}'. Provide an expression instead.`
       );
+    }
+    // Workaround to tell TypeScript pointer definitely is defined
+    if (!pointer) {
+      throw new Error('Code will never reach here, but TypeScript cannot determine',);
     }
 
     // trying to assign plain data to a link

--- a/packages/generate/src/syntax/json.ts
+++ b/packages/generate/src/syntax/json.ts
@@ -22,7 +22,7 @@ function jsonStringify(type: ParamType, val: any): string {
       );
     }
     return `[${val
-      .map((item, i) => jsonStringify(type.__items__[i], item))
+      .map((item, i) => jsonStringify(type.__items__[i]!, item))
       .join()}]`;
   }
   if (type.__kind__ === TypeKind.namedtuple) {
@@ -45,7 +45,7 @@ function jsonStringify(type: ParamType, val: any): string {
             ).join()}`
           );
         }
-        return `"${key}": ${jsonStringify(type.__shape__[key], item)}`;
+        return `"${key}": ${jsonStringify(type.__shape__[key]!, item)}`;
       })
       .join()}}`;
   }

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -492,7 +492,7 @@ export function $handleModifiers(
         const val = fs[key].__element__
           ? fs[key]
           : (literal as any)(
-              (root.__element__ as any as ObjectType)["__pointers__"][key][
+              (root.__element__ as any as ObjectType)["__pointers__"][key]![
                 "target"
               ],
               fs[key]

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -886,7 +886,7 @@ function renderEdgeQL(
       .map(
         key =>
           `  ${key} := ${renderEdgeQL(
-            expr.__shape__[key],
+            expr.__shape__[key]!,
             ctx,
             renderShape,
             noImplicitDetached
@@ -1128,25 +1128,25 @@ ${indent(groupStatement.join("\n"), 4)}
               index += renderEdgeQL(end, ctx);
             }
           } else {
-            index = renderEdgeQL(args[1], ctx);
+            index = renderEdgeQL(args[1]!, ctx);
           }
 
-          return `${renderEdgeQL(args[0], ctx)}[${index}]`;
+          return `${renderEdgeQL(args[0]!, ctx)}[${index}]`;
         }
-        return `(${renderEdgeQL(args[0], ctx)} ${operator} ${renderEdgeQL(
-          args[1],
+        return `(${renderEdgeQL(args[0]!, ctx)} ${operator} ${renderEdgeQL(
+          args[1]!,
           ctx
         )})`;
       case OperatorKind.Postfix:
-        return `(${renderEdgeQL(args[0], ctx)} ${operator})`;
+        return `(${renderEdgeQL(args[0]!, ctx)} ${operator})`;
       case OperatorKind.Prefix:
-        return `(${operator} ${renderEdgeQL(args[0], ctx)})`;
+        return `(${operator} ${renderEdgeQL(args[0]!, ctx)})`;
       case OperatorKind.Ternary:
         if (operator === "if_else") {
-          return `(${renderEdgeQL(args[0], ctx)} IF ${renderEdgeQL(
-            args[1],
+          return `(${renderEdgeQL(args[0]!, ctx)} IF ${renderEdgeQL(
+            args[1]!,
             ctx
-          )} ELSE ${renderEdgeQL(args[2], ctx)})`;
+          )} ELSE ${renderEdgeQL(args[2]!, ctx)})`;
         } else {
           throw new Error(`Unknown operator: ${operator}`);
         }
@@ -1500,7 +1500,7 @@ function literalToEdgeQL(type: BaseType, val: any): string {
     if (isNamedTupleType(type)) {
       stringRep = `( ${Object.entries(val).map(
         ([key, value]) =>
-          `${key} := ${literalToEdgeQL(type.__shape__[key], value)}`
+          `${key} := ${literalToEdgeQL(type.__shape__[key]!, value)}`
       )} )`;
       skipCast = true;
     } else {


### PR DESCRIPTION
This fix allow generated code to compile in user projects with the following `tsconifg.json` options on:
```
{
  "compilerOptions": {
    /* Strict Type-Checking Options */
    "strict": true,                              /* Enable all strict type-checking options. */
    "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
    "strictNullChecks": true,                    /* Enable strict null checks. */
    "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
    "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
    "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
    "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
    "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */

    /* Additional Checks */
    "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
    "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
    "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
    "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
    "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
  }
}
```