### PR TITLE
Support HTTPS connections in HTTP client

### DIFF
--- a/packages/driver/test/client.test.ts
+++ b/packages/driver/test/client.test.ts
@@ -1832,6 +1832,7 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
       {
         address: config.connectionParams.address,
         database: config.connectionParams.database,
+        tlsSecurity: "insecure",
         user: config.connectionParams.user,
         token: "invalid token"
       },


### PR DESCRIPTION
This PR adds support for HTTPS connections in `FetchConnection` and `AdminUIFetchConnection`. An HTTP connection is established if `tlsSecurity` is set to `insecure`; otherwise, the connection will be made over HTTPS.