### PR TITLE
Fix variables being used before being assigned

### DIFF
--- a/packages/driver/src/baseConn.ts
+++ b/packages/driver/src/baseConn.ts
@@ -462,12 +462,12 @@ export class BaseRawConnection {
 
     this._sendData(wb.unwrap());
 
-    let cardinality: number | void;
-    let inTypeId: uuid | void;
-    let outTypeId: uuid | void;
-    let inCodec: ICodec | null;
-    let outCodec: ICodec | null;
-    let capabilities: number = -1;
+    let cardinality: number | null = null;
+    let inTypeId: uuid | null = null;
+    let outTypeId: uuid | null = null;
+    let inCodec: ICodec | null = null;
+    let outCodec: ICodec | null = null;
+    let capabilities = -1;
     let parsing = true;
     let error: Error | null = null;
     let inCodecData: Uint8Array | null = null;


### PR DESCRIPTION
Fixes #635 

```
TSError:
src/baseConn.ts:533:9 - error TS2454: Variable 'inTypeId' is used before being assigned.
src/baseConn.ts:533:29 - error TS2454: Variable 'outTypeId' is used before being assigned.
src/baseConn.ts:619:9 - error TS2454: Variable 'cardinality' is used before being assigned.
```