### PR TITLE
Add helper function to create tuple types from object types

### DIFF
--- a/packages/generate/src/syntax/collections.ts
+++ b/packages/generate/src/syntax/collections.ts
@@ -347,15 +347,15 @@ export function $objectTypeToTupleType(...args: any[]): any {
     string[] | undefined
   ];
   const shape = Object.entries(objExpr.__element__.__pointers__).reduce(
-    (shape, [key, val]) => {
+    (_shape, [key, val]) => {
       if (
         fields?.length
           ? fields.includes(key)
           : key !== "id" && val.__kind__ === "property" && !val.computed
       ) {
-        shape[key] = val.target;
+        _shape[key] = val.target;
       }
-      return shape;
+      return _shape;
     },
     {} as NamedTupleShape
   );

--- a/packages/generate/src/syntax/collections.ts
+++ b/packages/generate/src/syntax/collections.ts
@@ -17,6 +17,9 @@ import type {
   NamedTupleShape,
   NamedTupleType,
   NonArrayType,
+  ObjectTypeExpression,
+  ObjectTypePointers,
+  PropertyDesc,
   TupleType,
   TypeSet
 } from "./typesystem";
@@ -282,7 +285,7 @@ export function tuple(input: any) {
     const exprShape: NamedTupleLiteralShape = {};
     const typeShape: NamedTupleShape = {};
     for (const [key, val] of Object.entries(input)) {
-      const typeSet = literalToTypeSet(val)
+      const typeSet = literalToTypeSet(val);
       exprShape[key] = typeSet;
       typeShape[key] = typeSet.__element__;
     }
@@ -304,8 +307,57 @@ export function tuple(input: any) {
   }
 }
 
-// export type {
-//   ArrayType as $Array,
-//   NamedTupleType as $NamedTuple,
-//   TupleType as $Tuple
-// } from "edgedb/dist/reflection/index";
+type PropertyNamesFromPointers<Pointers extends ObjectTypePointers> = {
+  [k in keyof Pointers as Pointers[k] extends PropertyDesc
+    ? Pointers[k]["computed"] extends true
+      ? never
+      : k
+    : never]: Pointers[k];
+};
+
+export function $objectTypeToTupleType<Expr extends ObjectTypeExpression>(
+  objectType: Expr
+): PropertyNamesFromPointers<
+  Expr["__element__"]["__pointers__"]
+> extends infer Pointers
+  ? Pointers extends ObjectTypePointers
+    ? NamedTupleType<{
+        [k in keyof Pointers as k extends "id"
+          ? never
+          : k]: Pointers[k]["target"];
+      }>
+    : never
+  : never;
+export function $objectTypeToTupleType<
+  Expr extends ObjectTypeExpression,
+  Fields extends keyof PropertyNamesFromPointers<
+    Expr["__element__"]["__pointers__"]
+  >
+>(
+  objectType: Expr,
+  includeFields: Fields[]
+): NamedTupleType<{
+  [k in Fields]: Expr["__element__"]["__pointers__"][k] extends PropertyDesc
+    ? Expr["__element__"]["__pointers__"][k]["target"]
+    : never;
+}>;
+export function $objectTypeToTupleType(...args: any[]): any {
+  const [objExpr, fields] = args as [
+    ObjectTypeExpression,
+    string[] | undefined
+  ];
+  const shape = Object.entries(objExpr.__element__.__pointers__).reduce(
+    (shape, [key, val]) => {
+      if (
+        fields?.length
+          ? fields.includes(key)
+          : key !== "id" && val.__kind__ === "property" && !val.computed
+      ) {
+        shape[key] = val.target;
+      }
+      return shape;
+    },
+    {} as NamedTupleShape
+  );
+  return tuple(shape);
+}

--- a/packages/generate/src/syntax/external.ts
+++ b/packages/generate/src/syntax/external.ts
@@ -15,7 +15,11 @@ export {
 } from "./select";
 export {update} from "./update";
 export {insert} from "./insert";
-export {array, tuple} from "./collections";
+export {
+  array,
+  tuple,
+  $objectTypeToTupleType as objectTypeToTupleType
+} from "./collections";
 export {} from "./funcops";
 export {for} from "./for";
 export {alias, with} from "./with";


### PR DESCRIPTION
Fixes #541

Adds a function that takes an object type expression, and converts it to a tuple type containing by default the non-computed properties (excluding 'id'). Eg:
```ts
import e, {objectTypeToTupleType} from "./dbschema/edgeql-js";

const movieTuple = objectTypeToTupleType(e.Movie);
// => tuple<genre: default::Genre, rating: std::float64, title: std::str, release_year: default::year>
```
Specific fields can by selected be providing a second arg:
```ts
const movieTuple2 = objectTypeToTupleType(e.Movie, ['title', 'rating']);
// => tuple<title: std::str, rating: std::float64>
```