### PR TITLE
 Remove/move exit calls from generators to cli.ts

### DIFF
--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -367,29 +367,33 @@ Run this command inside an EdgeDB project directory or specify the desired targe
     exitWithError(`Failed to connect: ${(e as Error).message}`);
   }
 
-  switch (generator) {
-    case Generator.QueryBuilder:
-      await generateQueryBuilder({
-        options,
-        client,
-        root: projectRoot,
-      });
-      adapter.process.exit();
-      break;
-    case Generator.Queries:
-      await generateQueryFiles({
-        options,
-        client,
-        root: projectRoot,
-      });
-      break;
-    case Generator.Interfaces:
-      await runInterfacesGenerator({
-        options,
-        client,
-        root: projectRoot,
-      });
-      break;
+  try {
+    switch (generator) {
+      case Generator.QueryBuilder:
+        await generateQueryBuilder({
+          options,
+          client,
+          root: projectRoot,
+        });
+        adapter.process.exit();
+        break;
+      case Generator.Queries:
+        await generateQueryFiles({
+          options,
+          client,
+          root: projectRoot,
+        });
+        break;
+      case Generator.Interfaces:
+        await runInterfacesGenerator({
+          options,
+          client,
+          root: projectRoot,
+        });
+        break;
+    }
+  } catch (e) {
+    exitWithError((e as Error).message);
   }
 };
 

--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -375,7 +375,6 @@ Run this command inside an EdgeDB project directory or specify the desired targe
           client,
           root: projectRoot,
         });
-        adapter.process.exit();
         break;
       case Generator.Queries:
         await generateQueryFiles({
@@ -395,6 +394,7 @@ Run this command inside an EdgeDB project directory or specify the desired targe
   } catch (e) {
     exitWithError((e as Error).message);
   }
+  adapter.process.exit();
 };
 
 function printHelp() {

--- a/packages/generate/src/edgeql-js.ts
+++ b/packages/generate/src/edgeql-js.ts
@@ -7,7 +7,6 @@ import {
   isTTY,
   promptBoolean,
 } from "./commandutil";
-import { exitWithError } from "./genutil";
 import { DirBuilder } from "./builders";
 import { syntax } from "./FILES";
 
@@ -358,8 +357,8 @@ async function canOverwrite(outputDir: string, options: CommandOptions) {
   } catch {}
 
   const error = config
-    ? `A query builder with a different config already exists in that location.`
-    : `Output directory '${outputDir}' already exists.`;
+    ? `Error: A query builder with a different config already exists in that location.`
+    : `Error: Output directory '${outputDir}' already exists.`;
 
   if (
     isTTY() &&
@@ -368,5 +367,5 @@ async function canOverwrite(outputDir: string, options: CommandOptions) {
     return true;
   }
 
-  return exitWithError(`Error: ${error}`);
+  throw new Error(error);
 }

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -37,7 +37,6 @@ currently supported.`);
   const matches = await getMatches(root);
   if (matches.length === 0) {
     console.log(`No .edgeql files found in project`);
-    adapter.exit();
     return;
   }
 
@@ -109,7 +108,6 @@ currently supported.`);
         );
       }
     }
-    adapter.exit();
     return;
   }
 
@@ -144,11 +142,6 @@ currently supported.`);
   // generate per-query files
   console.log(`Generating files for following queries:`);
   await Promise.all(matches.map(generateFilesForQuery));
-
-  if (!params.options.watch) {
-    adapter.exit();
-    return;
-  }
 
   // find all *.edgeql files
   // for query in queries:


### PR DESCRIPTION
Currently I have `watch: true` only to prevent the function from calling exit. Very weird lol.
It appears this functionality is stubbed, so dropping this seems fine. Even when implemented I'd question if this would be needed.