### PR TITLE
ESM compatibility for generated query builder

### DIFF
--- a/packages/generate/buildDeno.ts
+++ b/packages/generate/buildDeno.ts
@@ -9,9 +9,11 @@ await run({
     {
       match: /^edgedb\/dist\//,
       replace: (match, path) => {
-        return path?.includes("src/generators")
-          ? match.replace(/^edgedb\/dist\//, "../../_src/")
-          : match.replace(/^edgedb\/dist\//, "../_src/");
+        return (
+          path?.includes("src/generators")
+            ? match.replace(/^edgedb\/dist\//, "../../_src/")
+            : match.replace(/^edgedb\/dist\//, "../_src/")
+        ).replace(/.js$/, '');
       }
     },
     {

--- a/packages/generate/src/genutil.ts
+++ b/packages/generate/src/genutil.ts
@@ -5,7 +5,7 @@ import type {
   IdentRef,
 } from "./builders";
 import * as introspect from "edgedb/dist/reflection/queries/types";
-import { util } from "edgedb/dist/reflection/index";
+import { util } from "edgedb/dist/reflection/index.js";
 
 export { $ } from "edgedb";
 import type { $ } from "edgedb";

--- a/packages/generate/src/syntax/cardinality.ts
+++ b/packages/generate/src/syntax/cardinality.ts
@@ -1,4 +1,4 @@
-import { Cardinality } from "edgedb/dist/reflection/index";
+import { Cardinality } from "edgedb/dist/reflection/index.js";
 import type { TypeSet } from "./typesystem";
 
 // Computing cardinality of path

--- a/packages/generate/src/syntax/cast.ts
+++ b/packages/generate/src/syntax/cast.ts
@@ -1,4 +1,4 @@
-import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index";
+import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index.js";
 import type {
   Expression,
   BaseType,

--- a/packages/generate/src/syntax/casting.ts
+++ b/packages/generate/src/syntax/casting.ts
@@ -1,4 +1,4 @@
-import type { Cardinality } from "edgedb/dist/reflection/index";
+import type { Cardinality } from "edgedb/dist/reflection/index.js";
 import type {
   ArrayType,
   BaseType,

--- a/packages/generate/src/syntax/collections.ts
+++ b/packages/generate/src/syntax/collections.ts
@@ -3,7 +3,7 @@ import {
   ExpressionKind,
   TypeKind,
   typeutil,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import { cardutil } from "./cardinality";
 import type {
   $expr_Array,

--- a/packages/generate/src/syntax/detached.ts
+++ b/packages/generate/src/syntax/detached.ts
@@ -1,4 +1,4 @@
-import { ExpressionKind } from "edgedb/dist/reflection/index";
+import { ExpressionKind } from "edgedb/dist/reflection/index.js";
 import type { Expression, TypeSet } from "./typesystem";
 import { $expressionify } from "./path";
 

--- a/packages/generate/src/syntax/for.ts
+++ b/packages/generate/src/syntax/for.ts
@@ -1,4 +1,4 @@
-import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index";
+import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index.js";
 import { cardutil } from "./cardinality";
 import type { Expression, BaseType, BaseTypeSet } from "./typesystem";
 import { $expressionify } from "./path";

--- a/packages/generate/src/syntax/funcops.ts
+++ b/packages/generate/src/syntax/funcops.ts
@@ -2,7 +2,7 @@ import {
   Cardinality,
   introspect,
   TypeKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import { cardutil } from "./cardinality";
 import { makeType } from "./hydrate";
 import type {
@@ -21,7 +21,7 @@ import { literal } from "./literal";
 import type {
   ExpressionKind,
   OperatorKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 
 export type $expr_Function<
   // Name extends string = string,

--- a/packages/generate/src/syntax/globals.ts
+++ b/packages/generate/src/syntax/globals.ts
@@ -1,4 +1,4 @@
-import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index";
+import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index.js";
 import type { Expression, BaseType } from "./typesystem";
 import { $expressionify } from "./path";
 

--- a/packages/generate/src/syntax/group.ts
+++ b/packages/generate/src/syntax/group.ts
@@ -12,7 +12,7 @@ import {
   Cardinality,
   ExpressionKind,
   TypeKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import { makeType } from "./hydrate";
 
 import { $expressionify, $getScopedExpr } from "./path";

--- a/packages/generate/src/syntax/hydrate.ts
+++ b/packages/generate/src/syntax/hydrate.ts
@@ -9,8 +9,8 @@ import type {
   TupleType,
 } from "./typesystem";
 
-import { util, TypeKind } from "edgedb/dist/reflection/index";
-import type { typeutil } from "edgedb/dist/reflection/index";
+import { util, TypeKind } from "edgedb/dist/reflection/index.js";
+import type { typeutil } from "edgedb/dist/reflection/index.js";
 
 const typeCache = new Map<string, BaseType>();
 

--- a/packages/generate/src/syntax/insert.ts
+++ b/packages/generate/src/syntax/insert.ts
@@ -3,7 +3,7 @@ import {
   ExpressionKind,
   typeutil,
   TypeKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import type {
   Expression,
   LinkDesc,

--- a/packages/generate/src/syntax/json.ts
+++ b/packages/generate/src/syntax/json.ts
@@ -1,6 +1,6 @@
-import { ExpressionKind, TypeKind } from "edgedb/dist/reflection/index";
+import { ExpressionKind, TypeKind } from "edgedb/dist/reflection/index.js";
 import type { ParamType } from "./typesystem";
-import { encodeB64 } from "edgedb/dist/primitives/buffer";
+import { encodeB64 } from "edgedb/dist/primitives/buffer.js";
 import type { $expr_WithParams } from "./params";
 
 function jsonStringify(type: ParamType, val: any): string {

--- a/packages/generate/src/syntax/literal.ts
+++ b/packages/generate/src/syntax/literal.ts
@@ -12,12 +12,12 @@ import type {
 //   BaseTypeToTsType,
 //   makeType,
 //   ScalarType
-// } from "edgedb/dist/reflection/index";
+// } from "edgedb/dist/reflection/index.js";
 
 // import type {$expr_Literal} from "./literal";
 import { $expressionify } from "./path";
 import { spec } from "./__spec__";
-import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index";
+import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index.js";
 import { makeType } from "./hydrate";
 
 export type $expr_Literal<Type extends BaseType = BaseType> = Expression<{

--- a/packages/generate/src/syntax/modules/std.ts
+++ b/packages/generate/src/syntax/modules/std.ts
@@ -8,7 +8,7 @@ import type {
 } from "../typesystem";
 
 import type { $expr_PathNode } from "../path";
-import type { Cardinality } from "edgedb/dist/reflection/index";
+import type { Cardinality } from "edgedb/dist/reflection/index.js";
 declare function assert_single(input: TypeSet<BaseType>): any;
 
 declare const number: scalarTypeWithConstructor<

--- a/packages/generate/src/syntax/params.ts
+++ b/packages/generate/src/syntax/params.ts
@@ -3,7 +3,7 @@ import {
   ExpressionKind,
   Cardinality,
   TypeKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import type {
   Expression,
   ParamType,

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -10,7 +10,7 @@ import {
   Cardinality,
   // BaseType,
   typeutil,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 
 import { cardutil } from "./cardinality";
 

--- a/packages/generate/src/syntax/query.ts
+++ b/packages/generate/src/syntax/query.ts
@@ -1,5 +1,5 @@
 import type * as edgedb from "edgedb";
-import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index";
+import { Cardinality, ExpressionKind } from "edgedb/dist/reflection/index.js";
 import { jsonifyComplexParams } from "./json";
 import { select } from "./select";
 

--- a/packages/generate/src/syntax/range.ts
+++ b/packages/generate/src/syntax/range.ts
@@ -1,6 +1,6 @@
 import type { LocalDate, LocalDateTime, Duration } from "edgedb";
 import { Range } from "edgedb";
-import { TypeKind, ExpressionKind } from "edgedb/dist/reflection/index";
+import { TypeKind, ExpressionKind } from "edgedb/dist/reflection/index.js";
 
 import type { cardutil } from "./cardinality";
 import type {

--- a/packages/generate/src/syntax/reflection.ts
+++ b/packages/generate/src/syntax/reflection.ts
@@ -1,4 +1,4 @@
-export * from "edgedb/dist/reflection/index";
+export * from "edgedb/dist/reflection/index.js";
 export * from "./typesystem";
 export { cardutil } from "./cardinality";
 export type { $expr_Literal } from "./literal";

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -14,7 +14,7 @@ import {
   ExpressionKind,
   TypeKind,
   OperatorKind,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import { makeType } from "./hydrate";
 
 import { cardutil } from "./cardinality";

--- a/packages/generate/src/syntax/set.ts
+++ b/packages/generate/src/syntax/set.ts
@@ -1,5 +1,5 @@
 import type { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index";
-import { TypeKind } from "edgedb/dist/reflection/index";
+import { TypeKind } from "edgedb/dist/reflection/index.js";
 import type {
   ArrayType,
   BaseTypeTuple,

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -13,7 +13,7 @@ import {
   OperatorKind,
   TypeKind,
   util,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import {
   $expr_Array,
   $expr_NamedTuple,
@@ -36,7 +36,7 @@ import type {
   $expr_PathNode,
   $expr_TypeIntersection,
 } from "./path";
-import { reservedKeywords } from "edgedb/dist/reflection/index";
+import { reservedKeywords } from "edgedb/dist/reflection/index.js";
 import type { $expr_Cast } from "./cast";
 import type { $expr_Detached } from "./detached";
 import type { $expr_For, $expr_ForVar } from "./for";

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -6,8 +6,8 @@ import type {
   typeutil,
   Cardinality,
   ExpressionKind,
-} from "edgedb/dist/reflection/index";
-import { TypeKind } from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
+import { TypeKind } from "edgedb/dist/reflection/index.js";
 import type { cardutil } from "./cardinality";
 import type { Range } from "edgedb";
 

--- a/packages/generate/src/syntax/update.ts
+++ b/packages/generate/src/syntax/update.ts
@@ -2,7 +2,7 @@ import {
   ExpressionKind,
   typeutil,
   Cardinality,
-} from "edgedb/dist/reflection/index";
+} from "edgedb/dist/reflection/index.js";
 import type {
   Expression,
   ObjectTypePointers,

--- a/packages/generate/src/syntax/with.ts
+++ b/packages/generate/src/syntax/with.ts
@@ -1,4 +1,4 @@
-import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index";
+import { ExpressionKind, Cardinality } from "edgedb/dist/reflection/index.js";
 import type { BaseType, Expression, TypeSet } from "./typesystem";
 import type { $expr_Select } from "./select";
 import type { $expr_For } from "./for";


### PR DESCRIPTION
With these files copied wholesale to the user's codebase, they need to be compatible with ESM syntax.
This shouldn't conflict with commonjs functionality.