### PR TITLE
Add any existing `ext::*` scalar to a type's `__casttype__`

### DIFF
--- a/integration-tests/stable/pgvector.test.ts
+++ b/integration-tests/stable/pgvector.test.ts
@@ -41,7 +41,6 @@ describe("pgvector", () => {
       };
     });
 
-    console.log(query.toEdgeQL());
     const result = await query.run(client);
 
     tc.assert<

--- a/integration-tests/stable/setupTeardown.ts
+++ b/integration-tests/stable/setupTeardown.ts
@@ -15,7 +15,7 @@ export async function setupTests() {
 }
 
 async function cleanupData(client: Client) {
-  await client.execute(`reset schema to initial`);
+  await client.execute(`delete PgVectorTest`);
 }
 
 export async function teardownTests(client: Client) {

--- a/packages/driver/src/reflection/queries/types.ts
+++ b/packages/driver/src/reflection/queries/types.ts
@@ -127,7 +127,7 @@ export async function getTypes(
       material_scalars := (
         SELECT ScalarType
         FILTER
-          (.name LIKE 'std::%' OR .name LIKE 'cal::%')
+          (.name LIKE 'std::%' OR .name LIKE 'cal::%' OR .name LIKE 'ext::%')
           AND NOT .is_abstract
       )
 

--- a/packages/driver/src/reflection/queries/types.ts
+++ b/packages/driver/src/reflection/queries/types.ts
@@ -128,7 +128,9 @@ export async function getTypes(
         SELECT ScalarType
         FILTER
           (.name LIKE 'std::%' OR .name LIKE 'cal::%' OR .name LIKE 'ext::%')
-          AND NOT .is_abstract
+          AND NOT .abstract
+          AND NOT EXISTS .enum_values
+          AND NOT EXISTS (SELECT .ancestors FILTER NOT .abstract)
       )
 
     SELECT Type {

--- a/packages/driver/src/reflection/queries/types.ts
+++ b/packages/driver/src/reflection/queries/types.ts
@@ -126,11 +126,9 @@ export async function getTypes(
 
       material_scalars := (
         SELECT ScalarType
-        FILTER
-          (.name LIKE 'std::%' OR .name LIKE 'cal::%' OR .name LIKE 'ext::%')
-          AND NOT .abstract
-          AND NOT EXISTS .enum_values
-          AND NOT EXISTS (SELECT .ancestors FILTER NOT .abstract)
+        FILTER NOT .abstract
+           AND NOT EXISTS .enum_values
+           AND NOT EXISTS (SELECT .ancestors FILTER NOT .abstract)
       )
 
     SELECT Type {

--- a/packages/generate/src/syntax/funcops.ts
+++ b/packages/generate/src/syntax/funcops.ts
@@ -127,9 +127,15 @@ export function $resolveOverload(
   throw new Error(
     `No function overload found for ${
       funcName.includes("::")
-        ? `'e.${funcName.split("::")[1]}()'`
+        ? `'e.${funcName.split("::").join(".")}()'`
         : `operator '${funcName}'`
-    } with args: ${args.map((arg) => `${arg}`).join(", ")}`
+    } with args: ${[...positionalArgs, ...Object.values(namedArgs ?? {})]
+      .filter(Boolean)
+      .map(
+        (arg) =>
+          `Element: ${arg!.__element__.__name__} (${arg!.__cardinality__})`
+      )
+      .join(", ")}`
   );
 }
 


### PR DESCRIPTION
Closes #685 

The type system resolves ancestor types to scalars calling them "material scalars" and we were not getting any `ext::*` scalars in our subquery that resolves these.

Some additional updates to make error messages a bit more useful since they currently print `[object Object]` instead of anything useful 😬 