### PR TITLE
Inject `assert_single` when using `filter_single` not with exclusive object api

### DIFF
--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -366,7 +366,7 @@ function isFunc(this: any, expr: ObjectTypeSet) {
   });
 }
 
-function assert_single(expr: Expression) {
+export function $assert_single(expr: Expression) {
   return $expressionify({
     __kind__: ExpressionKind.Function,
     __element__: expr.__element__,
@@ -428,7 +428,7 @@ export function $expressionify<T extends ExpressionRoot>(
   expr.runJSON = $queryFuncJSON.bind(expr) as any;
   expr.is = isFunc.bind(expr) as any;
   expr.toEdgeQL = $toEdgeQL.bind(expr);
-  expr.assert_single = () => assert_single(expr) as any;
+  expr.assert_single = () => $assert_single(expr) as any;
 
   return Object.freeze(expr) as any;
 }

--- a/packages/generate/src/syntax/update.ts
+++ b/packages/generate/src/syntax/update.ts
@@ -15,7 +15,7 @@ import type {
   $scopify
 } from "./typesystem";
 import type {pointerToAssignmentExpression} from "./casting";
-import {$expressionify, $getScopedExpr} from "./path";
+import {$expressionify, $getScopedExpr, $assert_single} from "./path";
 import {
   SelectModifiers,
   NormalisedSelectModifiers,
@@ -83,16 +83,7 @@ export function update<
 >(
   expr: Expr,
   shape: (scope: $scopify<Expr["__element__"]>) => Readonly<Shape>
-): $expr_Update<
-  // {
-  //   __element__: Expr["__element__"];
-  //   __cardinality__: ComputeSelectCardinality<Expr, Shape>;
-  // },
-  Expr["__element__"],
-  ComputeSelectCardinality<Expr, Shape>
-  // Expr,
-  // Shape["set"]
-> {
+): $expr_Update<Expr["__element__"], ComputeSelectCardinality<Expr, Shape>> {
   const cleanScopedExprs = $existingScopes.size === 0;
 
   const scope = $getScopedExpr(expr as any, $existingScopes);
@@ -122,9 +113,12 @@ export function update<
     throw new Error(`Update shape must contain 'set' shape`);
   }
 
-  const {modifiers, cardinality} = $handleModifiers(mods, {root: expr, scope});
+  const {modifiers, cardinality, needsAssertSingle} = $handleModifiers(mods, {
+    root: expr,
+    scope
+  });
 
-  return $expressionify({
+  const updateExpr = {
     __kind__: ExpressionKind.Update,
     __element__: expr.__element__,
     __cardinality__: cardinality,
@@ -132,5 +126,9 @@ export function update<
     __shape__: $normaliseInsertShape(expr, updateShape, true),
     __modifiers__: modifiers,
     __scope__: scope
-  }) as any;
+  } as any;
+
+  return needsAssertSingle
+    ? $assert_single(updateExpr)
+    : $expressionify(updateExpr);
 }

--- a/packages/generate/test/select.test.ts
+++ b/packages/generate/test/select.test.ts
@@ -4,6 +4,7 @@ import * as tc from "conditional-type-checks";
 
 import e, {$infer} from "../dbschema/edgeql-js";
 import {setupTests, teardownTests, TestData} from "./setupTeardown";
+import {CardinalityViolationError} from "edgedb";
 let client: edgedb.Client;
 let data: TestData;
 
@@ -1329,12 +1330,12 @@ test("filter_single expect error", async () => {
 });
 
 test("filter_single card mismatch", async () => {
-  const query = e.select(e.Movie, () => ({
+  const query = e.select(e.Movie, movie => ({
     title: true,
-    filter_single: {genre: e.Genre.Horror} as any
+    filter_single: e.op(movie.genre, "=", e.Genre.Action)
   }));
 
-  expect(query.run(client)).rejects.toThrow();
+  await expect(query.run(client)).rejects.toThrow(CardinalityViolationError);
 });
 
 // EdgeQL limitation

--- a/packages/generate/test/update.test.ts
+++ b/packages/generate/test/update.test.ts
@@ -81,29 +81,28 @@ test("update assignable", () => {
   })).toEdgeQL();
 });
 
-// commenting out until fix lands in nightly
-// test("scoped update", async () => {
-//   const query = e.update(e.Hero, hero => ({
-//     filter: e.op(hero.name, "=", data.spidey.name),
-//     set: {
-//       name: e.op("The Amazing ", "++", hero.name),
-//     },
-//   }));
+test("scoped update", async () => {
+  const query = e.update(e.Hero, hero => ({
+    filter_single: e.op(hero.name, "=", data.spidey.name),
+    set: {
+      name: e.op("The Amazing ", "++", hero.name)
+    }
+  }));
 
-//   const result = await query.run(client);
-//   tc.assert<tc.IsExact<typeof result, {id: string} | null>>(true);
+  const result = await query.run(client);
+  tc.assert<tc.IsExact<typeof result, {id: string} | null>>(true);
 
-//   expect(result).toEqual({id: data.spidey.id});
+  expect(result).toEqual({id: data.spidey.id});
 
-//   expect(
-//     await e
-//       .select(e.Hero, hero => ({
-//         name: true,
-//         filter: e.op(hero.id, "=", e.uuid(result!.id)),
-//       }))
-//       .run(client)
-//   ).toEqual({id: data.spidey.id, name: `The Amazing ${data.spidey.name}`});
-// });
+  expect(
+    await e
+      .select(e.Hero, hero => ({
+        name: true,
+        filter_single: e.op(hero.id, "=", e.uuid(result!.id))
+      }))
+      .run(client)
+  ).toEqual({name: `The Amazing ${data.spidey.name}`});
+});
 
 test("update link property", async () => {
   const theAvengers = e
@@ -216,6 +215,19 @@ test("update with filter_single", async () => {
     .update(e.Movie, () => ({
       filter_single: {id: data.the_avengers.id},
       set: {}
+    }))
+    .run(client);
+});
+
+test("update with filter_single + op", async () => {
+  await e
+    .update(e.Profile, profile => ({
+      filter_single: e.op(
+        profile["<profile[is Movie]"].title,
+        "=",
+        "The Avengers"
+      ),
+      set: {a: "test"}
     }))
     .run(client);
 });


### PR DESCRIPTION
Fixes #548

When using `filter_single` we always assume the result to have singleton cardinality. However when used with an arbitrary expr instead of the object api, we cannot guarantee that edgedb will infer singleton cardinality for the result, so in this case the querybuilder should inject `assert_single` to ensure inferred cardinality stays in sync.