### PR TITLE
Use `spawnSync` to allow spaces in server bin path

### DIFF
--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -93,7 +93,9 @@ export const getServerCommand = (
   }
 
   const helpCmd = [...args, "--help"];
-  const help = child_process.execSync(helpCmd.join(" "));
+  const help = child_process
+    .spawnSync(srvcmd, helpCmd.slice(1))
+    .stdout.toString();
 
   if (help.includes("--tls-cert-mode")) {
     args.push("--tls-cert-mode=generate_self_signed");


### PR DESCRIPTION
Turns out this was all it took to properly link to `"/User/someone/Library/Application Support/edgedb/portable/bin/edgedb-server"`, which is the default path for macOS. We're already using `spawn` downstream which correctly handles paths with spaces.