### PR TITLE
Enable the resendVerificationEmail Next.js action to work with email …

### DIFF
--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -145,6 +145,13 @@ export class Auth {
     });
   }
 
+  async resendVerificationEmailForEmail(email: string) {
+    await this._post("resend-verification-email", {
+      provider: emailPasswordProviderName,
+      email,
+    });
+  }
+
   async sendPasswordResetEmail(email: string, resetUrl: string) {
     const { challenge, verifier } = await pkce.createVerifierChallengePair();
     return {

--- a/packages/auth-nextjs/src/app/index.ts
+++ b/packages/auth-nextjs/src/app/index.ts
@@ -159,7 +159,7 @@ export class NextAppAuth extends NextAuth {
 
         if (verificationToken) {
           await (await this.core).resendVerificationEmail(verificationToken);
-        } else {
+        } else if (email) {
           await (await this.core).resendVerificationEmailForEmail(email);
         }
       },

--- a/packages/auth-nextjs/src/app/index.ts
+++ b/packages/auth-nextjs/src/app/index.ts
@@ -135,14 +135,33 @@ export class NextAppAuth extends NextAuth {
         return tokenData;
       },
       emailPasswordResendVerificationEmail: async (
-        data: FormData | { verification_token: string }
+        data: FormData | { verification_token: string } | { email: string }
       ) => {
-        const [verificationToken] = _extractParams(
-          data,
-          ["verification_token"],
-          "verification_token missing"
-        );
-        await (await this.core).resendVerificationEmail(verificationToken);
+        let email;
+        let verificationToken;
+        try {
+          [verificationToken] = _extractParams(
+            data,
+            ["verification_token"],
+            "verification_token missing"
+          );
+        } catch (tokenError) {
+          try {
+            [email] = _extractParams(data, ["email"], "email missing");
+          } catch (emailError) {
+            const bothParamsMissing = [tokenError, emailError]
+              .map((err) => (err as Error).message)
+              .join(" and ");
+
+            throw new Error(`${bothParamsMissing}. Either one is required.`);
+          }
+        }
+
+        if (verificationToken) {
+          await (await this.core).resendVerificationEmail(verificationToken);
+        } else {
+          await (await this.core).resendVerificationEmailForEmail(email);
+        }
       },
     };
   }


### PR DESCRIPTION
…param. (#845)

I've tested locally that the server endpoint work just with the `email` param:

```ts
    const url = new URL(
      "resend-verification-email",
      "http://localhost:10705/db/edgedb/ext/auth/",
    ).toString();

    const res = await fetch(url, {
      method: "post",
      body: JSON.stringify({
        provider: "builtin::local_emailpassword",
        email: formData.get("email"),
      }),
      headers: { "Content-Type": "application/json" },
    });
```