### PR TITLE
Fix typescript errors for generated query builder

### DIFF
--- a/packages/generate/src/syntax/collections.ts
+++ b/packages/generate/src/syntax/collections.ts
@@ -2,7 +2,7 @@ import {
   Cardinality,
   ExpressionKind,
   TypeKind,
-  typeutil,
+  type typeutil,
 } from "edgedb/dist/reflection/index";
 import { cardutil } from "./cardinality";
 import type {
@@ -24,14 +24,14 @@ import type {
   TypeSet,
 } from "./typesystem";
 
-import { $expressionify, ExpressionRoot } from "./path";
+import { $expressionify, type ExpressionRoot } from "./path";
 import type { getCardsFromExprs } from "./set";
 import {
-  literalToScalarType,
+  type literalToScalarType,
   literalToTypeSet,
-  mapLiteralToTypeSet,
-  orScalarLiteral,
-  scalarLiterals,
+  type mapLiteralToTypeSet,
+  type orScalarLiteral,
+  type scalarLiterals,
 } from "./castMaps";
 
 const indexSliceRegx = /^(-?\d+)(?:(:)(-?\d+)?)?|:(-?\d+)$/;

--- a/packages/generate/src/syntax/insert.ts
+++ b/packages/generate/src/syntax/insert.ts
@@ -1,7 +1,7 @@
 import {
   Cardinality,
   ExpressionKind,
-  typeutil,
+  type typeutil,
   TypeKind,
 } from "edgedb/dist/reflection/index";
 import type {

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -9,7 +9,7 @@ import {
   // PropertyDesc,
   Cardinality,
   // BaseType,
-  typeutil,
+  type typeutil,
 } from "edgedb/dist/reflection/index";
 
 import { cardutil } from "./cardinality";

--- a/packages/generate/src/syntax/range.ts
+++ b/packages/generate/src/syntax/range.ts
@@ -23,7 +23,7 @@ import type { literalToScalarType, orScalarLiteral } from "./castMaps";
 import { literalToTypeSet } from "./castMaps";
 import { spec } from "./__spec__";
 import { literal, $nameMapping } from "./literal";
-import { $expr_Function, $resolveOverload } from "./funcops";
+import { type $expr_Function, $resolveOverload } from "./funcops";
 import { $expressionify } from "./path";
 
 type $anypoint =

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -39,18 +39,18 @@ import type {
 
 import {
   $assert_single,
-  $expr_PathLeaf,
-  $expr_PathNode,
-  $linkPropify,
-  ExpressionRoot,
+  type $expr_PathLeaf,
+  type $expr_PathNode,
+  type $linkPropify,
+  type ExpressionRoot,
 } from "./path";
 import type { anonymizeObject } from "./casting";
 import { $expressionify, $getScopedExpr } from "./path";
 import { $getTypeByName, literal } from "./literal";
 import { spec } from "./__spec__";
 import {
-  scalarLiterals,
-  literalToScalarType,
+  type scalarLiterals,
+  type literalToScalarType,
   literalToTypeSet,
 } from "./castMaps";
 import type { $expr_Operator } from "./funcops";

--- a/packages/generate/src/syntax/set.ts
+++ b/packages/generate/src/syntax/set.ts
@@ -14,7 +14,7 @@ import type {
   SomeType,
 } from "./typesystem";
 
-import { $mergeObjectTypes, mergeObjectTypes } from "./hydrate";
+import { $mergeObjectTypes, type mergeObjectTypes } from "./hydrate";
 
 import * as castMaps from "./castMaps";
 

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -15,20 +15,20 @@ import {
   util,
 } from "edgedb/dist/reflection/index";
 import {
-  $expr_Array,
-  $expr_NamedTuple,
-  $expr_Tuple,
-  $expr_TuplePath,
-  BaseType,
-  EnumType,
+  type $expr_Array,
+  type $expr_NamedTuple,
+  type $expr_Tuple,
+  type $expr_TuplePath,
+  type BaseType,
+  type EnumType,
   isArrayType,
   isNamedTupleType,
   isObjectType,
   isTupleType,
-  ObjectType,
-  ObjectTypeSet,
-  RangeType,
-  TypeSet,
+  type ObjectType,
+  type ObjectTypeSet,
+  type RangeType,
+  type TypeSet,
 } from "./typesystem";
 import type { $expr_Literal } from "./literal";
 import type {

--- a/packages/generate/src/syntax/update.ts
+++ b/packages/generate/src/syntax/update.ts
@@ -1,6 +1,6 @@
 import {
   ExpressionKind,
-  typeutil,
+  type typeutil,
   Cardinality,
 } from "edgedb/dist/reflection/index";
 import type {
@@ -17,13 +17,13 @@ import type {
 import type { pointerToAssignmentExpression } from "./casting";
 import { $expressionify, $getScopedExpr, $assert_single } from "./path";
 import {
-  SelectModifiers,
-  NormalisedSelectModifiers,
-  ComputeSelectCardinality,
+  type SelectModifiers,
+  type NormalisedSelectModifiers,
+  type ComputeSelectCardinality,
   $existingScopes,
   $handleModifiers,
 } from "./select";
-import { $normaliseInsertShape, pointerIsOptional } from "./insert";
+import { $normaliseInsertShape, type pointerIsOptional } from "./insert";
 
 /////////////////
 /// UPDATE


### PR DESCRIPTION
Trying to use the query builder together in a SvelteKit project throws some errors.
The fix is to just do what the compiler suggested. 

Found another user hit with the bug on the main repo: https://github.com/edgedb/edgedb/issues/5486