### PR TITLE
Move expensive type expressions to generic

### DIFF
--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -15,14 +15,14 @@ bench("select: free object", () => {
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3642, "instantiations"]);
+}).types([3895, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5384, "instantiations"]);
+}).types([5386, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -31,7 +31,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([7412, "instantiations"]);
+}).types([7593, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -43,7 +43,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6339, "instantiations"]);
+}).types([6556, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -55,7 +55,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([98669, "instantiations"]);
+}).types([6690, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -68,7 +68,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([98963, "instantiations"]);
+}).types([6985, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -81,7 +81,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([98694, "instantiations"]);
+}).types([6713, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -94,5 +94,4 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([98730, "instantiations"]);
-
+}).types([6752, "instantiations"]);

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -848,18 +848,17 @@ export const $existingScopes = new Set<
 
 function $shape<
   Expr extends ObjectTypeExpression,
-  Shape extends objectTypeToSelectShape<Expr["__element__"]> &
-    SelectModifiers<Expr["__element__"]> // <Expr["__element__"]>
+  Element extends Expr["__element__"],
+  Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
+  Scope extends $scopify<Element> &
+    $linkPropify<{
+      [k in keyof Expr]: k extends "__cardinality__"
+        ? Cardinality.One
+        : Expr[k];
+    }>
 >(
   expr: Expr,
-  _shape: (
-    scope: $scopify<Expr["__element__"]> &
-      $linkPropify<{
-        [k in keyof Expr]: k extends "__cardinality__"
-          ? Cardinality.One
-          : Expr[k];
-      }>
-  ) => Readonly<Shape>
+  _shape: (scope: Scope) => Readonly<Shape>
 ): (scope: unknown) => Readonly<Shape>;
 function $shape(_a: unknown, b: (...args: any) => any) {
   return b;
@@ -881,23 +880,22 @@ export function select<Expr extends TypeSet>(
 ): $expr_Select<stripSet<Expr>>;
 export function select<
   Expr extends ObjectTypeExpression,
-  Shape extends objectTypeToSelectShape<Expr["__element__"]> &
-    SelectModifiers<Expr["__element__"]>,
+  Element extends Expr["__element__"],
+  Scope extends $scopify<Element> &
+    $linkPropify<{
+      [k in keyof Expr]: k extends "__cardinality__"
+        ? Cardinality.One
+        : Expr[k];
+    }>,
+  Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
   Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,
-  shape: (
-    scope: $scopify<Expr["__element__"]> &
-      $linkPropify<{
-        [k in keyof Expr]: k extends "__cardinality__"
-          ? Cardinality.One
-          : Expr[k];
-      }>
-  ) => Readonly<Shape>
+  shape: (scope: Scope) => Readonly<Shape>
 ): $expr_Select<{
   __element__: ObjectType<
-    `${Expr["__element__"]["__name__"]}`, // _shape
-    Expr["__element__"]["__pointers__"],
+    `${Element["__name__"]}`, // _shape
+    Element["__pointers__"],
     Omit<normaliseShape<Shape>, SelectModifierNames>
   >;
   __cardinality__: ComputeSelectCardinality<Expr, Modifiers>;


### PR DESCRIPTION
Thanks to the quick feedback cycle introduced by #829 was able to spend some time speeding up the `select` types. Was able to determine that the `scope` variable was the part of the expression that was taking the most time, and moved the type instantiation to a generic.