### PR TITLE
Update `@edgedb/auth-express` module spec

### DIFF
--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -17,6 +17,7 @@
   "exports": {
     "./*": "./dist/*/index.js"
   },
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc --project tsconfig.json"
   },

--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -13,6 +13,7 @@
   "files": [
     "/dist"
   ],
+  "main": "./dist/index.js",
   "exports": {
     "./*": "./dist/*/index.js"
   },

--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -2,6 +2,7 @@
   "name": "@edgedb/auth-express",
   "description": "Helper library to integrate the EdgeDB Auth extension with Express",
   "version": "0.1.0-beta.1",
+  "type": "module",
   "author": "EdgeDB <info@edgedb.com>",
   "repository": {
     "type": "git",
@@ -14,10 +15,13 @@
     "/dist"
   ],
   "main": "./dist/index.js",
-  "exports": {
-    "./*": "./dist/*/index.js"
-  },
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc --project tsconfig.json"
   },
@@ -29,9 +33,9 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
+    "cookie-parser": "^1.4.6",
     "edgedb": "^1.3.6",
-    "express": "^4.18.2",
-    "cookie-parser": "^1.4.6"
+    "express": "^4.18.2"
   },
   "dependencies": {
     "@edgedb/auth-core": "0.1.0-beta.1"

--- a/packages/auth-express/tsconfig.json
+++ b/packages/auth-express/tsconfig.json
@@ -2,12 +2,9 @@
   "compilerOptions": {
     "declarationDir": "./dist",
     "outDir": "./dist",
-    "lib": [
-      "ESNext"
-    ],
-    "target": "ESNext",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "declaration": true,
     "strict": true,
     "downlevelIteration": true,

--- a/packages/auth-express/tsconfig.json
+++ b/packages/auth-express/tsconfig.json
@@ -1,17 +1,11 @@
 {
   "compilerOptions": {
-    "declarationDir": "./dist",
     "outDir": "./dist",
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "declaration": true,
+    "module": "node16",
+    "target": "es2020",
     "strict": true,
-    "downlevelIteration": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "isolatedModules": true
+    "verbatimModuleSyntax": true,
+    "declaration": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Noticed that TypeScript was complaining about missing types, so did a [little bit of research](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports) on how declaration files are found during module resolution and came up with this minimal addition which fixes the issue locally in the example app I'm working on.