### PR TITLE
Avoid import collision for queries generator

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -60,13 +60,18 @@ The following command will run the ``queries`` generator.
 
     $ deno run --allow-all --unstable https://deno.land/x/edgedb/generate.ts queries
 
-The generator will detect the project root by looking for an ``edgedb.toml``, then scan the directory for ``*.edgeql`` files. In this case, there's only one: ``queries/getUser.edgeql``.
+The generator will detect the project root by looking for an ``edgedb.toml``,
+then scan the directory for ``*.edgeql`` files. In this case, there's only one:
+``queries/getUser.edgeql``.
 
 .. code-block:: text
 
   select User { name, email } filter .id = <uuid>$user_id;
 
-For each ``.edgeql`` file, the generator will read the contents and send the query to the database, which returns type information about its parameters and return type. The generator uses this information to create a new file ``getUser.edgeql.ts`` alongside the original ``getUser.edgeql`` file.
+For each ``.edgeql`` file, the generator will read the contents and send the
+query to the database, which returns type information about its parameters and
+return type. The generator uses this information to create a new file
+``getUser.query.ts`` alongside the original ``getUser.edgeql`` file.
 
 .. code-block:: text
 
@@ -77,12 +82,15 @@ For each ``.edgeql`` file, the generator will read the contents and send the que
   ├── dbschema
   └── queries
       └── getUser.edgeql
-      └── getUser.edgeql.ts    <-- generated file
+      └── getUser.query.ts    <-- generated file
 
 
 .. note::
 
-  This example assumes you are using TypeScript. The generator tries to auto-detect the language you're using; you can also specify the language with the ``--target`` flag. See the :ref:`Targets <edgedb_qb_target>` section for more information.
+  This example assumes you are using TypeScript. The generator tries to
+  auto-detect the language you're using; you can also specify the language with
+  the ``--target`` flag. See the :ref:`Targets <edgedb_qb_target>` section for
+  more information.
 
 The generated file will look something like this:
 
@@ -110,7 +118,7 @@ We can now use this function in our code.
 
 .. code-block:: typescript
 
-  import {getUser} from "./queries/getUser.edgeql";
+  import {getUser} from "./queries/getUser.query";
   import {createClient} from "edgedb";
 
   const client = await createClient();

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -197,6 +197,8 @@ function generateFiles(params: {
   extension: string;
 }[] {
   const queryFileName = adapter.path.basename(params.path);
+  const baseFileName = queryFileName.replace(/\.edgeql$/, "");
+  const outputBaseFileName = `${baseFileName}.query`;
 
   const method =
     params.types.cardinality === Cardinality.ONE
@@ -204,8 +206,7 @@ function generateFiles(params: {
       : params.types.cardinality === Cardinality.AT_MOST_ONE
       ? "querySingle"
       : "query";
-  const functionName = queryFileName
-    .replace(/\.edgeql$/, "")
+  const functionName = baseFileName
     .replace(/-[A-Za-z]/g, (m) => m[1].toUpperCase())
     .replace(/^[^A-Za-z_]|\W/g, "_");
   const imports: any = {};
@@ -239,13 +240,13 @@ function generateFiles(params: {
     case "cjs":
       return [
         {
-          path: `${params.path}.js`,
+          path: `${outputBaseFileName}.js`,
           contents: `${jsImpl}\n\nmodule.exports.${functionName} = ${functionName};`,
           imports: {},
           extension: ".js",
         },
         {
-          path: `${params.path}.d.ts`,
+          path: `${outputBaseFileName}.d.ts`,
           contents: `export ${dtsImpl}`,
           imports: tsImports,
           extension: ".d.ts",
@@ -255,7 +256,7 @@ function generateFiles(params: {
     case "deno":
       return [
         {
-          path: `${params.path}.ts`,
+          path: `${outputBaseFileName}.ts`,
           contents: `export ${tsImpl}`,
           imports: tsImports,
           extension: ".ts",
@@ -264,13 +265,13 @@ function generateFiles(params: {
     case "esm":
       return [
         {
-          path: `${params.path}.mjs`,
+          path: `${outputBaseFileName}.mjs`,
           contents: `export ${jsImpl}`,
           imports: {},
           extension: ".mjs",
         },
         {
-          path: `${params.path}.d.ts`,
+          path: `${outputBaseFileName}.d.ts`,
           contents: `export ${dtsImpl}`,
           imports: tsImports,
           extension: ".d.ts",
@@ -279,7 +280,7 @@ function generateFiles(params: {
     case "mts":
       return [
         {
-          path: `${params.path}.mts`,
+          path: `${outputBaseFileName}.mts`,
           contents: `export ${tsImpl}`,
           imports: tsImports,
           extension: ".mts",
@@ -288,7 +289,7 @@ function generateFiles(params: {
     case "ts":
       return [
         {
-          path: `${params.path}.ts`,
+          path: `${outputBaseFileName}.ts`,
           contents: `export ${tsImpl}`,
           imports: tsImports,
           extension: ".ts",


### PR DESCRIPTION
Closes #540 #568 

Apparently this has never worked since importing `getUser.edgeql` would attempt to import the original query file rather than `getUser.edgeql.ts`, and TypeScript doesn't support specifying an extension for a TypeScript module unless you enable [`allowImportingTsExtensions`](https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions) but then the emitted file has the wrong extension, so you would need to do some rewriting at buildtime to convert `ts` -> `js` for most build systems.