### PR TITLE
Ignore the dbschema/fixups directory in queries generator

### DIFF
--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -156,7 +156,11 @@ export function stringifyImports(imports: { [k: string]: boolean }) {
 async function getMatches(root: string) {
   return adapter.walk(root, {
     match: [/[^\/]\.edgeql$/],
-    skip: [/node_modules/, RegExp(`dbschema\\${adapter.path.sep}migrations`)],
+    skip: [
+      /node_modules/,
+      RegExp(`dbschema\\${adapter.path.sep}migrations`),
+      RegExp(`dbschema\\${adapter.path.sep}fixups`),
+    ],
   });
 }
 


### PR DESCRIPTION
Closes #678 

**Note**: There is an existing bug here: we should be looking up your dbschema directory from your edgedb.toml configuration instead of hardcoding this, but I'll fix that in the context of #617 and a general `include`/`exclude` solution.