### PR TITLE
Fix TLS SNI

### DIFF
--- a/packages/driver/src/adapter.deno.ts
+++ b/packages/driver/src/adapter.deno.ts
@@ -287,6 +287,7 @@ export namespace tls {
     ca?: string | string[];
     checkServerIdentity?: (a: string, b: any) => Error | undefined;
     rejectUnauthorized?: boolean;
+    servername?: string;
   }
 
   export class TLSSocket extends net.BaseSocket<Deno.TlsConn> {

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -49,6 +49,9 @@ function getTlsOptions(config: ResolvedConnectConfig): tls.ConnectionOptions {
 
   const tlsOptions: tls.ConnectionOptions = {
     ALPNProtocols: ["edgedb-binary"],
+    // XXX Deno doesn't support this and that means it won't
+    // work with EdgeDB Cloud.
+    servername: config.address[0],
     rejectUnauthorized: tlsSecurity !== "insecure",
   };
 


### PR DESCRIPTION
Remote might rely on SNI to route the connection request properly, so
make sure to send it.