### PR TITLE
Update node version matrix for current LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,18 +18,18 @@ jobs:
     continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["16", "18", "20"]
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
         include:
           - os: ubuntu-latest
-            node-version: "16"
+            node-version: "18"
             edgedb-version: "nightly"
           - os: ubuntu-latest
-            node-version: "16"
+            node-version: "18"
             edgedb-version: "1.4"
           - os: macos-latest
-            node-version: "16"
+            node-version: "18"
             edgedb-version: "stable"
           # - os: windows-2019
           #   node-version: "16"
@@ -94,12 +94,12 @@ jobs:
           server-version: ${{ matrix.edgedb-version }}
 
       - name: Run query builder tests
-        if: ${{ matrix.node-version >= 14 && matrix.edgedb-version != '1.4'}}
+        if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}
         run: |
           yarn workspace @edgedb/generate test:ci
 
       - name: Test QB generation on v1
-        if: ${{ matrix.node-version >= 14 && matrix.edgedb-version == '1.4' }}
+        if: ${{ matrix.node-version >= 16 && matrix.edgedb-version == '1.4' }}
         run: |
           yarn workspace @edgedb/generate test:v1
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -40,7 +40,7 @@
     "build": "echo 'Building edgedb-js...' && rm -rf dist && yarn build:cjs && yarn build:deno",
     "build:cjs": "tsc --project tsconfig.json",
     "build:deno": "deno run --unstable --allow-all ./buildDeno.ts",
-    "test": "jest --detectOpenHandles",
+    "test": "npx --node-options='--experimental-fetch' jest --detectOpenHandles",
     "lint": "tslint 'packages/*/src/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "gen-errors": "edb gen-errors-json --client | node genErrors.js",

--- a/packages/driver/src/httpScram.ts
+++ b/packages/driver/src/httpScram.ts
@@ -73,7 +73,7 @@ export async function HTTPSCRAMAuth(
     serverNonce
   );
 
-  const serverFinalRes = await fetch(authUrl, {
+  const serverFinalRes = await FETCH(authUrl, {
     headers: {
       Authorization: `SCRAM-SHA-256 sid=${sid}, data=${utf8ToB64(clientFinal)}`,
     },

--- a/packages/driver/src/httpScram.ts
+++ b/packages/driver/src/httpScram.ts
@@ -73,7 +73,7 @@ export async function HTTPSCRAMAuth(
     serverNonce
   );
 
-  const serverFinalRes = await FETCH(authUrl, {
+  const serverFinalRes = await fetch(authUrl, {
     headers: {
       Authorization: `SCRAM-SHA-256 sid=${sid}, data=${utf8ToB64(clientFinal)}`,
     },

--- a/packages/driver/test/browser.test.ts
+++ b/packages/driver/test/browser.test.ts
@@ -1,18 +1,11 @@
 /**
- * @jest-environment jsdom
+ * @jest-environment ./test/jsdom-with-fetch.ts
  */
 
 const { TextEncoder, TextDecoder } = require("util");
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 import { getEdgeDBVersion } from "./testbase";
-
-// @ts-ignore
-if (typeof fetch === "undefined") {
-  // Pre 17.5 NodeJS environment.
-  // @ts-ignore
-  globalThis.fetch = require("node-fetch"); // tslint:disable-line
-}
 
 const nodeVersion = parseInt(process.version.slice(1).split(".")[0], 10);
 

--- a/packages/driver/test/createClient.test.ts
+++ b/packages/driver/test/createClient.test.ts
@@ -100,7 +100,7 @@ function timeScriptShutdown(script: string, timeout = 5_000) {
         return;
       }
       clearTimeout(timeoutRef);
-      if (code === 0 && !err && shutdownStart) {
+      if (code === 0 && shutdownStart) {
         resolve(Date.now() - shutdownStart);
       } else {
         reject(`script failed with exit code: ${code}\n${err}`);

--- a/packages/driver/test/createClient.test.ts
+++ b/packages/driver/test/createClient.test.ts
@@ -77,7 +77,7 @@ test("lazy connect + concurrency", async () => {
 
 function timeScriptShutdown(script: string, timeout = 5_000) {
   return new Promise<number>((resolve, reject) => {
-    const proc = spawn("node", ["--eval", script]);
+    const proc = spawn("node", ["--experimental-fetch", "--eval", script]);
 
     const timeoutRef = setTimeout(() => {
       proc.kill();

--- a/packages/driver/test/jsdom-with-fetch.ts
+++ b/packages/driver/test/jsdom-with-fetch.ts
@@ -1,0 +1,12 @@
+import JSDOMEnvironment from "jest-environment-jsdom";
+
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+  }
+}


### PR DESCRIPTION
Node v14 is end-of-life at the end of the month, and Node v20 is out, so this moves our testing matrix window forward based on the current LTS schedule. I picked v18 as our common version to test against in the extra versions since v16 is technically in maintenance mode and will be EOL in 6 months.

As of today:
![image](https://user-images.githubusercontent.com/1682194/233378381-0a276593-5150-4537-96a0-b0fee6f70b8a.png)

Source: https://github.com/nodejs/Release

<details>
<summary>Release schedule JSON</summary>

```json
{
  "v0.8": {
    "start": "2012-06-25",
    "end": "2014-07-31"
  },
  "v0.10": {
    "start": "2013-03-11",
    "end": "2016-10-31"
  },
  "v0.12": {
    "start": "2015-02-06",
    "end": "2016-12-31"
  },
  "v4": {
    "start": "2015-09-08",
    "lts": "2015-10-12",
    "maintenance": "2017-04-01",
    "end": "2018-04-30",
    "codename": "Argon"
  },
  "v5": {
    "start": "2015-10-29",
    "maintenance": "2016-04-30",
    "end": "2016-06-30"
  },
  "v6": {
    "start": "2016-04-26",
    "lts": "2016-10-18",
    "maintenance": "2018-04-30",
    "end": "2019-04-30",
    "codename": "Boron"
  },
  "v7": {
    "start": "2016-10-25",
    "maintenance": "2017-04-30",
    "end": "2017-06-30"
  },
  "v8": {
    "start": "2017-05-30",
    "lts": "2017-10-31",
    "maintenance": "2019-01-01",
    "end": "2019-12-31",
    "codename": "Carbon"
  },
  "v9": {
    "start": "2017-10-01",
    "maintenance": "2018-04-01",
    "end": "2018-06-30"
  },
  "v10": {
    "start": "2018-04-24",
    "lts": "2018-10-30",
    "maintenance": "2020-05-19",
    "end": "2021-04-30",
    "codename": "Dubnium"
  },
  "v11": {
    "start": "2018-10-23",
    "maintenance": "2019-04-22",
    "end": "2019-06-01"
  },
  "v12": {
    "start": "2019-04-23",
    "lts": "2019-10-21",
    "maintenance": "2020-11-30",
    "end": "2022-04-30",
    "codename": "Erbium"
  },
  "v13": {
    "start": "2019-10-22",
    "maintenance": "2020-04-01",
    "end": "2020-06-01"
  },
  "v14": {
    "start": "2020-04-21",
    "lts": "2020-10-27",
    "maintenance": "2021-10-19",
    "end": "2023-04-30",
    "codename": "Fermium"
  },
  "v15": {
    "start": "2020-10-20",
    "maintenance": "2021-04-01",
    "end": "2021-06-01"
  },
  "v16": {
    "start": "2021-04-20",
    "lts": "2021-10-26",
    "maintenance": "2022-10-18",
    "end": "2023-09-11",
    "codename": "Gallium"
  },
  "v17": {
    "start": "2021-10-19",
    "maintenance": "2022-04-01",
    "end": "2022-06-01"
  },
  "v18": {
    "start": "2022-04-19",
    "lts": "2022-10-25",
    "maintenance": "2023-10-18",
    "end": "2025-04-30",
    "codename": "Hydrogen"
  },
  "v19": {
    "start": "2022-10-18",
    "maintenance": "2023-04-01",
    "end": "2023-06-01"
  },
  "v20": {
    "start": "2023-04-18",
    "lts": "2023-10-24",
    "maintenance": "2024-10-22",
    "end": "2026-04-30",
    "codename": ""
  }
}
```

</details>