### PR TITLE
Ignore prettier config change by commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Removed custom prettier config
+9c4daff8be18ca57592735898f0f5f0a1a7f9c35


### PR DESCRIPTION
Ignore the changes made in #580 when using `git blame` and other tools that honor the `.git-blame-ignore-revs` file like GitHub https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view