### PR TITLE
Update docs and tests for optional parameters on update

### DIFF
--- a/docs/funcops.rst
+++ b/docs/funcops.rst
@@ -24,6 +24,8 @@ All built-in standard library functions are reflected as functions in ``e``.
   // math::mean({3, 5, 7})
 
 
+.. _edgedb-js-funcops-prefix:
+
 Prefix operators
 ^^^^^^^^^^^^^^^^
 
@@ -43,6 +45,8 @@ Prefix operators operate on a single argument: ``OPERATOR <arg>``.
   * - ``"exists"`` ``"distinct"`` ``"not"``
 
 
+.. _edgedb-js-funcops-infix:
+
 Infix operators
 ^^^^^^^^^^^^^^^
 
@@ -60,6 +64,8 @@ Infix operators operate on two arguments: ``<arg> OPERATOR <arg>``.
       ``"^"`` ``"in"`` ``"not in"`` ``"union"`` ``"??"`` ``"++"`` ``"like"``
       ``"ilike"`` ``"not like"`` ``"not ilike"``
 
+
+.. _edgedb-js-funcops-ternary:
 
 Ternary operators
 ^^^^^^^^^^^^^^^^^

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -47,6 +47,8 @@ an expression inside a larger query.
   wrappedQuery.run(client, {name: "Harry Styles"});
 
 
+.. _edgedb-js-optional-parameters:
+
 Optional parameters
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/update.rst
+++ b/docs/update.rst
@@ -7,8 +7,8 @@ Update objects with the ``e.update`` function.
 
 .. code-block:: typescript
 
-  e.update(e.Movie, movie => ({
-    filter_single: {title: "Avengers 4"},
+  e.update(e.Movie, () => ({
+    filter_single: { title: "Avengers 4" },
     set: {
       title: "Avengers: Endgame"
     }
@@ -19,12 +19,27 @@ You can reference the current value of the object's properties.
 
 .. code-block:: typescript
 
-  e.update(e.Movie, movie => ({
+  e.update(e.Movie, (movie) => ({
     filter: e.op(movie.title[0], '=', ' '),
     set: {
       title: e.str_trim(movie.title)
     }
   }))
+
+You can conditionally update a property by using an :ref:`optional parameter
+<edgedb-js-optional-parameters>` and the :ref:`coalescing infix operator
+<edgedb-js-funcops-infix>`.
+
+.. code-block:: typescript
+
+  e.params({ id: e.uuid, title: e.optional(e.str) }, (params) =>
+    e.update(e.Movie, (movie) => ({
+      filter_single: { id: params.id },
+      set: {
+        title: e.op(params.title, "??", movie.title),
+      }
+    }))
+  );
 
 
 Updating links

--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -188,16 +188,32 @@ describe("update", () => {
   });
 
   test("optional prop update", async () => {
+    const theAvengers = await e
+      .select(e.Movie, (movie) => ({
+        filter: e.op(movie.title, "=", "The Avengers"),
+        limit: 1,
+      }))
+      .assert_single()
+      .run(client);
+    assert.ok(theAvengers);
+
     const query = e.params({ title: e.optional(e.str) }, (params) => {
       return e.update(e.Movie, (m) => ({
-        filter_single: { title: "not a real title" },
+        filter_single: { id: theAvengers.id },
         set: {
-          // Error here
-          title: params.title,
+          title: e.op(params.title, "??", m.title),
         },
       }));
     });
-    await query.run(client, { title: "still not real" });
+    await query.run(client, { title: "The Avengers!" });
+
+    const selected = await e.select(e.Movie, () => ({
+      id: true,
+      title: true,
+      filter_single: { id: theAvengers.id },
+    })).run(client);
+    assert.ok(selected);
+    assert.equal(selected.title, "The Avengers!");
   });
 
   test("exclude readonly props", () => {

--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -189,11 +189,7 @@ describe("update", () => {
 
   test("optional prop update", async () => {
     const theAvengers = await e
-      .select(e.Movie, (movie) => ({
-        filter: e.op(movie.title, "=", "The Avengers"),
-        limit: 1,
-      }))
-      .assert_single()
+      .select(e.Movie, () => ({ filter_single: { title: "The Avengers" } }))
       .run(client);
     assert.ok(theAvengers);
 

--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -206,6 +206,7 @@ describe("update", () => {
       }));
     });
     await query.run(client, { title: "The Avengers!" });
+    await query.run(client, {});
 
     const selected = await e.select(e.Movie, () => ({
       id: true,


### PR DESCRIPTION
This came up in the context of a user who was trying to figure out how to optionally update a property of an object with the query builder.

Noticed that our sole test case wasn't even really testing this either 🤦 