### PR TITLE
Use Web-compatible crypto for PKCE

### DIFF
--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -3,14 +3,14 @@ if (!globalThis.crypto) {
   globalThis.crypto = require("node:crypto").webcrypto;
 }
 
-export function bytesToBase64Url(bytes: Uint8Array): string {
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-  let base64url = "";
-  let i = 0;
+const BASE64_URL_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+export function bytesToBase64Url(bytes: Uint8Array): string {
   const len = bytes.length;
-  for (; i < len; i += 3) {
+  let base64url = "";
+
+  for (let i = 0; i < len; i += 3) {
     const b1 = bytes[i] & 0xff;
     const b2 = i + 1 < len ? bytes[i + 1] & 0xff : 0;
     const b3 = i + 2 < len ? bytes[i + 2] & 0xff : 0;
@@ -20,12 +20,12 @@ export function bytesToBase64Url(bytes: Uint8Array): string {
     const enc3 = ((b2 & 0x0f) << 2) | (b3 >> 6);
     const enc4 = b3 & 0x3f;
 
-    base64url += chars.charAt(enc1) + chars.charAt(enc2);
+    base64url += BASE64_URL_CHARS.charAt(enc1) + BASE64_URL_CHARS.charAt(enc2);
     if (i + 1 < len) {
-      base64url += chars.charAt(enc3);
+      base64url += BASE64_URL_CHARS.charAt(enc3);
     }
     if (i + 2 < len) {
-      base64url += chars.charAt(enc4);
+      base64url += BASE64_URL_CHARS.charAt(enc4);
     }
   }
 

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -33,11 +33,10 @@ export function bytesToBase64Url(bytes: Uint8Array): string {
 }
 
 export async function sha256(
-  bytes: BufferSource | string
+  source: BufferSource | string
 ): Promise<Uint8Array> {
-  if (typeof bytes === "string") {
-    bytes = new TextEncoder().encode(bytes);
-  }
+  const bytes =
+    typeof source === "string" ? new TextEncoder().encode(source) : source;
   return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
 }
 

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -1,6 +1,8 @@
+/* eslint @typescript-eslint/no-var-requires: ["off"] */
+
 // TODO: Drop when Node 18 is EOL: 2025-04-30
 if (!globalThis.crypto) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // tslint:disable-next-line: no-var-requires
   globalThis.crypto = require("node:crypto").webcrypto;
 }
 

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -1,0 +1,46 @@
+if (!globalThis.crypto) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  globalThis.crypto = require("node:crypto").webcrypto;
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  let base64url = "";
+  let i = 0;
+
+  const len = bytes.length;
+  for (; i < len; i += 3) {
+    const b1 = bytes[i] & 0xff;
+    const b2 = i + 1 < len ? bytes[i + 1] & 0xff : 0;
+    const b3 = i + 2 < len ? bytes[i + 2] & 0xff : 0;
+
+    const enc1 = b1 >> 2;
+    const enc2 = ((b1 & 0x03) << 4) | (b2 >> 4);
+    const enc3 = ((b2 & 0x0f) << 2) | (b3 >> 6);
+    const enc4 = b3 & 0x3f;
+
+    base64url += chars.charAt(enc1) + chars.charAt(enc2);
+    if (i + 1 < len) {
+      base64url += chars.charAt(enc3);
+    }
+    if (i + 2 < len) {
+      base64url += chars.charAt(enc4);
+    }
+  }
+
+  return base64url;
+}
+
+export async function sha256(
+  bytes: BufferSource | string
+): Promise<Uint8Array> {
+  if (typeof bytes === "string") {
+    bytes = new TextEncoder().encode(bytes);
+  }
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+export function randomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length));
+}

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -1,3 +1,4 @@
+// TODO: Drop when Node 18 is EOL: 2025-04-30
 if (!globalThis.crypto) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   globalThis.crypto = require("node:crypto").webcrypto;

--- a/packages/auth-core/src/pkce.ts
+++ b/packages/auth-core/src/pkce.ts
@@ -1,14 +1,11 @@
-import crypto from "node:crypto";
+import { bytesToBase64Url, sha256, randomBytes } from "./crypto";
 
-export function createVerifierChallengePair(): {
+export async function createVerifierChallengePair(): Promise<{
   verifier: string;
   challenge: string;
-} {
-  const verifier = crypto.randomBytes(32).toString("base64url");
-  const challenge = crypto
-    .createHash("sha256")
-    .update(verifier)
-    .digest("base64url");
+}> {
+  const verifier = bytesToBase64Url(randomBytes(32));
+  const challenge = await sha256(verifier).then(bytesToBase64Url);
 
   return { verifier, challenge };
 }

--- a/packages/auth-core/test/crypto.test.ts
+++ b/packages/auth-core/test/crypto.test.ts
@@ -1,0 +1,33 @@
+import crypto from "node:crypto";
+import { bytesToBase64Url, sha256, randomBytes } from "../src/crypto";
+
+describe("crypto", () => {
+  describe("bytesToBase64Url", () => {
+    test("Equivalent to Buffer implementation", () => {
+      for (let i = 0; i < 100; i++) {
+        const buffer = crypto.randomBytes(32);
+        expect(buffer.toString("base64url")).toEqual(bytesToBase64Url(buffer));
+      }
+    });
+  });
+
+  describe("sha256", () => {
+    test("Equivalent to Node crypto SHA256 implementation", async () => {
+      for (let i = 0; i < 100; i++) {
+        const buffer = crypto.randomBytes(32);
+        expect(crypto.createHash("sha256").update(buffer).digest()).toEqual(
+          Buffer.from(await sha256(buffer))
+        );
+      }
+    });
+  });
+
+  describe("randomBytes", () => {
+    test("Generates Uint8Array of correct length", () => {
+      const length = 32;
+      const bytes = randomBytes(length);
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toEqual(length);
+    });
+  });
+});

--- a/packages/auth-nextjs/src/app/index.ts
+++ b/packages/auth-nextjs/src/app/index.ts
@@ -76,7 +76,9 @@ export class NextAppAuth extends NextAuth {
               throw new Error(`invalid provider_name: ${provider}`);
             }
             const redirectUrl = `${this._authRoute}/oauth/callback`;
-            const pkceSession = (await this.core).createPKCESession();
+            const pkceSession = await this.core.then((core) =>
+              core.createPKCESession()
+            );
             cookies().set({
               name: this.options.pkceVerifierCookieName,
               value: pkceSession.verifier,
@@ -238,7 +240,9 @@ export class NextAppAuth extends NextAuth {
           }
           case "builtin/signin":
           case "builtin/signup": {
-            const pkceSession = (await this.core).createPKCESession();
+            const pkceSession = await this.core.then((core) =>
+              core.createPKCESession()
+            );
             cookies().set({
               name: this.options.pkceVerifierCookieName,
               value: pkceSession.verifier,


### PR DESCRIPTION
Closes #779 

I considered doing something dynamic to use `node:crypto` if run in the Node environment but that had two drawbacks: complexity, and making it harder to test. Since this path is not a hot-path, it doesn't seem like a good candidate for the tradeoff of complexity and performance that having a dynamic dispatch would provide.