### PR TITLE
Add decimal property to Person and test query

### DIFF
--- a/packages/driver/src/codecs/numerics.ts
+++ b/packages/driver/src/codecs/numerics.ts
@@ -76,6 +76,8 @@ export class BigIntCodec extends ScalarCodec implements ICodec {
 }
 
 export class DecimalStringCodec extends ScalarCodec implements ICodec {
+  tsType = "string";
+
   encode(buf: WriteBuffer, object: any): void {
     if (typeof object !== "string") {
       throw new InvalidArgumentError(`a string was expected, got "${object}"`);

--- a/packages/generate/dbschema/default.esdl
+++ b/packages/generate/dbschema/default.esdl
@@ -30,6 +30,7 @@ module default {
     required property name -> str {
       constraint exclusive;
     };
+    property height -> decimal;
   }
 
   type Villain extending Person {

--- a/packages/generate/dbschema/migrations/00020.edgeql
+++ b/packages/generate/dbschema/migrations/00020.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1lfiatnywnhkfhjojqxk5iaih2qj5nvaxv7yupc4bitalnvfr7cca
+    ONTO m1svs6bsex5nmq3fgcyr4y3ahgclgdywezxihwjbveft22427x6uya
+{
+  ALTER TYPE default::Person {
+      CREATE PROPERTY height -> std::decimal;
+  };
+};

--- a/packages/generate/dbschema/migrations/00020.edgeql
+++ b/packages/generate/dbschema/migrations/00020.edgeql
@@ -1,5 +1,5 @@
-CREATE MIGRATION m1lfiatnywnhkfhjojqxk5iaih2qj5nvaxv7yupc4bitalnvfr7cca
-    ONTO m1svs6bsex5nmq3fgcyr4y3ahgclgdywezxihwjbveft22427x6uya
+CREATE MIGRATION m1sxhoqfjqn7vtpmatzanmwydtxndf3jlf33npkblmya42fx3bcdoa
+    ONTO m1iycuov5wlzo3mivmlbnbavv6s5pwivjs2cqvjmhw3k2tagwqwzta
 {
   ALTER TYPE default::Person {
       CREATE PROPERTY height -> std::decimal;

--- a/packages/generate/dbschema/queries/get-movies-starring.edgeql
+++ b/packages/generate/dbschema/queries/get-movies-starring.edgeql
@@ -4,6 +4,7 @@ select Movie {
   release_year,
   characters: {
     name,
+    height,
     @character_name,
   },
   `tuple` := (123, 'abc', [123n]),

--- a/packages/generate/test/interfaces.test.ts
+++ b/packages/generate/test/interfaces.test.ts
@@ -15,6 +15,7 @@ export interface BaseObject {
 }
 export interface test_Person extends BaseObject {
   name: string;
+  height?: string | null;
 }
 export interface test_Movie extends BaseObject {
   characters: test_Person[];

--- a/packages/generate/test/objectTypes.test.ts
+++ b/packages/generate/test/objectTypes.test.ts
@@ -185,6 +185,7 @@ test("select *", () => {
     expect(hero["*"]).toEqual({
       id: true,
       name: true,
+      height: true,
       secret_identity: true,
       number_of_movies: true,
     });

--- a/packages/generate/test/queries.test.ts
+++ b/packages/generate/test/queries.test.ts
@@ -27,6 +27,7 @@ test("basic select", async () => {
         release_year: number;
         characters: {
           name: string;
+          height: string | null;
           "@character_name": string | null;
         }[];
         tuple: [number, string, bigint[]];

--- a/packages/generate/test/select.test.ts
+++ b/packages/generate/test/select.test.ts
@@ -317,6 +317,7 @@ test("* in polymorphic", async () => {
       $infer<typeof q>,
       {
         name: string | null;
+        height: string | null;
         number_of_movies: number | null;
         secret_identity: string | null;
       }[]


### PR DESCRIPTION
Closes #602 

We set up the `ScalarCodec` with `unknown` as the `tsType` and override it when extending `ScalarCodec`. We were not doing it in this case.