### PR TITLE
Assign private `EdgeDBError._message` before `defineProperties`

### DIFF
--- a/packages/driver/src/errors/base.ts
+++ b/packages/driver/src/errors/base.ts
@@ -15,12 +15,12 @@ export class EdgeDBError extends Error {
   ) {
     // @ts-ignore
     super(undefined, options);
+    this._message = message ?? "";
     Object.defineProperties(this, {
       _message: {enumerable: false},
       _query: {enumerable: false},
       _attrs: {enumerable: false}
     });
-    this._message = message ?? "";
   }
 
   get message() {

--- a/packages/driver/test/errors.test.ts
+++ b/packages/driver/test/errors.test.ts
@@ -26,3 +26,8 @@ test("resolve error", () => {
   expect(resolveErrorCode(0x04_ff_ff_ff)).toBe(edgedb.QueryError);
   expect(resolveErrorCode(0xfe_ff_ff_ff)).toBe(edgedb.EdgeDBError);
 });
+
+test("message is set", () => {
+  const error = new edgedb.AccessError("test");
+  expect(error.message).toBe("test");
+});

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -87,7 +87,7 @@ export const getServerCommand = (
     srvcmd = process.env.EDGEDB_SERVER_BIN;
   }
 
-  let args = [srvcmd];
+  let args = [srvcmd.replace(/ /g, "\\ ")];
   if (process.platform === "win32") {
     args = ["wsl", "-u", "edgedb", ...args];
   }
@@ -125,7 +125,7 @@ export const getServerCommand = (
     "--port=auto",
     "--emit-server-status=" + statusFile,
     "--security=strict",
-    "--bootstrap-command=ALTER ROLE edgedb { SET password := 'edgedbtest' }"
+    `--bootstrap-command="ALTER ROLE edgedb { SET password := 'edgedbtest' }"`
   ];
 
   return {args, availableFeatures};
@@ -145,7 +145,8 @@ export const startServer = async (
     console.log(`running command: ${cmd.join(" ")}`);
   }
   const proc = child_process.spawn(cmd[0], cmd.slice(1), {
-    env: {...process.env, ...env}
+    env: {...process.env, ...env},
+    shell: true,
   });
 
   try {


### PR DESCRIPTION
When working through the failing tests in #574 , I found this:

![Screenshot 2023-04-20 at 1 46 24 PM](https://user-images.githubusercontent.com/1682194/233447910-73211c75-b07f-4dba-8f30-7e19bf3fd01c.png)

> TypeError: Cannot assign to read only property '_message' of object

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties#parameters)

> writable
> true if and only if the value associated with the property may be changed with an [assignment operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#assignment_operators). Defaults to false.

Couldn't find any mention of this behavior changing between 16 and 18, but this _does_ seem strictly safer than what we had before. I went back and forth on whether or not to set `writable` explicitly on the `defineProperties` call itself, and decided to do the smallest change here and discuss the context for this change before committing to something more explicit. I couldn't find where `_query` or `_attrs` is ever getting set, but perhaps it used to be used somehow?

---

Separately, I had quite a time trying to run the test suite locally and had to make some drastic changes to the test setup to accommodate the standard install path for the server binary on macOS (`~/Library/Application Support/edgedb/portable/{version}/bin/edgedb-server`). I spent a while trying to find the most flexible solution, but it's honestly pretty hacky. I'll try to improve this as we go.