### PR TITLE
Fix codegen when expression wrapped by `e.params` is non-runnable

### DIFF
--- a/packages/generate/src/syntax/params.ts
+++ b/packages/generate/src/syntax/params.ts
@@ -11,8 +11,9 @@ import type {
   TypeSet,
   BaseTypeToTsType
 } from "./typesystem";
-
 import {$expressionify} from "./path";
+import {runnableExpressionKinds} from "./query";
+import {select} from "./select";
 
 export type $expr_OptionalParam<Type extends ParamType = ParamType> = {
   __kind__: ExpressionKind.OptionalParam;
@@ -132,7 +133,11 @@ export function params<
     }) as any;
   }
 
-  const returnExpr = expr(paramExprs as any);
+  let returnExpr = expr(paramExprs as any);
+
+  if (!runnableExpressionKinds.has((returnExpr as any).__kind__)) {
+    returnExpr = select(returnExpr) as any;
+  }
 
   return $expressionify({
     __kind__: ExpressionKind.WithParams,

--- a/packages/generate/src/syntax/query.ts
+++ b/packages/generate/src/syntax/query.ts
@@ -3,7 +3,7 @@ import {Cardinality, ExpressionKind} from "edgedb/dist/reflection/index";
 import {jsonifyComplexParams} from "./json";
 import {select} from "./select";
 
-const runnableExpressionKinds = new Set([
+export const runnableExpressionKinds = new Set([
   ExpressionKind.Select,
   ExpressionKind.Update,
   ExpressionKind.Insert,

--- a/packages/generate/test/params.test.ts
+++ b/packages/generate/test/params.test.ts
@@ -290,3 +290,11 @@ test("v2 param types", async () => {
     >
   >(true);
 });
+
+test("non-runnable return expression", () => {
+  const reusedExpr = e.set(1, 2, 3);
+
+  const query = e.params({}, $ => e.set(reusedExpr, reusedExpr));
+
+  expect(() => query.toEdgeQL()).not.toThrow();
+});


### PR DESCRIPTION
Fixes issue reported on Discord: https://discord.com/channels/841451783728529451/1054101776665686166/1054517955523784765