### PR TITLE
Use the configured passwordResetUrl in `auth-nextjs`

### DIFF
--- a/packages/auth-nextjs/src/app/index.ts
+++ b/packages/auth-nextjs/src/app/index.ts
@@ -466,7 +466,7 @@ export class NextAppAuth extends NextAuth {
         }
       },
       emailPasswordSendPasswordResetEmail: async (
-        data: FormData | { email: string; resetUrl: string }
+        data: FormData | { email: string }
       ) => {
         if (!this.options.passwordResetUrl) {
           throw new Error(`'passwordResetUrl' option not configured`);

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -24,6 +24,7 @@ export abstract class NextAuth {
       authCookieName: options.authCookieName ?? "edgedb-session",
       pkceVerifierCookieName:
         options.pkceVerifierCookieName ?? "edgedb-pkce-verifier",
+      passwordResetUrl: options.passwordResetUrl,
     };
   }
 


### PR DESCRIPTION
When requesting the reset password email, the URL from config is used, but was not really set during `auth` initialization.
The `resetUrl` param is not supported, so I've removed it from the type.