### PR TITLE
Do not cancel other tests if nightly fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     # when the release PR gets merged by the bot.
     if: needs.prep.outputs.version == 0
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
         node-version: ["14", "16", "18"]


### PR DESCRIPTION
Since nightly is a fast moving, and unstable target, I don't think it makes sense to fail all of the other test runs in the matrix if the nightly tests fail. Still worth knowing if it succeeds or not, but I think it makes the most sense to still run the other tests against stable.