### PR TITLE
Properly escape nested module names for globals

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
     // Svelte doesn't correctly compile if imports of the generated /modules
     // aren't imported as 'import type' in other parts of the generated
     // querybuilder, so set this option to ensure we always do that
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-namespace": "off"
   }
 };

--- a/integration-tests/nightly/auth.test.ts
+++ b/integration-tests/nightly/auth.test.ts
@@ -1,0 +1,39 @@
+import type { Client } from "edgedb";
+import e, { type $infer } from "./dbschema/edgeql-js";
+import { setupTests, tc, teardownTests } from "./setupTeardown";
+
+describe("auth", () => {
+  let client: Client;
+  beforeAll(async () => {
+    const setup = await setupTests();
+    ({ client } = setup);
+  });
+
+  afterAll(async () => {
+    await teardownTests(client);
+  }, 10_000);
+
+  test("check generated globals", () => {
+    const clientTokenIdentity = e.select(
+      e.ext.auth.global.ClientTokenIdentity,
+      (i) => ({
+        ...i["*"],
+      })
+    );
+    tc.assert<
+      tc.IsExact<
+        $infer<typeof clientTokenIdentity>,
+        {
+          id: string;
+          created_at: Date;
+          modified_at: Date;
+          issuer: string;
+          subject: string;
+        }[]
+      >
+    >(true);
+  });
+
+  const clientToken = e.select(e.ext.auth.global.client_token);
+  tc.assert<tc.IsExact<$infer<typeof clientToken>, string | null>>(true);
+});

--- a/integration-tests/nightly/dbschema/default.esdl
+++ b/integration-tests/nightly/dbschema/default.esdl
@@ -1,3 +1,5 @@
+using extension auth;
+
 module default {
   type WithMultiRange {
     required ranges: multirange<std::int32>;

--- a/integration-tests/nightly/dbschema/migrations/00002.edgeql
+++ b/integration-tests/nightly/dbschema/migrations/00002.edgeql
@@ -1,0 +1,6 @@
+CREATE MIGRATION m1sxd3hbdfjetkgd5okfnkylxf32szrksxs4wctldele4gbaaleoha
+    ONTO m1rlwpc5ikrkb7cvylhbcntglvnanm524yb6si5xlcjk6gd2lczugq
+{
+  CREATE EXTENSION pgcrypto VERSION '1.3';
+  CREATE EXTENSION auth VERSION '1.0';
+};

--- a/packages/generate/src/edgeql-js/generateGlobals.ts
+++ b/packages/generate/src/edgeql-js/generateGlobals.ts
@@ -15,9 +15,10 @@ export const generateGlobals = ({ dir, globals, types }: GeneratorParams) => {
 
   for (const [mod, gs] of Object.entries(globalsByMod)) {
     const code = dir.getModule(mod);
+    const modName = mod.split("::").join("_");
     code.writeln([
       dts`declare `,
-      ...frag`const $${mod}__globals`,
+      ...frag`const $${modName}__globals`,
       t`: {`,
       ...gs
         .flatMap((g) => {
@@ -53,9 +54,9 @@ export const generateGlobals = ({ dir, globals, types }: GeneratorParams) => {
     ]);
 
     code.nl();
-    code.registerRef(`$${mod}__globals`);
+    code.registerRef(`$${modName}__globals`);
     code.addToDefaultExport(
-      getRef(`$${mod}__globals`, { prefix: "" }),
+      getRef(`$${modName}__globals`, { prefix: "" }),
       "global"
     );
   }


### PR DESCRIPTION
Found a place where we were not properly escaping nested module names: globals. The name is not important here because it's not actually exported, it's added as a key on the module at `global`.