### PR TITLE
Call `copyTemplateFiles` with correct arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,10 @@ jobs:
         run: |
           yarn workspace edgedb test
 
+      - name: Run create-app tests
+        run: |
+          yarn workspace @edgedb/create test
+
   # This job exists solely to act as the test job aggregate to be
   # targeted by branch policies.
   regression-tests:

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -14,10 +14,8 @@
   },
   "license": "Apache-2.0",
   "sideEffects": false,
-  "files": [
-    "/dist"
-  ],
-  "bin":  "dist/cli.js",
+  "files": ["/dist"],
+  "bin": "dist/cli.js",
   "peerDependencies": {},
   "devDependencies": {
     "@types/debug": "^4.1.12",
@@ -33,6 +31,7 @@
   },
   "scripts": {
     "create": "tsx src/cli.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "tsc --noEmit"
   }
 }

--- a/packages/create/src/recipes/_edgedb/index.ts
+++ b/packages/create/src/recipes/_edgedb/index.ts
@@ -106,11 +106,7 @@ const recipe: Recipe<EdgeDBOptions> = {
       logger("Copying basic EdgeDB project files");
 
       const dirname = path.dirname(new URL(import.meta.url).pathname);
-      await copyTemplateFiles(
-        path.resolve(dirname, "./template"),
-        projectDir,
-        new Set()
-      );
+      await copyTemplateFiles(path.resolve(dirname, "./template"), projectDir);
     }
 
     if (useEdgeDBAuth) {


### PR DESCRIPTION
This drifted between my PR and the base. Added a simple `tsc --noEmit` check for this package to avoid hitting this simple case of a type error slipping through CI.