### PR TITLE
Fix `['*']` on scoped object of `e.select` on an `insert` expr

### DIFF
--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -18,11 +18,11 @@
   ],
   "bin": "dist/cli.js",
   "peerDependencies": {
-    "edgedb": "^1.0.0-alpha.0"
+    "edgedb": "^1.1.0"
   },
   "devDependencies": {
     "conditional-type-checks": "^1.0.5",
-    "edgedb": "~1.0.0-alpha.2",
+    "edgedb": "^1.1.0",
     "esbuild": "^0.15.7",
     "globby": "^13.1.2",
     "superjson": "^1.7.5",

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -447,22 +447,20 @@ export function $getScopedExpr<T extends ExpressionRoot>(
       expr.__cardinality__ === Cardinality.One &&
       expr.__element__.__name__ === "std::FreeObject";
 
-    const isInsert = expr.__kind__ === ExpressionKind.Insert;
-    scopedExpr =
-      isFreeObject || isInsert
-        ? (expr as any as Expression<TypeSet<BaseType, Cardinality>>)
-        : $expressionify({
-            ...expr,
-            __cardinality__: Cardinality.One,
-            __scopedFrom__: expr,
-            ...(expr.__element__.__kind__ === TypeKind.object
-              ? {
-                  "*": getStarShapeFromPointers(
-                    (expr.__element__ as ObjectType).__pointers__
-                  )
-                }
-              : {})
-          });
+    scopedExpr = isFreeObject
+      ? (expr as any as Expression<TypeSet<BaseType, Cardinality>>)
+      : $expressionify({
+          ...expr,
+          __cardinality__: Cardinality.One,
+          __scopedFrom__: expr,
+          ...(expr.__element__.__kind__ === TypeKind.object
+            ? {
+                "*": getStarShapeFromPointers(
+                  (expr.__element__ as ObjectType).__pointers__
+                )
+              }
+            : {})
+        });
     scopeRoots.add(scopedExpr);
     const uncached = !scopedExpr;
     if (uncached) {

--- a/packages/generate/test/objectTypes.test.ts
+++ b/packages/generate/test/objectTypes.test.ts
@@ -183,4 +183,11 @@ test("select *", () => {
 
     return {};
   });
+
+  // on insert select
+  e.select(e.insert(e.Movie, {title: "test"}), movie => {
+    expect(movie["*"]).toEqual(movieStarShape);
+
+    return movie["*"];
+  }).toEdgeQL();
 });


### PR DESCRIPTION
Fixes this bug reported on discord: https://discord.com/channels/841451783728529451/849374705210490900/1081691035199090708