### PR TITLE
Update changelog config to valid JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
             {
               "template": "## Commits:\n\n#{{UNCATEGORIZED}}",
               "pr_template": "- #{{MERGE_SHA}} #{{TITLE}}",
-              "categories": [],
+              "categories": []
             }
 
       - name: Create 'edgedb' Release
@@ -123,7 +123,7 @@ jobs:
             {
               "template": "## Commits:\n\n#{{UNCATEGORIZED}}",
               "pr_template": "- #{{MERGE_SHA}} #{{TITLE}}",
-              "categories": [],
+              "categories": []
             }
 
       - name: Create '@edgedb/generate' Release


### PR DESCRIPTION
We accidentally broke this in https://github.com/edgedb/edgedb-js/commit/8cc171faabfe650a05a226f02a0e961a44c67aec when we removed the bit of configuration for getting the `fromTag`. Took a second to realize this was happening but looking in the last version that would've run this, I saw this:

<img width="658" alt="image" src="https://user-images.githubusercontent.com/1682194/233230591-d58e0839-7164-4087-a8aa-f16f7c16d3a8.png">

And since, by default, it doesn't output uncategorized PRs, it was blank.