### PR TITLE
Allow NamedTuple as select expression

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -508,18 +508,21 @@ describe("select", () => {
     const pathResult = await e.select(namedTuple.foo).run(client);
     assert.deepEqual(pathResult, "bar");
 
-    const nestedObjectTuple = e.for(e.select(e.Hero), (hero) =>
-      e.tuple({
-        hero,
-        score: e.random(),
-      })
+    const nestedObjectTuple = e.for(
+      e.enumerate(e.select(e.Hero)),
+      (enumeration) =>
+        e.tuple({
+          hero: enumeration[1],
+          index: enumeration[0],
+        })
     );
     const nestedObjectQuery = e.select(nestedObjectTuple.hero, (hero) => ({
       name: hero.name,
-      order_by: nestedObjectTuple.score,
+      order_by: nestedObjectTuple.index,
     }));
     const nestedObjectResult = await nestedObjectQuery.run(client);
-    assert.deepEqual(nestedObjectResult, []);
+    assert.equal(nestedObjectResult.length, 3);
+    assert.ok(nestedObjectResult.every((r) => Boolean(r.name)));
   });
 
   test("filter by id", async () => {

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -500,6 +500,28 @@ describe("select", () => {
     );
   });
 
+  test("named tuples", async () => {
+    const namedTuple = e.tuple({ foo: e.str("bar") });
+    const result = await e.select(namedTuple).run(client);
+    assert.deepEqual(result, { foo: "bar" });
+
+    const pathResult = await e.select(namedTuple.foo).run(client);
+    assert.deepEqual(pathResult, "bar");
+
+    const nestedObjectTuple = e.for(e.select(e.Hero), (hero) =>
+      e.tuple({
+        hero,
+        score: e.random(),
+      })
+    );
+    const nestedObjectQuery = e.select(nestedObjectTuple.hero, (hero) => ({
+      name: hero.name,
+      order_by: nestedObjectTuple.score,
+    }));
+    const nestedObjectResult = await nestedObjectQuery.run(client);
+    assert.deepEqual(nestedObjectResult, []);
+  });
+
   test("filter by id", async () => {
     const result = await e
       .select(e.Hero, () => ({

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -1,6 +1,7 @@
 import type { Client } from "edgedb";
 import e, { type $infer } from "./dbschema/edgeql-js";
 import { setupTests, tc, teardownTests } from "./setupTeardown";
+import { $Post } from "./dbschema/edgeql-js/modules/default";
 
 describe("full-text search", () => {
   let client: Client;
@@ -43,7 +44,7 @@ describe("full-text search", () => {
       tc.IsExact<
         $infer<typeof allQuery>,
         {
-          object: Record<string, unknown>;
+          object: { id: string };
           score: number;
         }[]
       >
@@ -68,5 +69,9 @@ describe("full-text search", () => {
     }));
     const objectSelect = await objectSelectQuery.run(client);
     expect(objectSelect).toEqual([]);
+
+    tc.assert<tc.IsExact<$infer<typeof objectSelectQuery>, { text: string }[]>>(
+      true
+    );
   });
 });

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -63,8 +63,8 @@ describe("full-text search", () => {
 
     expect(noShape).toEqual(all);
 
-    const objectSelectQuery = e.select(searchExpr.object, () => ({
-      text: true,
+    const objectSelectQuery = e.select(searchExpr.object, (post) => ({
+      text: post.text,
     }));
     const objectSelect = await objectSelectQuery.run(client);
     expect(objectSelect).toEqual([]);

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -29,7 +29,9 @@ describe("full-text search", () => {
       })
       .run(client, { posts });
 
-    const allQuery = e.select(e.fts.search(e.Post, "search"), () => ({
+    const searchExpr = e.select(e.fts.search(e.Post, "search"));
+
+    const allQuery = e.select(searchExpr, (post) => ({
       object: true,
       score: true,
     }));
@@ -47,7 +49,7 @@ describe("full-text search", () => {
       >
     >(true);
 
-    const filteredQuery = e.select(e.fts.search(e.Post, "search"), (post) => ({
+    const filteredQuery = e.select(searchExpr, (post) => ({
       object: true,
       score: true,
       filter: e.op(post.score, ">", e.float64(0.81)),
@@ -55,5 +57,16 @@ describe("full-text search", () => {
     const filtered = await filteredQuery.run(client);
 
     expect(filtered.length).toBe(1);
+
+    const noShapeQuery = e.select(searchExpr);
+    const noShape = await noShapeQuery.run(client);
+
+    expect(noShape).toEqual(all);
+
+    const objectSelectQuery = e.select(searchExpr.object, () => ({
+      text: true,
+    }));
+    const objectSelect = await objectSelectQuery.run(client);
+    expect(objectSelect).toEqual([]);
   });
 });

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -50,12 +50,10 @@ describe("full-text search", () => {
     const filteredQuery = e.select(e.fts.search(e.Post, "search"), (post) => ({
       object: true,
       score: true,
-      filter: e.op(post.score, ">", e.float64(0.83)),
+      filter: e.op(post.score, ">", e.float64(0.81)),
     }));
-    console.log(filteredQuery.toEdgeQL());
     const filtered = await filteredQuery.run(client);
 
-    console.log(filtered);
     expect(filtered.length).toBe(1);
   });
 });

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -66,9 +66,16 @@ describe("full-text search", () => {
 
     const objectSelectQuery = e.select(searchExpr.object, (post) => ({
       text: post.text,
+      order_by: searchExpr.score,
     }));
     const objectSelect = await objectSelectQuery.run(client);
-    expect(objectSelect).toEqual([]);
+    expect(objectSelect).toEqual([
+      { text: posts[0] },
+      { text: posts[1] },
+      { text: posts[2] },
+      { text: posts[3] },
+      { text: posts[4] },
+    ]);
 
     tc.assert<tc.IsExact<$infer<typeof objectSelectQuery>, { text: string }[]>>(
       true

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -32,7 +32,7 @@ describe("full-text search", () => {
 
     const searchExpr = e.select(e.fts.search(e.Post, "search"));
 
-    const allQuery = e.select(searchExpr, (post) => ({
+    const allQuery = e.select(searchExpr, () => ({
       object: true,
       score: true,
     }));

--- a/integration-tests/stable/fts.test.ts
+++ b/integration-tests/stable/fts.test.ts
@@ -1,0 +1,61 @@
+import type { Client } from "edgedb";
+import e, { type $infer } from "./dbschema/edgeql-js";
+import { setupTests, tc, teardownTests } from "./setupTeardown";
+
+describe("full-text search", () => {
+  let client: Client;
+  beforeAll(async () => {
+    const setup = await setupTests();
+    ({ client } = setup);
+  });
+
+  afterAll(async () => {
+    await teardownTests(client);
+  }, 10_000);
+
+  test("basic fts", async () => {
+    const posts = [
+      "Full-text search is a technique for searching text content. It works by storing every unique word that appears in a document.",
+      "To perform a full-text search, the search engine examines all the words in the specified document or set of documents.",
+      "The process of full-text search begins with the user entering a string of characters (the search string).",
+      "The search engine then retrieves all instances of the search string in the document or collection of documents.",
+      "Full-text search can be used in many applications that require search capability, such as web search engines, document management systems, and digital libraries.",
+    ];
+    const inserted = await e
+      .params({ posts: e.array(e.str) }, (params) => {
+        return e.for(e.array_unpack(params.posts), (post) =>
+          e.insert(e.Post, { text: post })
+        );
+      })
+      .run(client, { posts });
+
+    const allQuery = e.select(e.fts.search(e.Post, "search"), () => ({
+      object: true,
+      score: true,
+    }));
+    const all = await allQuery.run(client);
+
+    expect(all.length).toBe(inserted.length);
+
+    tc.assert<
+      tc.IsExact<
+        $infer<typeof allQuery>,
+        {
+          object: Record<string, unknown>;
+          score: number;
+        }[]
+      >
+    >(true);
+
+    const filteredQuery = e.select(e.fts.search(e.Post, "search"), (post) => ({
+      object: true,
+      score: true,
+      filter: e.op(post.score, ">", e.float64(0.83)),
+    }));
+    console.log(filteredQuery.toEdgeQL());
+    const filtered = await filteredQuery.run(client);
+
+    console.log(filtered);
+    expect(filtered.length).toBe(1);
+  });
+});

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -16,7 +16,7 @@
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.2",
-    "edgedb": "workspaces:*"
+    "edgedb": "^1.4.1"
   },
   "dependencies": {}
 }

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -15,7 +15,8 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "edgedb": "workspaces:*"
   },
   "dependencies": {}
 }

--- a/packages/generate/src/edgeql-js/generateObjectTypes.ts
+++ b/packages/generate/src/edgeql-js/generateObjectTypes.ts
@@ -40,7 +40,7 @@ export const getStringRepresentation: (
   }
   if (type.name === "anyobject") {
     return {
-      staticType: [`$.AnyObjectType`],
+      staticType: frag`${params.anytype ?? "$.AnyObjectType"}`,
       runtimeType: [],
     };
   }

--- a/packages/generate/src/syntax/hydrate.ts
+++ b/packages/generate/src/syntax/hydrate.ts
@@ -98,7 +98,7 @@ export function makeType<T extends BaseType>(
 ): T {
   const type = spec.get(id);
 
-  if (type.name === "anytype" || type.name === "std::anypoint") {
+  if (type.name === "anytype" || type.name === "std::anypoint" || type.name === "anyobject") {
     if (anytype) return anytype as unknown as T;
     throw new Error("anytype not provided");
   }

--- a/packages/generate/src/syntax/hydrate.ts
+++ b/packages/generate/src/syntax/hydrate.ts
@@ -98,7 +98,11 @@ export function makeType<T extends BaseType>(
 ): T {
   const type = spec.get(id);
 
-  if (type.name === "anytype" || type.name === "std::anypoint" || type.name === "anyobject") {
+  if (
+    type.name === "anytype" ||
+    type.name === "std::anypoint" ||
+    type.name === "anyobject"
+  ) {
     if (anytype) return anytype as unknown as T;
     throw new Error("anytype not provided");
   }

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -23,6 +23,7 @@ import type {
   BaseType,
   Expression,
   LinkDesc,
+  NamedTupleType,
   ObjectType,
   ObjectTypePointers,
   ObjectTypeSet,
@@ -171,16 +172,28 @@ type pathifyLinkProps<
     : unknown;
 };
 
-export type getPropsShape<T extends ObjectType> = typeutil.flatten<
-  typeutil.stripNever<{
-    [k in keyof T["__pointers__"]]: T["__pointers__"][k]["__kind__"] extends "property"
-      ? true
-      : never;
-  }>
->;
+export type getPropsShape<T extends ObjectType | NamedTupleType> =
+  typeutil.flatten<
+    typeutil.stripNever<
+      T extends ObjectType
+        ? {
+            [k in keyof T["__pointers__"]]: T["__pointers__"][k]["__kind__"] extends "property"
+              ? true
+              : never;
+          }
+        : {
+            [k in keyof T["__shape__"]]: T["__shape__"][k]["__kind__"] extends "property"
+              ? true
+              : never;
+          }
+    >
+  >;
 
 export type $expr_PathNode<
-  Root extends ObjectTypeSet = ObjectTypeSet,
+  Root extends TypeSet<
+    ObjectType | NamedTupleType,
+    Cardinality
+  > = ObjectTypeSet,
   Parent extends PathParent | null = PathParent | null
   // Exclusive extends boolean = boolean
 > = Expression<{

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -20,6 +20,7 @@ import { $toEdgeQL } from "./toEdgeQL";
 import { $queryFunc, $queryFuncJSON } from "./query";
 
 import type {
+  $expr_TuplePath,
   BaseType,
   Expression,
   LinkDesc,
@@ -190,10 +191,7 @@ export type getPropsShape<T extends ObjectType | NamedTupleType> =
   >;
 
 export type $expr_PathNode<
-  Root extends TypeSet<
-    ObjectType | NamedTupleType,
-    Cardinality
-  > = ObjectTypeSet,
+  Root extends TypeSet<ObjectType, Cardinality> = ObjectTypeSet,
   Parent extends PathParent | null = PathParent | null
   // Exclusive extends boolean = boolean
 > = Expression<{
@@ -328,7 +326,11 @@ export function $pathify<Root extends TypeSet, Parent extends PathParent>(
     return _root as any;
   }
 
-  const root: $expr_PathNode<ObjectTypeSet> = _root as any;
+  const root: $expr_PathNode<ObjectTypeSet> | $expr_TuplePath = _root as any;
+
+  if (root.__kind__ === ExpressionKind.TuplePath) {
+    return _root as any;
+  }
 
   let pointers = {
     ...root.__element__.__pointers__,

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -309,24 +309,20 @@ const pathifyProxyHandlers: ProxyHandler<any> = {
   },
 };
 
-export function $pathify<Root extends TypeSet, Parent extends PathParent>(
-  _root: Root
-): $pathify<Root> {
+export function $pathify<Root extends TypeSet>(_root: Root): $pathify<Root> {
   if (_root.__element__.__kind__ !== TypeKind.object) {
-    return _root as any;
+    return _root as $pathify<Root>;
   }
 
-  const root: $expr_PathNode<ObjectTypeSet> | $expr_TuplePath = _root as any;
-
-  if (root.__kind__ === ExpressionKind.TuplePath) {
-    return _root as any;
-  }
+  const root = _root as unknown as
+    | $expr_PathNode<ObjectTypeSet>
+    | $expr_TuplePath<ObjectType>;
 
   let pointers = {
     ...root.__element__.__pointers__,
   };
 
-  if (root.__parent__) {
+  if (root.__parent__ && root.__kind__ !== ExpressionKind.TuplePath) {
     const { type, linkName } = root.__parent__;
     const parentPointer = type.__element__.__pointers__[linkName];
     if (parentPointer?.__kind__ === "link") {

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -24,7 +24,6 @@ import type {
   BaseType,
   Expression,
   LinkDesc,
-  NamedTupleType,
   ObjectType,
   ObjectTypePointers,
   ObjectTypeSet,
@@ -173,25 +172,16 @@ type pathifyLinkProps<
     : unknown;
 };
 
-export type getPropsShape<T extends ObjectType | NamedTupleType> =
-  typeutil.flatten<
-    typeutil.stripNever<
-      T extends ObjectType
-        ? {
-            [k in keyof T["__pointers__"]]: T["__pointers__"][k]["__kind__"] extends "property"
-              ? true
-              : never;
-          }
-        : {
-            [k in keyof T["__shape__"]]: T["__shape__"][k]["__kind__"] extends "property"
-              ? true
-              : never;
-          }
-    >
-  >;
+export type getPropsShape<T extends ObjectType> = typeutil.flatten<
+  typeutil.stripNever<{
+    [k in keyof T["__pointers__"]]: T["__pointers__"][k]["__kind__"] extends "property"
+      ? true
+      : never;
+  }>
+>;
 
 export type $expr_PathNode<
-  Root extends TypeSet<ObjectType, Cardinality> = ObjectTypeSet,
+  Root extends ObjectTypeSet = ObjectTypeSet,
   Parent extends PathParent | null = PathParent | null
   // Exclusive extends boolean = boolean
 > = Expression<{

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -36,6 +36,7 @@ import type {
   ExclusiveTuple,
   orLiteralValue,
   NamedTupleType,
+  $expr_TuplePath,
 } from "./typesystem";
 
 import {
@@ -930,7 +931,7 @@ export function select<
   Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,
-  shape: (scope: $scopify<Expr["__element__"]>) => Readonly<Shape>
+  shape: (scope: $expr_TuplePath<Expr["__element__"], Cardinality.One>) => Readonly<Shape>
 ): $expr_Select<{
   __element__: NamedTupleType<Expr["__element__"]["__shape__"]>;
   __cardinality__: ComputeSelectCardinality<Expr, Modifiers>;

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -1125,8 +1125,7 @@ function resolveShape(
 
   // get scoped object if expression is objecttypeset
   const scope =
-    expr.__element__.__kind__ === TypeKind.object ||
-    expr.__element__.__kind__ === TypeKind.namedtuple
+    expr.__element__.__kind__ === TypeKind.object
       ? $getScopedExpr(expr as any, $existingScopes)
       : expr;
 

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -112,7 +112,9 @@ export type exclusivesToFilterSingle<E extends ExclusiveTuple> =
             : orLiteralValue<E[j][k]>;
         };
       }[number];
-export type SelectModifiers<T extends ObjectType = ObjectType> = {
+export type SelectModifiers<
+  T extends ObjectType | NamedTupleType = ObjectType
+> = {
   // export type SelectModifiers = {
   filter?: SelectFilterExpression;
   filter_single?: // | Partial<
@@ -144,7 +146,9 @@ export type SelectModifiers<T extends ObjectType = ObjectType> = {
   //               : never
   //             : never;
   //         }>)
-  exclusivesToFilterSingle<T["__exclusives__"]> | SelectFilterExpression;
+  T extends ObjectType
+    ? exclusivesToFilterSingle<T["__exclusives__"]> | SelectFilterExpression
+    : never;
 
   // | (ObjectType extends T
   //     ? unknown
@@ -922,7 +926,7 @@ export function select<
 export function select<
   Expr extends TypeSet<NamedTupleType, Cardinality>,
   Shape extends namedTupleTypeToSelectShape<Expr["__element__"]> &
-    Omit<NormalisedSelectModifiers, "singleton">,
+    SelectModifiers<Expr["__element__"]>,
   Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -931,7 +931,9 @@ export function select<
   Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,
-  shape: (scope: $expr_TuplePath<Expr["__element__"], Cardinality.One>) => Readonly<Shape>
+  shape: (
+    scope: $expr_TuplePath<Expr["__element__"], Cardinality.One>
+  ) => Readonly<Shape>
 ): $expr_Select<{
   __element__: NamedTupleType<Expr["__element__"]["__shape__"]>;
   __cardinality__: ComputeSelectCardinality<Expr, Modifiers>;

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -149,13 +149,16 @@ export function $toEdgeQL(this: any) {
     if (withVars.has(expr)) {
       continue;
     }
-
     // ignore unbound leaves, nodes, and intersections
     // these should be rendered as is
     if (
       !refData.boundScope &&
       (expr.__kind__ === ExpressionKind.PathLeaf ||
         expr.__kind__ === ExpressionKind.PathNode ||
+        expr.__kind__ === ExpressionKind.TuplePath ||
+        (expr.__kind__ === ExpressionKind.Select &&
+          (expr.__expr__ as SomeExpression).__kind__ ===
+            ExpressionKind.TuplePath) ||
         expr.__kind__ === ExpressionKind.TypeIntersection)
     ) {
       continue;

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -264,7 +264,7 @@ export interface PropertyDesc<
   hasDefault: HasDefault;
 }
 
-export type $scopify<Type extends ObjectType | NamedTupleType> = $expr_PathNode<
+export type $scopify<Type extends ObjectType> = $expr_PathNode<
   TypeSet<Type, Cardinality.One>
   // null,
   // true // exclusivity

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -264,7 +264,7 @@ export interface PropertyDesc<
   hasDefault: HasDefault;
 }
 
-export type $scopify<Type extends ObjectType> = $expr_PathNode<
+export type $scopify<Type extends ObjectType | NamedTupleType> = $expr_PathNode<
   TypeSet<Type, Cardinality.One>
   // null,
   // true // exclusivity


### PR DESCRIPTION
We noticed that actually _using_ full-text search from the query builder wasn't working due to a few things:

- We were not properly returning the `anytype` in the new `anyobject` case
- We did not have an overload or code path that expected a named tuple in the "expression" position of a select expression.

---

TODO:
- [x] Add more overloads for handling no-shape selects
- [ ] Check regular tuples
