### PR TITLE
Avoid generate package migration in server setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,13 +91,12 @@ jobs:
       - name: Install EdgeDB
         uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284
         with:
+          instance-name: test
           server-version: ${{ matrix.edgedb-version }}
-          project-dir: ./packages/generate
 
       - name: Show actual EdgeDB server version
         run: |
-          cd packages/generate
-          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()') >> $GITHUB_ENV
+          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()' -I test) >> $GITHUB_ENV
 
       - name: Run query builder tests
         if: ${{ matrix.node-version >= 16 && matrix.edgedb-version != '1.4'}}


### PR DESCRIPTION
We want to control migrations of the generate project manually, so instead of initializing the project in the setup, we'll just create an instance and query that for our server version check.