### PR TITLE
Avoid copying existing buffer in base64 encoder

### DIFF
--- a/packages/driver/src/adapter.deno.ts
+++ b/packages/driver/src/adapter.deno.ts
@@ -87,11 +87,11 @@ export function homeDir(): string {
 //       `import * as fs from "https://deno.land/std@0.159.0/node/fs.ts";`
 //       when the 'fs' compat module does not require '--unstable' flag.
 
-async function toArray(iter: AsyncIterable<unknown>) {
-  const arr = [];
-  for await (const i of iter) arr.push(i);
-  return arr;
-}
+// async function toArray(iter: AsyncIterable<unknown>) {
+//   const arr = [];
+//   for await (const i of iter) arr.push(i);
+//   return arr;
+// }
 
 // deno-lint-ignore-file
 // export namespace fs {

--- a/packages/driver/src/primitives/buffer.ts
+++ b/packages/driver/src/primitives/buffer.ts
@@ -33,13 +33,17 @@ export const utf8Decoder = new TextDecoder("utf8");
 let decodeB64: (b64: string) => Uint8Array;
 let encodeB64: (data: Uint8Array) => string;
 
-if (typeof globalThis.Buffer === "function") {
+// @ts-ignore: Buffer is not defined in Deno
+if (Buffer === "function") {
   decodeB64 = (b64: string): Uint8Array => {
+    // @ts-ignore: Buffer is not defined in Deno
     return Buffer.from(b64, "base64");
   };
   encodeB64 = (data: Uint8Array): string => {
+    // @ts-ignore: Buffer is not defined in Deno
     const buf = !Buffer.isBuffer(data)
-      ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+      ? // @ts-ignore: Buffer is not defined in Deno
+        Buffer.from(data.buffer, data.byteOffset, data.byteLength)
       : data;
     return buf.toString("base64");
   };

--- a/packages/driver/src/primitives/buffer.ts
+++ b/packages/driver/src/primitives/buffer.ts
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-import char, * as chars from "./chars";
+import type char from "./chars";
+import * as chars from "./chars";
 import * as bi from "./bigint";
 import * as compat from "../compat";
 import { LegacyHeaderCodes } from "../ifaces";
@@ -32,14 +33,15 @@ export const utf8Decoder = new TextDecoder("utf8");
 let decodeB64: (b64: string) => Uint8Array;
 let encodeB64: (data: Uint8Array) => string;
 
-if (typeof btoa === "undefined") {
+if (typeof globalThis.Buffer === "function") {
   decodeB64 = (b64: string): Uint8Array => {
-    // @ts-ignore
     return Buffer.from(b64, "base64");
   };
   encodeB64 = (data: Uint8Array): string => {
-    // @ts-ignore
-    return Buffer.from(data).toString("base64");
+    const buf = !Buffer.isBuffer(data)
+      ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+      : data;
+    return buf.toString("base64");
   };
 } else {
   decodeB64 = (b64: string): Uint8Array => {


### PR DESCRIPTION
Closes #674

Avoid copying an existing buffer when encoding buffer data as base64. Also prioritizes using `Buffer` instead of `btoa` if both exist.