### PR TITLE
Fix event handling in fetch-based connection classes

### DIFF
--- a/packages/driver/src/fetchConn.ts
+++ b/packages/driver/src/fetchConn.ts
@@ -133,6 +133,8 @@ class BaseFetchConnection extends BaseRawConnection {
       this.messageWaiter.set();
     } catch (e) {
       this.messageWaiter.setError(e);
+    } finally {
+      this.messageWaiter = null;
     }
   }
 

--- a/packages/driver/src/fetchConn.ts
+++ b/packages/driver/src/fetchConn.ts
@@ -145,7 +145,10 @@ class BaseFetchConnection extends BaseRawConnection {
     registry: CodecsRegistry
   ): BaseFetchConnection {
     const conn = new this(config, registry);
+
     conn.connected = true;
+    conn.connWaiter.set();
+
     return conn;
   }
 }
@@ -200,6 +203,7 @@ export class FetchConnection extends BaseFetchConnection {
     );
 
     conn.connected = true;
+    conn.connWaiter.set();
 
     return conn;
   }


### PR DESCRIPTION
Fetch-based connection classes:
* never set `connWaiter` event, which is inherited from `BaseRawConnection`;
* set, but don't clear `messageWaiter` after receiving data.

This results in a "client has been closed" error when calling `Client.close()` on an HTTP client.

This PR fixes the issue above.