### PR TITLE
Fix with var extraction in `for` loops + fix `insert unless conflict` child expr tracking + add tests

### DIFF
--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -209,10 +209,7 @@ export function $toEdgeQL(this: any) {
       // first, check if expr is bound to scope
       let withBlock = refData.boundScope;
 
-      // filter nulls
-      const parentScopes = [...refData.parentScopes].filter(
-        scope => scope !== null
-      ) as WithScopeExpr[];
+      const parentScopes = [...refData.parentScopes];
 
       // if expression is unbound
       if (!withBlock) {
@@ -223,22 +220,31 @@ export function $toEdgeQL(this: any) {
           continue;
         }
 
-        // set withBlock to top-level parent scope
-        const resolvedParentScopes = parentScopes.map(
-          parentScope => withVars.get(parentScope)?.scope ?? parentScope
+        const [firstParentScopeChain, ...parentScopeChains] = parentScopes.map(
+          scope => {
+            const scopes = [scope];
+            const pendingScopes = [scope];
+            while (pendingScopes.length) {
+              const currentScope = pendingScopes.shift()!;
+              pendingScopes.push(
+                ...walkExprCtx.seen.get(currentScope)!.parentScopes
+              );
+              if (!scopes.includes(currentScope)) {
+                scopes.push(currentScope);
+              }
+            }
+            return scopes;
+          }
         );
-        withBlock =
-          resolvedParentScopes.find(parentScope => {
-            // loop over parent scopes
-            // get list of children exprs for each parent
-            const childExprs = new Set(
-              walkExprCtx.seen.get(parentScope)!.childExprs
-            );
-            // return true for scope that contains all other scopes
-            return resolvedParentScopes.every(
-              scope => childExprs.has(scope) || scope === parentScope
-            );
-          }) ?? walkExprCtx.rootScope;
+        const commonParentScope = firstParentScopeChain
+          ? firstParentScopeChain.find(scope =>
+              // find the first parent scope in the chain that is shared by
+              // the other parent scope chains
+              parentScopeChains.every(otherScope => otherScope.includes(scope))
+            )
+          : null;
+
+        withBlock = commonParentScope ?? walkExprCtx.rootScope;
       }
 
       if (!withBlock) {
@@ -321,7 +327,7 @@ interface WalkExprTreeCtx {
     {
       refCount: number;
       // tracks all withable ancestors
-      parentScopes: Set<WithScopeExpr | null>;
+      parentScopes: Set<WithScopeExpr>;
       // tracks all child exprs
       childExprs: SomeExpression[];
       // tracks bound scope from e.with
@@ -385,14 +391,16 @@ function walkExprTree(
     // const arg = (expr as any)?.__parent__ || (expr as any)?.__name__;
     // if (arg) console.log(arg);
     // }
-    seenExpr.parentScopes.add(parentScope);
+    if (parentScope) {
+      seenExpr.parentScopes.add(parentScope);
+    }
     return [expr, ...seenExpr.childExprs];
   }
 
   const childExprs: SomeExpression[] = [];
   ctx.seen.set(expr, {
     refCount: 1,
-    parentScopes: new Set([parentScope]),
+    parentScopes: new Set(parentScope ? [parentScope] : []),
     childExprs,
     boundScope: null,
     aliases: [],
@@ -535,8 +543,9 @@ function walkExprTree(
     case ExpressionKind.InsertUnlessConflict: {
       // InsertUnlessConflict doesn't create a new scope, the parent scope of
       // child expressions is the wrapped Insert expr
+      const insertChildExprs: SomeExpression[] = [];
       if (expr.__conflict__.on) {
-        childExprs.push(
+        insertChildExprs.push(
           ...walkExprTree(
             expr.__conflict__.on,
             expr.__expr__ as $expr_Insert,
@@ -545,7 +554,7 @@ function walkExprTree(
         );
       }
       if (expr.__conflict__.else) {
-        childExprs.push(
+        insertChildExprs.push(
           ...walkExprTree(
             expr.__conflict__.else,
             expr.__expr__ as $expr_Insert,
@@ -554,7 +563,10 @@ function walkExprTree(
         );
       }
 
-      childExprs.push(...walkExprTree(expr.__expr__, parentScope, ctx));
+      walkExprTree(expr.__expr__, parentScope, ctx);
+      ctx.seen
+        .get(expr.__expr__ as $expr_Insert)!
+        .childExprs.push(...insertChildExprs);
       break;
     }
     case ExpressionKind.Group: {
@@ -1048,7 +1060,7 @@ function renderEdgeQL(
     return `(${renderEdgeQL(expr.__expr__, ctx, false, true).slice(
       1,
       -1
-    )} ${clause.join("")})`;
+    )}${clause.join("")})`;
   } else if (expr.__kind__ === ExpressionKind.Group) {
     const groupingSet = expr.__modifiers__.by as any as GroupingSet;
     const elementsShape =

--- a/packages/generate/test/with.test.ts
+++ b/packages/generate/test/with.test.ts
@@ -518,3 +518,12 @@ SELECT __scope_0_defaultHero {
   single secret2 := __scope_0_defaultHero.__withVar_1
 }`);
 });
+
+test("repeated expr used outside scope", () => {
+  const expr = e.to_str(e.int64(123));
+  const query = e.tuple([expr, e.select(expr)]);
+
+  expect(() => query.toEdgeQL()).toThrow(
+    /Cannot extract repeated expression into 'WITH' block, expression used outside of 'WITH'able expression/
+  );
+});


### PR DESCRIPTION
In some cases when an expression is re-used inside a `for` expr, the `with` var it gets automatically extracted into gets bound to the outside of the `for` expr, which if the `with` expr references the loop var it causes an error. See: https://discord.com/channels/841451783728529451/849377751370432573/1098317767289090149

This PR fixes how the common parent scope of all usages of an expr is computed, so the `with` vars are correctly bound to the `insert` expr in this example. Also fixes a bug where child exprs in the `unless conflict` clause of an `insert` were not being correctly tracked as children of the `insert` expr.