### PR TITLE
Also build generator in deno release workflow

### DIFF
--- a/.github/workflows/deno-release.yml
+++ b/.github/workflows/deno-release.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           path: packages/driver
 
-
       - name: Write version to file
         run: |
           echo "${{ steps.package-version.outputs.current-version }}"
@@ -52,6 +51,7 @@ jobs:
       - name: Compile for Deno
         run: |
           yarn workspace edgedb build:deno
+          yarn workspace @edgedb/generate build:deno
 
       - name: Push to edgedb-deno
         run: ./.github/workflows/push-edgedb-deno.sh


### PR DESCRIPTION
It seems that we haven't been publishing the syntax file that we dynamically build as part of the generator's build step when pushing our changes to the `edgedb/deno` repo. That means the `FILES.ts` is from 8 months ago.