### PR TITLE
Some continued performance improvements

### DIFF
--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -42,14 +42,14 @@ bench("select: free object", () => {
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3699, "instantiations"]);
+}).types([3687, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5072, "instantiations"]);
+}).types([5081, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -58,7 +58,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6101, "instantiations"]);
+}).types([6099, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -70,7 +70,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6358, "instantiations"]);
+}).types([6342, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -82,7 +82,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6349, "instantiations"]);
+}).types([6331, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -95,7 +95,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6679, "instantiations"]);
+}).types([6666, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -108,7 +108,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6407, "instantiations"]);
+}).types([6394, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -121,7 +121,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6446, "instantiations"]);
+}).types([6433, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -135,4 +135,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([11920, "instantiations"]);
+}).types([11907, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -49,7 +49,7 @@ bench("select: filtered", () => {
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5081, "instantiations"]);
+}).types([5019, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -58,7 +58,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6099, "instantiations"]);
+}).types([6037, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -82,7 +82,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6331, "instantiations"]);
+}).types([6289, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -95,7 +95,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6666, "instantiations"]);
+}).types([6624, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -108,7 +108,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6394, "instantiations"]);
+}).types([6352, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -121,7 +121,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6433, "instantiations"]);
+}).types([6391, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -135,4 +135,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([11907, "instantiations"]);
+}).types([11865, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -10,14 +10,14 @@ bench("scalar literal", () => {
 bench("array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
   return {} as typeof lit;
-}).types([2454, "instantiations"]);
+}).types([2407, "instantiations"]);
 
 bench("named tuple literal", () => {
   const lit = e.literal(e.tuple({ str: e.str }), {
     str: "asdf",
   });
   return {} as typeof lit;
-}).types([11654, "instantiations"]);
+}).types([11597, "instantiations"]);
 
 bench("base type: array", () => {
   const baseType = e.array(e.str);
@@ -42,14 +42,14 @@ bench("select: free object", () => {
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3910, "instantiations"]);
+}).types([3699, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5283, "instantiations"]);
+}).types([5072, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -58,7 +58,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6420, "instantiations"]);
+}).types([6101, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -70,7 +70,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6691, "instantiations"]);
+}).types([6358, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -82,7 +82,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6788, "instantiations"]);
+}).types([6349, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -95,7 +95,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([7118, "instantiations"]);
+}).types([6679, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -108,7 +108,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6846, "instantiations"]);
+}).types([6407, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -121,7 +121,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6885, "instantiations"]);
+}).types([6446, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -135,4 +135,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([13048, "instantiations"]);
+}).types([11920, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -5,7 +5,7 @@ import e from "./dbschema/edgeql-js";
 bench("scalar literal", () => {
   const lit = e.int32(42);
   return {} as typeof lit;
-}).types([656, "instantiations"]);
+}).types([555, "instantiations"]);
 
 bench("array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
@@ -32,24 +32,24 @@ bench("base type: named tuple", () => {
 bench("select: scalar", () => {
   const query = e.select(e.int32(42));
   return {} as typeof query;
-}).types([1263, "instantiations"]);
+}).types([1155, "instantiations"]);
 
 bench("select: free object", () => {
   const query = e.select({ meaning: e.int32(42) });
   return {} as typeof query;
-}).types([2120, "instantiations"]);
+}).types([2012, "instantiations"]);
 
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([4105, "instantiations"]);
+}).types([3910, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5596, "instantiations"]);
+}).types([5283, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -58,7 +58,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([7911, "instantiations"]);
+}).types([6420, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -70,7 +70,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6887, "instantiations"]);
+}).types([6691, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -82,7 +82,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([7085, "instantiations"]);
+}).types([6788, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -95,7 +95,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([7380, "instantiations"]);
+}).types([7118, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -108,7 +108,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([7108, "instantiations"]);
+}).types([6846, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -121,7 +121,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([7147, "instantiations"]);
+}).types([6885, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -135,4 +135,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([14680, "instantiations"]);
+}).types([13048, "instantiations"]);

--- a/packages/driver/src/reflection/typeutil.ts
+++ b/packages/driver/src/reflection/typeutil.ts
@@ -7,7 +7,7 @@ export namespace typeutil {
 
   export type depromisify<T> = T extends Promise<infer U> ? depromisify<U> : T;
   export type identity<T> = T;
-  export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
+  export type flatten<T> = { [k in keyof T]: T[k] } & unknown;
   export type tupleOf<T> = [T, ...T[]] | [];
   export type writeable<T> = { -readonly [P in keyof T]: T[P] };
 

--- a/packages/generate/src/syntax/params.ts
+++ b/packages/generate/src/syntax/params.ts
@@ -16,6 +16,10 @@ import { runnableExpressionKinds } from "./query";
 import { select } from "./select";
 import { complexParamKinds } from "./__spec__";
 
+type Param = ParamType | $expr_OptionalParam;
+
+type ParamsRecord = Record<string, Param>;
+
 export type $expr_OptionalParam<Type extends ParamType = ParamType> = {
   __kind__: ExpressionKind.OptionalParam;
   __type__: Type;
@@ -32,9 +36,7 @@ export function optional<Type extends ParamType>(
 
 export type QueryableWithParamsExpression<
   Set extends TypeSet = TypeSet,
-  Params extends {
-    [key: string]: ParamType | $expr_OptionalParam;
-  } = {}
+  Params extends ParamsRecord = Record<string, never>
 > = Expression<Set, false> & {
   run(
     cxn: Executor,
@@ -44,9 +46,7 @@ export type QueryableWithParamsExpression<
 };
 
 export type $expr_WithParams<
-  Params extends {
-    [key: string]: ParamType | $expr_OptionalParam;
-  } = {},
+  Params extends ParamsRecord = Record<string, never>,
   Expr extends TypeSet = TypeSet
 > = QueryableWithParamsExpression<
   {
@@ -59,11 +59,7 @@ export type $expr_WithParams<
   Params
 >;
 
-type paramsToParamArgs<
-  Params extends {
-    [key: string]: ParamType | $expr_OptionalParam;
-  }
-> = {
+type paramsToParamArgs<Params extends ParamsRecord> = {
   [key in keyof Params as Params[key] extends ParamType
     ? key
     : never]: Params[key] extends ParamType
@@ -91,11 +87,7 @@ export type $expr_Param<
   __isComplex__: boolean;
 }>;
 
-type paramsToParamExprs<
-  Params extends {
-    [key: string]: ParamType | $expr_OptionalParam;
-  }
-> = {
+type paramsToParamExprs<Params extends ParamsRecord> = {
   [key in keyof Params]: Params[key] extends $expr_OptionalParam
     ? $expr_Param<key, Params[key]["__type__"], true>
     : Params[key] extends ParamType
@@ -104,9 +96,7 @@ type paramsToParamExprs<
 };
 
 export function params<
-  Params extends {
-    [key: string]: ParamType | $expr_OptionalParam;
-  } = {},
+  Params extends ParamsRecord = Record<string, never>,
   Expr extends Expression = Expression
 >(
   paramsDef: Params,

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -762,21 +762,24 @@ export type linkDescToSelectElement<L extends LinkDesc> =
 // pointers -> links
 // links -> target object type
 // links -> link properties
-export type objectTypeToSelectShape<T extends ObjectType = ObjectType> =
+export type objectTypeToSelectShape<
+  T extends ObjectType = ObjectType,
+  Pointers extends ObjectTypePointers = T["__pointers__"]
+> =
   // ObjectType extends T
   //   ? {[k: string]: unknown}
   //   :
   Partial<{
-    [k in keyof T["__pointers__"]]: T["__pointers__"][k] extends PropertyDesc
+    [k in keyof Pointers]: Pointers[k] extends PropertyDesc
       ?
           | boolean
           | TypeSet<
-              T["__pointers__"][k]["target"],
-              cardutil.assignable<T["__pointers__"][k]["cardinality"]>
+              Pointers[k]["target"],
+              cardutil.assignable<Pointers[k]["cardinality"]>
             >
           | $expr_PolyShapeElement
-      : T["__pointers__"][k] extends LinkDesc
-      ? linkDescToSelectElement<T["__pointers__"][k]>
+      : Pointers[k] extends LinkDesc
+      ? linkDescToSelectElement<Pointers[k]>
       : any;
   }> & { [k: string]: unknown };
 
@@ -891,16 +894,12 @@ export function select<
   Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
   SelectCard extends ComputeSelectCardinality<Expr, Modifiers>,
   SelectShape extends normaliseShape<Shape, SelectModifierNames>,
-  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>,
+  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,
   shape: (scope: Scope) => Readonly<Shape>
 ): $expr_Select<{
-  __element__: ObjectType<
-    ElementName,
-    Element["__pointers__"],
-    SelectShape
-  >;
+  __element__: ObjectType<ElementName, Element["__pointers__"], SelectShape>;
   __cardinality__: SelectCard;
 }>;
 /*

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -96,6 +96,10 @@ export type SelectModifierNames =
   | "offset"
   | "limit";
 
+type filterSingle<T extends TypeSet> = T extends ObjectTypeSet
+  ? TypeSet<anonymizeObject<T["__element__"]>, T["__cardinality__"]>
+  : orLiteralValue<T>;
+
 export type exclusivesToFilterSingle<E extends ExclusiveTuple> =
   ExclusiveTuple extends E
     ? never
@@ -103,12 +107,7 @@ export type exclusivesToFilterSingle<E extends ExclusiveTuple> =
     ? never
     : {
         [j in keyof E]: {
-          [k in keyof E[j]]: E[j][k] extends ObjectTypeSet
-            ? TypeSet<
-                anonymizeObject<E[j][k]["__element__"]>,
-                E[j][k]["__cardinality__"]
-              >
-            : orLiteralValue<E[j][k]>;
+          [k in keyof E[j]]: filterSingle<E[j][k]>;
         };
       }[number];
 export type SelectModifiers<T extends ObjectType = ObjectType> = {

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -881,6 +881,7 @@ export function select<Expr extends TypeSet>(
 export function select<
   Expr extends ObjectTypeExpression,
   Element extends Expr["__element__"],
+  ElementName extends `${Element["__name__"]}`,
   Scope extends $scopify<Element> &
     $linkPropify<{
       [k in keyof Expr]: k extends "__cardinality__"
@@ -888,17 +889,19 @@ export function select<
         : Expr[k];
     }>,
   Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
-  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
+  SelectCard extends ComputeSelectCardinality<Expr, Modifiers>,
+  SelectShape extends normaliseShape<Shape, SelectModifierNames>,
+  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>,
 >(
   expr: Expr,
   shape: (scope: Scope) => Readonly<Shape>
 ): $expr_Select<{
   __element__: ObjectType<
-    `${Element["__name__"]}`, // _shape
+    ElementName,
     Element["__pointers__"],
-    Omit<normaliseShape<Shape>, SelectModifierNames>
+    SelectShape
   >;
-  __cardinality__: ComputeSelectCardinality<Expr, Modifiers>;
+  __cardinality__: SelectCard;
 }>;
 /*
 

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -31,8 +31,8 @@ export type BaseTypeTuple = typeutil.tupleOf<BaseType>;
 
 export interface ScalarType<
   Name extends string = string,
-  TsType extends any = any,
-  TsArgType extends any = TsType,
+  TsType = any,
+  TsArgType = TsType,
   TsConstType extends TsType = TsType
 > extends BaseType {
   __kind__: TypeKind.scalar;
@@ -47,13 +47,14 @@ export type scalarTypeWithConstructor<
   ExtraTsTypes = never
 > = S & {
   // tslint:disable-next-line
-  <T extends S["__tstype__"] | ExtraTsTypes>(val: T): $expr_Literal<
-    ScalarType<
-      S["__name__"],
-      S["__tstype__"],
-      S["__tsargtype__"],
-      T extends S["__tstype__"] ? T : S["__tstype__"]
-    >
+  <
+    T extends S["__tstype__"] | ExtraTsTypes,
+  >(
+    val: T
+  ): $expr_Literal<
+    Omit<S, "__tsconsttype__"> & {
+      __tsconsttype__: T extends S["__tstype__"] ? T : S["__tstype__"];
+    }
   >;
 };
 

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -47,11 +47,7 @@ export type scalarTypeWithConstructor<
   ExtraTsTypes = never
 > = S & {
   // tslint:disable-next-line
-  <
-    T extends S["__tstype__"] | ExtraTsTypes,
-  >(
-    val: T
-  ): $expr_Literal<
+  <T extends S["__tstype__"] | ExtraTsTypes>(val: T): $expr_Literal<
     Omit<S, "__tsconsttype__"> & {
       __tsconsttype__: T extends S["__tstype__"] ? T : S["__tstype__"];
     }


### PR DESCRIPTION
A handful of smaller improvements. Some of these are micro-optimizations, but a few had some measurable impact. I don't think there is much low-hanging fruit that I can use these same tricks on as far as I can tell, but here are the general flavors of these changes:

- Preferring `Omit` + intersection to "replace" a particular property on a type instead of mapping each property directly.
- Name unions used in conditional types
- Name internal conditional types within a larger conditional type

None of these seem to be silver bullets, and required actually benchmarking the changes to detect if they made things worse or better. Still not sure if I have a good intuition yet.
