### PR TITLE
Allow a named tuple to be passed as the shape of an insert

### DIFF
--- a/docs/insert.rst
+++ b/docs/insert.rst
@@ -13,7 +13,7 @@ Insert new data with ``e.insert``.
   });
 
 For convenience, the second argument of ``e.insert`` function can also accept
-plain JS data.
+plain JS data or a named tuple.
 
 .. code-block:: typescript
 
@@ -24,6 +24,18 @@ plain JS data.
       '@character_name': e.str("Iron Man")
     }))
   });
+
+
+.. code-block:: typescript
+
+  e.params({
+    movie: e.tuple({
+      title: e.str,
+      release_year: e.int64
+    })
+  }, $ =>
+    e.insert(e.Movie, $.movie)
+  );
 
 
 Link properties

--- a/packages/generate/src/syntax/insert.ts
+++ b/packages/generate/src/syntax/insert.ts
@@ -15,7 +15,8 @@ import type {
   $scopify,
   stripSet,
   TypeSet,
-  ObjectType
+  ObjectType,
+  NamedTupleType
 } from "./typesystem";
 import type {pointerToAssignmentExpression} from "./casting";
 import {$expressionify, $getScopedExpr} from "./path";
@@ -170,7 +171,14 @@ export function $normaliseInsertShape(
   const newShape: {
     [key: string]: TypeSet | {"+=": TypeSet} | {"-=": TypeSet};
   } = {};
-  for (const [key, _val] of Object.entries(shape)) {
+
+  const _shape: [string, any][] =
+    shape.__element__?.__kind__ === TypeKind.namedtuple
+      ? Object.keys((shape.__element__ as NamedTupleType).__shape__).map(
+          key => [key, shape[key]]
+        )
+      : Object.entries(shape);
+  for (const [key, _val] of _shape) {
     let val = _val;
     let setModify: string | null = null;
     if (isUpdate && _val != null && typeof _val === "object") {
@@ -225,7 +233,9 @@ export function $normaliseInsertShape(
     }
     // Workaround to tell TypeScript pointer definitely is defined
     if (!pointer) {
-      throw new Error('Code will never reach here, but TypeScript cannot determine',);
+      throw new Error(
+        "Code will never reach here, but TypeScript cannot determine"
+      );
     }
 
     // trying to assign plain data to a link

--- a/packages/generate/test/insert.test.ts
+++ b/packages/generate/test/insert.test.ts
@@ -373,3 +373,25 @@ test("empty arrays for array and multi properties", async () => {
   });
   const result = await query.run(client);
 });
+
+test("insert named tuple as shape", async () => {
+  const query = e.params(
+    {
+      profiles: e.array(
+        e.tuple({
+          a: e.str,
+          b: e.str,
+          c: e.str
+        })
+      )
+    },
+    params =>
+      e.for(e.array_unpack(params.profiles), profile =>
+        e.insert(e.Profile, profile)
+      )
+  );
+
+  const result = await query.run(client, {
+    profiles: [{a: "a", b: "b", c: "c"}]
+  });
+});


### PR DESCRIPTION
Though not valid in edgeql, it seems reasonable to allow a named tuple to be passed as the shape of an insert expression for convenience in the querybuilder, instead of requiring the user to manually re-define the object.

Fixes #523