### PR TITLE
Add EdgeDB create-app recipe

### DIFF
--- a/packages/create/src/recipes/_edgedb/index.ts
+++ b/packages/create/src/recipes/_edgedb/index.ts
@@ -61,7 +61,7 @@ const recipe: Recipe<EdgeDBOptions> = {
 
         spinner.start("Installing EdgeDB CLI");
         await exec(
-          "curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh"
+          "curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh -s -- -y"
         );
         spinner.stop("EdgeDB CLI installed");
       }
@@ -82,7 +82,7 @@ const recipe: Recipe<EdgeDBOptions> = {
         { cwd: projectDir }
       );
       const serverVersion = JSON.parse(stdout.trim());
-      logger(`EdgeDB version: ${serverVersion}`);
+      logger(`EdgeDB server version: ${serverVersion}`);
       if (serverVersion === "") {
         const err = new Error(
           "There was a problem initializing the EdgeDB project"
@@ -95,7 +95,7 @@ const recipe: Recipe<EdgeDBOptions> = {
       spinner.stop(`EdgeDB v${serverVersion} project initialized`);
     } else {
       logger("Skipping edgedb project init");
-      logger("Copying EdgeDB schema to project");
+      logger("Copying basic EdgeDB project files");
 
       const dirname = path.dirname(new URL(import.meta.url).pathname);
       await copyTemplateFiles(

--- a/packages/create/src/recipes/_edgedb/index.ts
+++ b/packages/create/src/recipes/_edgedb/index.ts
@@ -5,35 +5,105 @@ import debug from "debug";
 import util from "node:util";
 import childProcess from "node:child_process";
 
-import { BaseOptions, Recipe } from "../types.js";
+import type { BaseOptions, Recipe } from "../types.js";
+import { copyTemplateFiles } from "../../utils.js";
 
 const logger = debug("@edgedb/create:recipe:edgedb");
 const exec = util.promisify(childProcess.exec);
 
-const recipe: Recipe = {
-  async apply({ projectDir, useEdgeDBAuth }: BaseOptions) {
+interface EdgeDBOptions {
+  initializeProject: boolean;
+}
+
+const recipe: Recipe<EdgeDBOptions> = {
+  getOptions() {
+    return p.group({
+      initializeProject: () =>
+        p.confirm({
+          message: "Initialize a new EdgeDB project with edgedb project init?",
+          initialValue: true,
+        }),
+    });
+  },
+
+  async apply(
+    { projectDir, useEdgeDBAuth }: BaseOptions,
+    { initializeProject }: EdgeDBOptions
+  ) {
     logger("Running edgedb recipe");
+    logger("Checking for existing EdgeDB CLI");
 
     const spinner = p.spinner();
 
-    spinner.start("Initializing EdgeDB project");
-    await exec("edgedb project init --non-interactive", { cwd: projectDir });
-    const { stdout, stderr } = await exec(
-      "edgedb query 'select sys::get_version_as_str()'",
-      { cwd: projectDir }
-    );
-    const serverVersion = JSON.parse(stdout.trim());
-    logger(`EdgeDB version: ${serverVersion}`);
-    if (serverVersion === "") {
-      const err = new Error(
-        "There was a problem initializing the EdgeDB project"
-      );
-      spinner.stop(err.message);
-      logger({ stdout, stderr });
+    if (initializeProject) {
+      let edgedbCliVersion: string | null = null;
+      let shouldInstallCli: boolean | symbol = true;
+      try {
+        const { stdout } = await exec("edgedb --version");
+        edgedbCliVersion = stdout.trim();
+        logger(edgedbCliVersion);
+      } catch (error) {
+        logger("No EdgeDB CLI detected");
+        shouldInstallCli = await p.confirm({
+          message:
+            "The EdgeDB CLI is required to initialize a project. Install now?",
+          initialValue: true,
+        });
+      }
 
-      throw err;
+      if (edgedbCliVersion === null) {
+        if (shouldInstallCli === false) {
+          logger("User declined to install EdgeDB CLI");
+          throw new Error("EdgeDB CLI is required");
+        }
+
+        logger("Installing EdgeDB CLI");
+
+        spinner.start("Installing EdgeDB CLI");
+        await exec(
+          "curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh"
+        );
+        spinner.stop("EdgeDB CLI installed");
+      }
+
+      try {
+        const { stdout } = await exec("edgedb --version");
+        edgedbCliVersion = stdout.trim();
+        logger(edgedbCliVersion);
+      } catch (error) {
+        logger("EdgeDB CLI could not be installed.");
+        throw new Error("EdgeDB CLI could not be installed.");
+      }
+
+      spinner.start("Initializing EdgeDB project");
+      await exec("edgedb project init --non-interactive", { cwd: projectDir });
+      const { stdout, stderr } = await exec(
+        "edgedb query 'select sys::get_version_as_str()'",
+        { cwd: projectDir }
+      );
+      const serverVersion = JSON.parse(stdout.trim());
+      logger(`EdgeDB version: ${serverVersion}`);
+      if (serverVersion === "") {
+        const err = new Error(
+          "There was a problem initializing the EdgeDB project"
+        );
+        spinner.stop(err.message);
+        logger({ stdout, stderr });
+
+        throw err;
+      }
+      spinner.stop(`EdgeDB v${serverVersion} project initialized`);
+    } else {
+      logger("Skipping edgedb project init");
+      logger("Copying EdgeDB schema to project");
+
+      const dirname = path.dirname(new URL(import.meta.url).pathname);
+      await copyTemplateFiles(
+        path.resolve(dirname, "./template"),
+        projectDir,
+        new Set()
+      );
     }
-    spinner.stop(`EdgeDB v${serverVersion} project initialized`);
 
     if (useEdgeDBAuth) {
       logger("Adding auth extension to project");

--- a/packages/create/src/recipes/_edgedb/index.ts
+++ b/packages/create/src/recipes/_edgedb/index.ts
@@ -2,10 +2,9 @@ import * as p from "@clack/prompts";
 import fs from "node:fs/promises";
 import path from "node:path";
 import debug from "debug";
-import { spawn } from "node:child_process";
 
 import type { BaseOptions, Recipe } from "../types.js";
-import { copyTemplateFiles } from "../../utils.js";
+import { copyTemplateFiles, execInLoginShell } from "../../utils.js";
 
 const logger = debug("@edgedb/create:recipe:edgedb");
 
@@ -71,6 +70,7 @@ const recipe: Recipe<EdgeDBOptions> = {
         logger(edgedbCliVersion);
       } catch (error) {
         logger("EdgeDB CLI could not be installed.");
+        logger(error);
         throw new Error("EdgeDB CLI could not be installed.");
       }
 
@@ -119,28 +119,3 @@ const recipe: Recipe<EdgeDBOptions> = {
 };
 
 export default recipe;
-
-async function execInLoginShell(
-  command: string,
-  options?: { cwd?: string }
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const child = spawn("/bin/bash", ["-l", "-c", command], options);
-    child.stdout.on("data", (data) => {
-      stdout += data;
-    });
-    child.stderr.on("data", (data) => {
-      stderr += data;
-    });
-    child.on("close", (code) => {
-      if (code !== 0) {
-        logger({ stdout, stderr });
-        reject(new Error(`Command "${command}" exited with code ${code}`));
-      } else {
-        resolve({ stdout, stderr });
-      }
-    });
-  });
-}

--- a/packages/create/src/recipes/_edgedb/template/dbschema/default.esdl
+++ b/packages/create/src/recipes/_edgedb/template/dbschema/default.esdl
@@ -1,0 +1,3 @@
+module default {
+
+}

--- a/packages/create/src/recipes/_edgedb/template/edgedb.toml
+++ b/packages/create/src/recipes/_edgedb/template/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "4.2"

--- a/packages/create/src/recipes/_edgedb/template/edgedb.toml
+++ b/packages/create/src/recipes/_edgedb/template/edgedb.toml
@@ -1,2 +1,0 @@
-[edgedb]
-server-version = "4.2"

--- a/packages/create/src/recipes/_install/index.ts
+++ b/packages/create/src/recipes/_install/index.ts
@@ -1,8 +1,7 @@
 import debug from "debug";
 import * as p from "@clack/prompts";
 
-import * as utils from "../../utils.js";
-import { BaseOptions, Recipe } from "../types.js";
+import type { BaseOptions, Recipe } from "../types.js";
 
 const logger = debug("@edgedb/create:recipe:install");
 

--- a/packages/create/src/recipes/index.ts
+++ b/packages/create/src/recipes/index.ts
@@ -5,7 +5,7 @@ import _install from "./_install/index.js";
 import express from "./express/index.js";
 import nextjs from "./nextjs/index.js";
 
-import { Recipe } from "./types.js";
+import { type Recipe } from "./types.js";
 
 export { baseRecipe };
 

--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import fs from "node:fs/promises";
 import { type Dirent } from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, type SpawnOptionsWithoutStdio } from "node:child_process";
 
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
@@ -121,7 +121,7 @@ async function _walkDir(
 
 export async function execInLoginShell(
   command: string,
-  options?: { cwd?: string }
+  options?: SpawnOptionsWithoutStdio
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     let stdout = "";


### PR DESCRIPTION
Includes a step that will attempt to install the CLI. Only works for *nix like systems at the moment due to how we have to spawn the commands in a "login shell" to get the correct PATH to include the `edgedb` CLI. The workaround for Windows users at the moment will be to install the CLI following the Windows installation instructions from the website before using the create-app flow.

Going to keep this as a draft to allow the base branch to land in `master` so this can land as a separate commit into `master` as well, but it should be ready for review.