### PR TITLE
Allow `$infer` to work on `e.shape` objects

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1277,19 +1277,34 @@ SELECT __scope_0_defaultPerson {
 
   test("portable shape", async () => {
     const baseShape = e.shape(e.Movie, (movie) => ({
-      ...movie["*"],
+      title: true,
+      rating: true,
+      filter_single: e.op(movie.title, "=", "The Avengers"),
     }));
+
+    type ShapeType = $infer<typeof baseShape>;
+    tc.assert<
+      tc.IsExact<
+        ShapeType,
+        {
+          title: string;
+          rating: number | null;
+        } | null
+      >
+    >(true);
+
     const query = e.select(e.Movie, (m) => {
       return {
         ...baseShape(m),
         characters: { name: true },
-        filter_single: e.op(m.title, "=", "The Avengers"),
       };
     });
 
     const result = await query.run(client);
-    assert.ok(result?.rating);
-    assert.ok(result?.characters);
+    assert.ok(result);
+    assert.ok(result.title);
+    assert.ok(result.rating);
+    assert.ok(result.characters);
   });
 
   test("filter_single id", async () => {

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -847,16 +847,23 @@ function $shape<
   Expr extends ObjectTypeExpression,
   Element extends Expr["__element__"],
   Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
+  SelectCard extends ComputeSelectCardinality<Expr, Modifiers>,
+  SelectShape extends normaliseShape<Shape, SelectModifierNames>,
   Scope extends $scopify<Element> &
     $linkPropify<{
       [k in keyof Expr]: k extends "__cardinality__"
         ? Cardinality.One
         : Expr[k];
-    }>
+    }>,
+  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>
 >(
   expr: Expr,
   _shape: (scope: Scope) => Readonly<Shape>
-): (scope: unknown) => Readonly<Shape>;
+): ((scope: unknown) => Readonly<Shape>) &
+  TypeSet<
+    ObjectType<Element["__name__"], Element["__pointers__"], SelectShape>,
+    SelectCard
+  >;
 function $shape(_a: unknown, b: (...args: any) => any) {
   return b;
 }


### PR DESCRIPTION
Closes #621 

Build a `TypeSet` in a similar way to `e.select` and use the existing `$infer` utility type.