### PR TITLE
Allow scalarToLiteralMapping to declare TS type for extended scalar type

### DIFF
--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -130,22 +130,10 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
       } else if (isLink) {
         return getTypeName(targetType.name);
       } else {
-        const baseType =
-          targetType.kind === "scalar"
-            ? (targetType.bases
-                .map(({ id }) => types.get(id))
-                .filter(
-                  (base) => !base.is_abstract
-                )[0] as $.introspect.ScalarType)
-            : null;
-        return toTSScalarType(
-          baseType ?? (targetType as $.introspect.PrimitiveType),
-          types,
-          {
-            getEnumRef: (enumType) => getTypeName(enumType.name),
-            edgedbDatatypePrefix: "",
-          }
-        ).join("");
+        return toTSScalarType(targetType as $.introspect.PrimitiveType, types, {
+          getEnumRef: (enumType) => getTypeName(enumType.name),
+          edgedbDatatypePrefix: "",
+        }).join("");
       }
     };
 

--- a/packages/generate/src/edgeql-js/generateScalars.ts
+++ b/packages/generate/src/edgeql-js/generateScalars.ts
@@ -115,10 +115,7 @@ export const generateScalars = (params: GeneratorParams) => {
     }
 
     // generate non-enum non-abstract scalar
-    const baseType = type.bases
-      .map(({ id }) => types.get(id))
-      .filter((base) => !base.is_abstract)[0] as $.introspect.ScalarType;
-    const tsType = toTSScalarType(baseType ?? type, types);
+    const tsType = toTSScalarType(type, types);
     // const tsType = toTSScalarType(type, types);
     // const extraTypes = scalarToLiteralMapping[type.name]?.extraTypes;
     // const extraTypesUnion = extraTypes ? `, ${extraTypes.join(" | ")}` : "";

--- a/packages/generate/src/genutil.ts
+++ b/packages/generate/src/genutil.ts
@@ -145,7 +145,7 @@ export function toTSScalarType(
         return [getRef(type.name, { prefix: "" })];
       }
 
-      if (type.material_id) {
+      if (type.material_id && !scalarToLiteralMapping[type.name]) {
         return toTSScalarType(
           types.get(type.material_id) as introspect.ScalarType,
           types,


### PR DESCRIPTION
As far as I've been able to deduce there's no need to jump to the `type`'s first `base` type to determine the TS literal value.
This is because the function already jumps to the `type`'s `material_id`, which has already worked out the "base concrete type".
https://github.com/edgedb/edgedb-js/blob/dfcf3d48f74fd78c47146b505a4e942d4b33d849/packages/driver/src/reflection/queries/types.ts#L165-L169
https://github.com/edgedb/edgedb-js/blob/dfcf3d48f74fd78c47146b505a4e942d4b33d849/packages/driver/src/reflection/queries/types.ts#L139-L144
This change resulted in no changes in my generated query builder, schema, or query files, so I'm fairly confident in it. Though not 100% and I don't know the difference between `bases` and `ancestors` (maybe they are the same for `ScalarType`?).

---

With that change in place I was able to add the logical change: allowing `scalarToLiteralMapping` to declare scalars that should use their own TS literal type instead of the base type.
My use case is this:
```edgeql
scalar type RichText extending json;
```
```ts
scalarToLiteralMapping['default::RichText'] = { type: 'TSShapeOfRichText' };
```