### PR TITLE
Add explicit CI check for 2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,6 @@ jobs:
             edgedb-version: "nightly"
           - os: ubuntu-latest
             node-version: "18"
-            edgedb-version: "1.4"
-          - os: ubuntu-latest
-            node-version: "18"
             edgedb-version: "2"
           - os: macos-latest
             node-version: "18"
@@ -95,6 +92,12 @@ jobs:
         uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284
         with:
           server-version: ${{ matrix.edgedb-version }}
+          project-dir: ./packages/generate
+
+      - name: Show actual EdgeDB server version
+        run: |
+          cd packages/generate
+          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()') >> $GITHUB_ENV
 
       - name: Run query builder tests
         if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,9 @@ jobs:
           - os: ubuntu-latest
             node-version: "18"
             edgedb-version: "1.4"
+          - os: ubuntu-latest
+            node-version: "18"
+            edgedb-version: "2"
           - os: macos-latest
             node-version: "18"
             edgedb-version: "stable"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,11 @@ jobs:
         with:
           server-version: ${{ matrix.edgedb-version }}
 
+      - name: Show actual EdgeDB server version
+        run: |
+          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()') >> $GITHUB_ENV
+
+
       - name: Run query builder tests
         if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,12 +95,6 @@ jobs:
         uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284
         with:
           server-version: ${{ matrix.edgedb-version }}
-          project-dir: ./packages/generate
-
-      - name: Show actual EdgeDB server version
-        run: |
-          cd packages/generate
-          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()') >> $GITHUB_ENV
 
       - name: Run query builder tests
         if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       #     yarn build:deno
 
       - name: Install EdgeDB
-        uses: edgedb/setup-edgedb@v1
+        uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284
         with:
           server-version: ${{ matrix.edgedb-version }}
           project-dir: ./packages/generate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,8 +98,8 @@ jobs:
 
       - name: Show actual EdgeDB server version
         run: |
+          cd packages/generate
           echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()') >> $GITHUB_ENV
-
 
       - name: Run query builder tests
         if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
         uses: edgedb/setup-edgedb@v1
         with:
           server-version: ${{ matrix.edgedb-version }}
+          project-dir: ./packages/generate
 
       - name: Show actual EdgeDB server version
         run: |

--- a/packages/generate/test/globals.test.ts
+++ b/packages/generate/test/globals.test.ts
@@ -4,7 +4,7 @@ import { $ } from "edgedb";
 
 import e from "../dbschema/edgeql-js";
 
-import { setupTests, teardownTests, testIfVersionGTE } from "./setupTeardown";
+import { setupTests, teardownTests } from "./setupTeardown";
 
 describe("globals", () => {
   let client: edgedb.Client;
@@ -18,7 +18,7 @@ describe("globals", () => {
     await teardownTests(client);
   });
 
-  testIfVersionGTE(2)("globals", async () => {
+  test("globals", async () => {
     assert.equal(
       e.select(e.global.uuid_global).toEdgeQL(),
       `SELECT (GLOBAL default::uuid_global)`

--- a/packages/generate/test/group.test.ts
+++ b/packages/generate/test/group.test.ts
@@ -3,12 +3,7 @@ import type * as edgedb from "edgedb";
 import * as tc from "conditional-type-checks";
 
 import e, { type $infer } from "../dbschema/edgeql-js";
-import {
-  setupTests,
-  teardownTests,
-  type TestData,
-  versionGTE,
-} from "./setupTeardown";
+import { setupTests, teardownTests, type TestData } from "./setupTeardown";
 
 describe("group", () => {
   let client: edgedb.Client;
@@ -23,11 +18,6 @@ describe("group", () => {
     await teardownTests(client);
   });
 
-  if (!versionGTE(2)) {
-    return test.skip("group requires EdgeDB 2+", () => {
-      assert.ok(true);
-    });
-  }
   test("basic group", async () => {
     const query = e.group(e.Movie, (movie) => {
       const release_year = movie.release_year;

--- a/packages/generate/test/insert.test.ts
+++ b/packages/generate/test/insert.test.ts
@@ -4,12 +4,7 @@ import type { Villain } from "../dbschema/edgeql-js/modules/default";
 import type { InsertShape } from "../dbschema/edgeql-js/insert";
 import e from "../dbschema/edgeql-js";
 
-import {
-  setupTests,
-  teardownTests,
-  tc,
-  testIfVersionGTE,
-} from "./setupTeardown";
+import { setupTests, teardownTests, tc } from "./setupTeardown";
 
 describe("insert", () => {
   let client: Client;
@@ -369,7 +364,7 @@ describe("insert", () => {
     assert.deepEqual(Object.keys(res), ["id"]);
   });
 
-  testIfVersionGTE(2)("insert custom ID", async () => {
+  test("insert custom ID", async () => {
     await e
       .insert(e.Hero, {
         id: "00000000-0000-0000-0000-000000000000",

--- a/packages/generate/test/literals.test.ts
+++ b/packages/generate/test/literals.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import * as edgedb from "edgedb";
 import { TypeKind } from "edgedb/dist/reflection";
 import e from "../dbschema/edgeql-js";
-import { setupTests, testIfVersionGTE } from "./setupTeardown";
+import { setupTests } from "./setupTeardown";
 
 describe("literals", () => {
   test("literals", () => {
@@ -114,7 +114,7 @@ describe("literals", () => {
     assert.throws(() => e.literal(e.Genre, "NotAGenre" as "Horror").toEdgeQL());
   });
 
-  testIfVersionGTE(2)("constructing with strings", async () => {
+  test("constructing with strings", async () => {
     const { client } = await setupTests();
 
     const dateString = new Date().toISOString();

--- a/packages/generate/test/params.test.ts
+++ b/packages/generate/test/params.test.ts
@@ -1,13 +1,7 @@
 import assert from "node:assert/strict";
 import * as edgedb from "edgedb";
 import e from "../dbschema/edgeql-js";
-import {
-  setupTests,
-  teardownTests,
-  tc,
-  testIfVersionGTE,
-  versionGTE,
-} from "./setupTeardown";
+import { setupTests, teardownTests, tc, versionGTE } from "./setupTeardown";
 
 let client: edgedb.Client;
 
@@ -283,7 +277,7 @@ SELECT (SELECT __param__test)`
     assert.deepEqual(Object.values(complexResult.tuple), Object.values(args));
   });
 
-  testIfVersionGTE(2)("v2 param types", async () => {
+  test("v2 param types", async () => {
     const params = {
       date_duration: e.cal.date_duration,
     };

--- a/packages/generate/test/params.test.ts
+++ b/packages/generate/test/params.test.ts
@@ -299,11 +299,7 @@ SELECT (SELECT __param__test)`
       >
     >(true);
 
-    assert.deepEqual(result, {
-      // @ts-expect-error result includes an id
-      id: result.id,
-      ...args,
-    });
+    assert.deepEqual(result, args);
   });
 
   test("non-runnable return expression", () => {


### PR DESCRIPTION
Closes #612 

Add a check for 2.x to the testing matrix for when 3.x becomes stable soon.

## Notes

I wanted to be able to query the EdgeDB instance that the `generate` package uses from CI. However, the migrations in that project are not valid for the 1.x server. I discussed with the team and we're fine with dropping 1.4 from the testing matrix. That's not an indication that the driver doesn't work with 1.x, but we're no longer checking for compatibility going forward.