### PR TITLE
Support new functional `if..then..else` syntax

### DIFF
--- a/integration-tests/lts/operators.test.ts
+++ b/integration-tests/lts/operators.test.ts
@@ -26,20 +26,22 @@ describe("operators", () => {
     cardinality: T["__cardinality__"],
     edgeql?: string
   ) {
-    assert.deepEqual(expr.__name__, name);
-    assert.deepEqual(
-      superjson.stringify(expr.__args__),
-      superjson.stringify(args.filter((arg) => arg !== undefined))
-    );
-    assert.deepEqual(expr.__element__, returnType);
-    assert.deepEqual(expr.__cardinality__, cardinality);
+    test(`${name} operator: expect ${edgeql ?? "(NO EDGEQL)"}`, async () => {
+      assert.deepEqual(expr.__name__, name);
+      assert.deepEqual(
+        superjson.stringify(expr.__args__),
+        superjson.stringify(args.filter((arg) => arg !== undefined))
+      );
+      assert.deepEqual(expr.__element__, returnType);
+      assert.deepEqual(expr.__cardinality__, cardinality);
 
-    if (edgeql) {
-      assert.deepEqual(expr.toEdgeQL(), edgeql);
-    }
+      if (edgeql) {
+        assert.deepEqual(expr.toEdgeQL(), edgeql);
+      }
+    });
   }
 
-  test("slice and index ops", () => {
+  describe("slice and index ops", () => {
     checkOperatorExpr(
       e.str("test string")["2:5"],
       "[]",
@@ -113,7 +115,7 @@ describe("operators", () => {
     );
   });
 
-  test("if else op", () => {
+  describe("if else op", () => {
     checkOperatorExpr(
       e.op(
         "this",
@@ -202,6 +204,15 @@ describe("operators", () => {
       e.str,
       $.Cardinality.AtMostOne,
       `"this" IF (42 = <std::float32>42) ELSE <std::str>{}`
+    );
+
+    checkOperatorExpr(
+      e.op("if", e.bool(true), "then", e.int64(1), "else", e.int64(2)),
+      "if_else",
+      [e.int64(1), e.bool(true), e.int64(2)],
+      e.int64,
+      $.Cardinality.One,
+      `<std::int64>1 IF true ELSE <std::int64>2`
     );
   });
 

--- a/packages/driver/src/reflection/queries/operators.ts
+++ b/packages/driver/src/reflection/queries/operators.ts
@@ -1,10 +1,11 @@
-import { Executor } from "../../ifaces";
+import type { Executor } from "../../ifaces";
 import { StrictMap } from "../strictMap";
 
-import { FuncopParam, replaceNumberTypes, FuncopTypemod } from "./functions";
+import type { FuncopParam, FuncopTypemod } from "./functions";
+import { replaceNumberTypes } from "./functions";
 import { util } from "../util";
-import { typeutil } from "../typeutil";
-import { OperatorKind } from "../enums";
+import type { typeutil } from "../typeutil";
+import type { OperatorKind } from "../enums";
 
 export type { FuncopTypemod };
 
@@ -49,7 +50,7 @@ const _operators = async (cxn: Executor) => {
 
   for (const op of JSON.parse(operatorsJson)) {
     const identifier = op.annotations.find(
-      (anno: any) => anno.name === "std::identifier"
+      (anno: { name: string }) => anno.name === "std::identifier"
     )?.["@value"];
 
     if (!identifier) {
@@ -70,7 +71,7 @@ const _operators = async (cxn: Executor) => {
       kind: op.operator_kind,
       originalName: op.name,
       description: op.annotations.find(
-        (anno: any) => anno.name === "std::description"
+        (anno: { name: string }) => anno.name === "std::description"
       )?.["@value"],
       annotations: undefined,
     };

--- a/packages/generate/src/edgeql-js/generateOperatorTypes.ts
+++ b/packages/generate/src/edgeql-js/generateOperatorTypes.ts
@@ -108,7 +108,8 @@ export function generateOperators({
         overloadIndex++;
       }
 
-      const operatorForms = opName === "std::if_else" ? ["PYTHON", "FUNCTIONAL"] : ["NORMAL"];
+      const operatorForms =
+        opName === "std::if_else" ? ["PYTHON", "FUNCTIONAL"] : ["NORMAL"];
       for (const operatorForm of operatorForms) {
         if (opDef.description) {
           overloadsBuf.writeln([
@@ -196,7 +197,7 @@ export function generateOperators({
                 } else {
                   overloadsBuf.writeln([
                     t`op: "if", ${args[1]}, op2: "then", ${args[0]}, op3: "else", ${args[2]}`,
-                  ])
+                  ]);
                 }
               } else {
                 throw new Error(`unknown ternary operator: ${opName}`);

--- a/packages/generate/src/syntax/funcops.ts
+++ b/packages/generate/src/syntax/funcops.ts
@@ -1,6 +1,6 @@
 import {
   Cardinality,
-  introspect,
+  type introspect,
   TypeKind,
 } from "edgedb/dist/reflection/index";
 import { cardutil } from "./cardinality";


### PR DESCRIPTION
We still map this to the old style in the generated EdgeQL for now. Since the reflection doesn't give us separate operator definitions, we don't have an easy way to reflect which form is available to you.

We can make this distinction in the future by providing an optional `__form__` expression property and generating the appropriate EdgeQL based on that, but for now since we don't have an easy way to tell ifthe EdgeDB server supports it without hardcoding some notion of that into the generated logic, seems best to not do this yet.

Closes #794 