### PR TITLE
Properly quote enum values when generating query text

### DIFF
--- a/packages/driver/genReservedKeywords.js
+++ b/packages/driver/genReservedKeywords.js
@@ -6,7 +6,7 @@ const execFile = util.promisify(require("child_process").execFile);
 const prettier = require("prettier");
 
 (async () => {
-  const {stdout: grammar} = await execFile("edb", [
+  const { stdout: grammar } = await execFile("edb", [
     "gen-meta-grammars",
     "edgeql",
   ]);
@@ -16,15 +16,17 @@ const prettier = require("prettier");
 
   const reservedKeywords = resKeywords
     .split("\n")
-    .map(line => line.trim().replace(/,$/, "").slice(1, -1))
-    .filter(keyword => !!keyword);
+    .map((line) => line.trim().replace(/,$/, "").slice(1, -1))
+    .filter((keyword) => !!keyword);
 
   await fs.writeFile(
     path.join(__dirname, "../src/reflection/reservedKeywords.ts"),
-    `export const reservedKeywords = ${JSON.stringify(
-      reservedKeywords,
-      null,
-      2
-    )}\n`
+    prettier.format(
+      `export const reservedKeywords = new Set(${JSON.stringify(
+        reservedKeywords,
+        null,
+        2
+      )})\n`
+    )
   );
 })();

--- a/packages/driver/src/reflection/reservedKeywords.ts
+++ b/packages/driver/src/reflection/reservedKeywords.ts
@@ -1,4 +1,4 @@
-export const reservedKeywords = [
+export const reservedKeywords = new Set([
   "__edgedbsys__",
   "__edgedbtpl__",
   "__source__",
@@ -85,4 +85,4 @@ export const reservedKeywords = [
   "when",
   "window",
   "with",
-];
+]);

--- a/packages/generate/dbschema/default.esdl
+++ b/packages/generate/dbschema/default.esdl
@@ -1,7 +1,7 @@
 
 module default {
 
-  scalar type Genre extending enum<"Horror", "Action", "RomCom", "Science Fiction">;
+  scalar type Genre extending enum<"Horror", "Action", "RomCom", "Science Fiction", "Select">;
   global uuid_global -> uuid;
   global num_global -> int64;
   global arr_global -> array<str>;

--- a/packages/generate/dbschema/migrations/00019.edgeql
+++ b/packages/generate/dbschema/migrations/00019.edgeql
@@ -1,0 +1,5 @@
+CREATE MIGRATION m1iycuov5wlzo3mivmlbnbavv6s5pwivjs2cqvjmhw3k2tagwqwzta
+    ONTO m1j6yidiiae7thrsrtlajwzgbmzuwuhsoeikzxje4ok4dpka7lyhha
+{
+  ALTER SCALAR TYPE default::Genre EXTENDING enum<Horror, Action, RomCom, `Science Fiction`, `Select`>;
+};

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1459,7 +1459,7 @@ function literalToEdgeQL(type: BaseType, val: any): string {
         if (val.includes(" ")) {
           stringRep = `<${type.__name__}>"${val}"`;
         } else {
-          stringRep = `${type.__name__}.${val}`;
+          stringRep = `${type.__name__}.${q(val)}`;
         }
       } else {
         throw new Error(

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1577,7 +1577,7 @@ function q(ident: string, allowBacklinks: boolean = true): string {
     const isReserved =
       lident !== "__type__" &&
       lident !== "__std__" &&
-      reservedKeywords.includes(lident);
+      reservedKeywords.has(lident);
 
     if (!isReserved) {
       return ident;

--- a/packages/generate/test/insert.test.ts
+++ b/packages/generate/test/insert.test.ts
@@ -45,6 +45,22 @@ test("basic insert", async () => {
   await client.execute(`DELETE Movie FILTER .title = 'Black Widow';`);
 });
 
+test("insert with keyword enum", async () => {
+  const q1 = e.insert(e.Movie, {
+    title: "A fine selection",
+    genre: e.Genre.Select,
+    rating: 2,
+  });
+
+  await q1.run(client);
+  await e
+    .delete(e.Movie, (movie) => ({
+      filter: e.op(movie.title, "=", "A fine selection"),
+    }))
+    .run(client);
+  await client.execute(`DELETE Movie FILTER .title = 'A fine selection';`);
+});
+
 test("unless conflict", async () => {
   const q0 = e
     .insert(e.Movie, {

--- a/packages/generate/test/interfaces.test.ts
+++ b/packages/generate/test/interfaces.test.ts
@@ -3,7 +3,12 @@ import * as tc from "conditional-type-checks";
 
 import type { Movie, X, Y, Z } from "../dbschema/interfaces";
 
-export type Genre = "Horror" | "Action" | "RomCom" | "Science Fiction";
+export type Genre =
+  | "Horror"
+  | "Action"
+  | "RomCom"
+  | "Science Fiction"
+  | "Select";
 
 export interface BaseObject {
   id: string;

--- a/packages/generate/test/params.test.ts
+++ b/packages/generate/test/params.test.ts
@@ -247,7 +247,7 @@ test("all param types", async () => {
         bytes: Uint8Array;
         uuid: string;
         datetime: Date;
-        genre: "Horror" | "Action" | "RomCom" | "Science Fiction";
+        genre: "Horror" | "Action" | "RomCom" | "Science Fiction" | "Select";
         duration: edgedb.Duration;
         local_date: edgedb.LocalDate;
         local_time: edgedb.LocalTime;

--- a/packages/generate/test/sets.test.ts
+++ b/packages/generate/test/sets.test.ts
@@ -144,9 +144,9 @@ test("invalid sets", () => {
 });
 
 test("enums", () => {
-  const query = e.set(e.Genre.Action, e.Genre.Horror);
+  const query = e.set(e.Genre.Action, e.Genre.Horror, e.Genre.Select);
   expect(query.toEdgeQL()).toEqual(
-    `{ default::Genre.Action, default::Genre.Horror }`
+    "{ default::Genre.Action, default::Genre.Horror, default::Genre.`Select` }"
   );
 
   expect(() => e.set(e.Genre.Action, e.sys.VersionStage.dev as any)).toThrow();


### PR DESCRIPTION
We already had a mechanism for quoting values when inserting them into generated queries, we just were not calling it in the case of enums. Will do a little more auditing and open additional PRs if there are more places where we're missing this. I wish I could've thought of a better keyword that is an actual movie genre, but alas.

I also did a non-essential optimization here: Use `Set.has` instead of `Array.includes` to lookup reserved keywords. Probably a pretty small performance impact, but since `.toEdgeQL` gets called a lot, thought it was worth optimizing while touching this code. Any reason to think we'll have platform support issues here? It looks like we're using `Set`s in other places in the code already, but thought it was worth pointing out.

Closes #577 