### PR TITLE
Add examples of referencing non-default modules

### DIFF
--- a/docs/querybuilder.rst
+++ b/docs/querybuilder.rst
@@ -607,3 +607,19 @@ Reference global variables.
   e.default.global.user_id;  // same as above
   e.my_module.global.some_value;
 
+Other modules
+^^^^^^^^^^^^^
+
+Reference entities in modules other than ``default``.
+
+The ``Vampire`` type in a module named ``characters``:
+
+.. code-block:: typescript
+
+  e.characters.Vampire;
+
+As shown in "Globals," a global ``some_value`` in a module ``my_module``:
+
+.. code-block:: typescript
+
+  e.my_module.global.some_value;


### PR DESCRIPTION
I notice we already have an example of this in "Globals" just above, but it could be easy to miss if you're not interested in referencing globals in particular. I wanted to draw attention to a couple of examples of how to reference entities on non-`default` modules with the query builder. (Recycled the one in "Globals," but I think it's useful to call attention to it again here.)