### PR TITLE
Remove extra flattening of array literal

### DIFF
--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -2,6 +2,33 @@ import { bench } from "@arktype/attest";
 
 import e from "./dbschema/edgeql-js";
 
+bench("scalar literal", () => {
+  const lit = e.int32(42);
+  return {} as typeof lit;
+}).types([656, "instantiations"]);
+
+bench("array literal", () => {
+  const lit = e.literal(e.array(e.str), ["abcd"]);
+  return {} as typeof lit;
+}).types([2454, "instantiations"]);
+
+bench("named tuple literal", () => {
+  const lit = e.literal(e.tuple({ str: e.str }), {
+    str: "asdf",
+  });
+  return {} as typeof lit;
+}).types([11654, "instantiations"]);
+
+bench("base type: array", () => {
+  const baseType = e.array(e.str);
+  return {} as typeof baseType;
+}).types([348, "instantiations"]);
+
+bench("base type: named tuple", () => {
+  const baseType = e.tuple({ str: e.str });
+  return {} as typeof baseType;
+}).types([2160, "instantiations"]);
+
 bench("select: scalar", () => {
   const query = e.select(e.int32(42));
   return {} as typeof query;
@@ -15,14 +42,14 @@ bench("select: free object", () => {
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3895, "instantiations"]);
+}).types([4105, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5386, "instantiations"]);
+}).types([5596, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -31,7 +58,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([7593, "instantiations"]);
+}).types([7911, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -43,7 +70,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6556, "instantiations"]);
+}).types([6887, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -55,7 +82,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6690, "instantiations"]);
+}).types([7085, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -68,7 +95,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6985, "instantiations"]);
+}).types([7380, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -81,7 +108,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6713, "instantiations"]);
+}).types([7108, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -94,4 +121,18 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6752, "instantiations"]);
+}).types([7147, "instantiations"]);
+
+bench("params select", () => {
+  const query = e.params({ name: e.str }, (params) =>
+    e.select(e.Hero, (hero) => ({
+      name: true,
+      villains: () => ({
+        id: true,
+        name: true,
+      }),
+      filter_single: e.op(hero.name, "=", params.name),
+    }))
+  );
+  return {} as typeof query;
+}).types([14680, "instantiations"]);

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -44,7 +44,7 @@ export interface ScalarType<
 
 export type scalarTypeWithConstructor<
   S extends ScalarType,
-  ExtraTsTypes extends any = never
+  ExtraTsTypes = never
 > = S & {
   // tslint:disable-next-line
   <T extends S["__tstype__"] | ExtraTsTypes>(val: T): $expr_Literal<
@@ -706,7 +706,7 @@ export type BaseTypeToTsType<
   : Type extends EnumType
   ? Type["__tstype__"]
   : Type extends ArrayType<any>
-  ? typeutil.flatten<ArrayTypeToTsType<Type, isParam>>
+  ? ArrayTypeToTsType<Type, isParam>
   : Type extends RangeType
   ? Range<Type["__element__"]["__tsconsttype__"]>
   : Type extends MultiRangeType


### PR DESCRIPTION
While investigating compatibility with the latest version of TypeScript (5.3.3 at the moment), I was working against the `main` branch of TypeScript and found a case where `e.literal` was causing a `TS2589: Type instantiation is excessively deep and possibly infinite.` error.

There are additional issues on 5.3.3, but this was one that was detectable and fixable in isolation, so adding this fix now. Might be a fix for #782 but I haven't been able to repro that issue.

Not sure why there is a benchmark regression here. I'm also getting this against `master`, so maybe there are some weird environmental issues that affect the benchmarks and make them slightly non-deterministic? 🤷 