### PR TITLE
Cloudfalre change Node Imports to supported node: prefix

### DIFF
--- a/packages/driver/src/adapter.node.ts
+++ b/packages/driver/src/adapter.node.ts
@@ -1,13 +1,13 @@
-import * as crypto from "crypto";
-import { promises as fs } from "fs";
-import * as net from "net";
-import * as os from "os";
-import * as path from "path";
-import * as tls from "tls";
+import * as crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as tls from "node:tls";
 
-import process from "process";
-import * as readline from "readline";
-import { Writable } from "stream";
+import process from "node:process";
+import * as readline from "node:readline";
+import { Writable } from "node:stream";
 
 export { path, net, fs, tls, process };
 


### PR DESCRIPTION
Currently it is not possible to use Edgedb-js natively with Cloudflares Pages with there Edge network (Cloudflare Workers).
The Problem of this, are most likely connected to the imports, which cannot be found for the Workers since we need to add coresponding to Cloudflare: https://developers.cloudflare.com/workers/runtime-apis/nodejs/ 
The node: prefix.

The main point of this, is also to discuss future improvement on the integretation of Cloudflare Pages, which is one of the most popular Edge deployment methodes.