### PR TITLE
Add Args and Returns types to queries generator

### DIFF
--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -1,7 +1,7 @@
 import { $, adapter, createClient, createHttpClient } from "edgedb";
 import type { ConnectConfig } from "edgedb/dist/conUtils";
 import { Cardinality } from "edgedb/dist/ifaces";
-import { CommandOptions, getPackageVersion } from "./commandutil";
+import { type CommandOptions, getPackageVersion } from "./commandutil";
 import type { Target } from "./genutil";
 
 // generate per-file queries
@@ -208,6 +208,8 @@ function generateFiles(params: {
     .replace(/\.edgeql$/, "")
     .replace(/-[A-Za-z]/g, (m) => m[1].toUpperCase())
     .replace(/^[^A-Za-z_]|\W/g, "_");
+  const interfaceName =
+    functionName.charAt(0).toUpperCase() + functionName.slice(1);
   const imports: any = {};
   for (const i of params.types.imports) {
     imports[i] = true;
@@ -221,7 +223,11 @@ function generateFiles(params: {
   return client.${method}(\`${params.types.query
     .trim()
     .replace(/`/g, "\\`")}\`${hasArgs ? `, args` : ""});
-}`;
+
+}
+${hasArgs ? `\nexport type ${interfaceName}Args = ${params.types.args};` : ""}
+export type ${interfaceName}Returns = ${params.types.result};
+`;
 
   const jsImpl = `async function ${functionName}(client${
     hasArgs ? `, args` : ""

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -217,6 +217,9 @@ function generateFiles(params: {
 ${hasArgs ? `export type ${argsInterfaceName} = ${params.types.args};\n` : ""}
 export type ${returnsInterfaceName} = ${params.types.result};\
 `;
+  const functionBody = `\
+${params.types.query.trim().replace(/`/g, "\\`")}\`${hasArgs ? `, args` : ""});
+`;
   const imports: any = {};
   for (const i of params.types.imports) {
     imports[i] = true;
@@ -229,9 +232,7 @@ export async function ${functionName}(client: Executor${
     hasArgs ? `, args: ${argsInterfaceName}` : ""
   }): Promise<${returnsInterfaceName}> {
   return client.${method}(\`\\
-${params.types.query
-    .trim()
-    .replace(/`/g, "\\`")}\`${hasArgs ? `, args` : ""});
+${functionBody}
 }
 `;
 
@@ -239,9 +240,7 @@ ${params.types.query
     hasArgs ? `, args` : ""
   }) {
   return client.${method}(\`\\
-${params.types.query.replace(/`/g, "\\`")}\`${
-    hasArgs ? `, args` : ""
-  });
+${functionBody}
 }`;
 
   const dtsImpl = `${queryDefs}

--- a/packages/generate/test/queries.test.ts
+++ b/packages/generate/test/queries.test.ts
@@ -1,8 +1,12 @@
 import type * as edgedb from "edgedb";
 import * as tc from "conditional-type-checks";
 
-import { getMoviesStarring } from "../dbschema/queries";
-import { setupTests, teardownTests, TestData } from "./setupTeardown";
+import {
+  getMoviesStarring,
+  type GetMoviesStarringArgs,
+  type GetMoviesStarringReturns,
+} from "../dbschema/queries";
+import { setupTests, teardownTests } from "./setupTeardown";
 let client: edgedb.Client;
 
 beforeAll(async () => {
@@ -45,4 +49,15 @@ test("basic select", async () => {
   >(true);
 
   expect(result.length).toEqual(2);
+
+  tc.assert<
+    tc.IsExact<
+      GetMoviesStarringArgs,
+      {
+        name?: string | null;
+      }
+    >
+  >(true);
+
+  tc.assert<tc.IsExact<GetMoviesStarringReturns, result>>(true);
 });


### PR DESCRIPTION
Closes #470 

Export types we generate for the parameters to the query and the return type of running the query.

**Note**: I chose to _not_ return a type for `FooArgs` if the query does not take parameters rather than exporting `never`. I initially thought it would be good to have some symmetry and consistency here, but I decided to leave it out for now since adding it later is a backward compatible change, but removing it would be a breaking change.