### PR TITLE
Release `@edgedb/create` v0.2.0

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgedb/create",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Create a new EdgeDB-based project",
   "homepage": "https://edgedb.com/docs",


### PR DESCRIPTION
Note: The previous `0.1.0` release should've been an `alpha`.