### PR TITLE
Bump ring buffer size + abort conn if ring buffer overflows

### DIFF
--- a/packages/driver/src/primitives/buffer.ts
+++ b/packages/driver/src/primitives/buffer.ts
@@ -28,7 +28,7 @@ const BUFFER_INC_SIZE: number = 4096;
 /* Max number of recv buffers that can be queued for
  * reading.
  */
-const BUFFER_RING_CAPACITY: number = 2048;
+const BUFFER_RING_CAPACITY: number = 8192;
 
 const EMPTY_BUFFER = new Uint8Array(0);
 

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -174,9 +174,8 @@ export class RawConnection extends BaseRawConnection {
       if (this.messageWaiter) {
         this.messageWaiter.setError(e);
         this.messageWaiter = null;
-      } else {
-        throw e;
       }
+      this._abortWithError(e);
     }
 
     if (pause) {


### PR DESCRIPTION
Should fix #571.

Currently if the ring buffer that incoming data is placed into overflows, an error is thrown for the currently running query but the ring buffer is never cleaned up, so subsequent queries will also fail.
For now the safest fix seems to be to just abort the connection if the ring buffer overflows, since cleaning up the buffer properly will probably require some refactoring to track the boundaries of the separate messages in the buffer.

Also bump the ring buffer size by 4x, to allow larger results, though this also is a temporary fix, and we should probably find a way to remove this query result size limitation.