### PR TITLE
Use latest npm-publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,19 +43,19 @@ jobs:
 
       - id: publish_driver
         name: Publish 'edgedb' to NPM
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/driver/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
 
       - name: If publish 'edgedb'
-        if: steps.publish_driver.outputs.type != 'none'
+        if: steps.publish_driver.outputs.type
         run: |
           echo "Published ${{ steps.publish_driver.outputs.type }} version: ${{ steps.publish_driver.outputs.version }}"
 
       - name: If 'edgedb' version unchanged
-        if: steps.publish_driver.outputs.type == 'none'
+        if: !steps.publish_driver.outputs.type
         run: |
           echo "Version in package.json has not changed. Skipping."
 
@@ -76,7 +76,7 @@ jobs:
             }
 
       - name: Create 'edgedb' Release
-        if: steps.publish_driver.outputs.type != 'none'
+        if: steps.publish_driver.outputs.type
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,19 +95,19 @@ jobs:
 
       - id: publish_generate
         name: Publish '@edgedb/generate' to NPM
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/generate/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
 
       - name: If publish '@edgedb/generate'
-        if: steps.publish_generate.outputs.type != 'none'
+        if: steps.publish_generate.outputs.type
         run: |
           echo "Published ${{ steps.publish_generate.outputs.type }} version: ${{ steps.publish_generate.outputs.version }}"
 
       - name: If '@edgedb/generate' version unchanged
-        if: steps.publish_generate.outputs.type == 'none'
+        if: !steps.publish_generate.outputs.type
         run: |
           echo "Version in package.json has not changed. Skipping."
 
@@ -128,7 +128,7 @@ jobs:
             }
 
       - name: Create '@edgedb/generate' Release
-        if: steps.publish_generate.outputs.type != 'none'
+        if: steps.publish_generate.outputs.type
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,19 +147,19 @@ jobs:
 
       - id: publish_auth_core
         name: Publish '@edgedb/auth-core' to NPM
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-core/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
 
       - name: If publish '@edgedb/auth-core'
-        if: steps.publish_auth_core.outputs.type != 'none'
+        if: steps.publish_auth_core.outputs.type
         run: |
           echo "Published ${{ steps.publish_auth_core.outputs.type }} version: ${{ steps.publish_auth_core.outputs.version }}"
 
       - name: If '@edgedb/auth-core' version unchanged
-        if: steps.publish_auth_core.outputs.type == 'none'
+        if: !steps.publish_auth_core.outputs.type
         run: |
           echo "Version in package.json has not changed. Skipping."
 
@@ -180,7 +180,7 @@ jobs:
             }
 
       - name: Create '@edgedb/auth-core' Release
-        if: steps.publish_auth_core.outputs.type != 'none'
+        if: steps.publish_auth_core.outputs.type
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -199,19 +199,19 @@ jobs:
 
       - id: publish_auth_nextjs
         name: Publish '@edgedb/auth-nextjs' to NPM
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-nextjs/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
 
       - name: If publish '@edgedb/auth-nextjs'
-        if: steps.publish_auth_nextjs.outputs.type != 'none'
+        if: steps.publish_auth_nextjs.outputs.type
         run: |
           echo "Published ${{ steps.publish_auth_nextjs.outputs.type }} version: ${{ steps.publish_auth_nextjs.outputs.version }}"
 
       - name: If '@edgedb/auth-nextjs' version unchanged
-        if: steps.publish_auth_nextjs.outputs.type == 'none'
+        if: !steps.publish_auth_nextjs.outputs.type
         run: |
           echo "Version in package.json has not changed. Skipping."
 
@@ -232,7 +232,7 @@ jobs:
             }
 
       - name: Create '@edgedb/auth-nextjs' Release
-        if: steps.publish_auth_nextjs.outputs.type != 'none'
+        if: steps.publish_auth_nextjs.outputs.type
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,11 +57,6 @@ jobs:
         with:
           deno-version: v1.x
 
-      # - uses: bahmutov/npm-install@v1.8.15
-      # - uses: bahmutov/npm-install@v1.8.15
-      #   with:
-      #     working-directory: qb
-
       - name: Install dev deps
         run: |
           yarn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
-        node-version: ["16", "18", "20"]
+        node-version: ["18", "20"]
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
         include:
@@ -29,9 +29,6 @@ jobs:
           - os: ubuntu-latest
             node-version: "18"
             edgedb-version: "2"
-          - os: ubuntu-latest
-            node-version: "18"
-            edgedb-version: "1"
           - os: macos-latest
             node-version: "18"
             edgedb-version: "stable"
@@ -108,7 +105,7 @@ jobs:
           yarn workspace @edgedb/generate test:ci
 
       - name: Run query builder integration tests legacy
-        if: ${{ matrix.edgedb-version == '1' || matrix.edgedb-version == '2' }}
+        if: ${{ matrix.edgedb-version == '2' }}
         run: |
           yarn workspace @edgedb/integration-legacy test:ci
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.30.x
+          deno-version: v1.x
 
       # - uses: bahmutov/npm-install@v1.8.15
       # - uses: bahmutov/npm-install@v1.8.15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,6 @@ jobs:
         uses: edgedb/setup-edgedb@8bc9e10005674ec772652b86e1fdd476e6462284
         with:
           instance-name: test
-          cli-version: 3.5
           server-version: ${{ matrix.edgedb-version }}
 
       - name: Show actual EdgeDB server version

--- a/integration-tests/legacy/package.json
+++ b/integration-tests/legacy/package.json
@@ -15,7 +15,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -21,7 +21,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/nightly/package.json
+++ b/integration-tests/nightly/package.json
@@ -15,7 +15,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -15,7 +15,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "lint": "tslint 'packages/*/src/**/*.ts'",

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -21,12 +21,12 @@
     "gen-consts": "node genConsts.js"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.2",
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
-    "typescript": "5.0.4",
-    "@types/jest": "^29.5.2",
     "jest": "29.5.0",
-    "ts-jest": "29.1.0"
+    "ts-jest": "29.1.0",
+    "typescript": "^5.2.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-nextjs/package.json
+++ b/packages/auth-nextjs/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
-    "typescript": "5.0.4",
-    "next": "13.5.6"
+    "next": "13.5.6",
+    "typescript": "^5.2.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -34,7 +34,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "29.1.0",
     "tsx": "^3.12.7",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "build": "echo 'Building edgedb-js...' && rm -rf dist && yarn build:cjs && yarn build:deno",

--- a/packages/driver/src/baseConn.ts
+++ b/packages/driver/src/baseConn.ts
@@ -472,9 +472,9 @@ export class BaseRawConnection {
 
     this._sendData(wb.unwrap());
 
-    let cardinality: number | void;
-    let inTypeId: uuid | void;
-    let outTypeId: uuid | void;
+    let cardinality: number | null = null;
+    let inTypeId: uuid | null = null;
+    let outTypeId: uuid | null = null;
     let inCodec: ICodec | null;
     let outCodec: ICodec | null;
     let capabilities: number = -1;

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -30,7 +30,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {},
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,10 +3647,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 undici-types@~5.25.1:
   version "5.25.3"


### PR DESCRIPTION
This fixes an issue in v1 where the action was overriding the `.npmrc` file which was causing subsequent calls to `npm` or `yarn` to have a malformed `.npmrc`. This was fixed in v2. We are pinning the action to version v3.0.1 which is the latest version as of today.

The other notable change here:

> The `type` output is now an empty string instead of 'none' when no release occurs

https://github.com/JS-DevTools/npm-publish/tree/v3.0.1#v2-output-changes
 