### PR TITLE
Use latest Deno std and node: specifiers

### DIFF
--- a/compileForDeno.ts
+++ b/compileForDeno.ts
@@ -1,10 +1,10 @@
-import { ensureDir, walk } from "https://deno.land/std@0.177.0/fs/mod.ts";
+import { ensureDir, walk } from "https://deno.land/std@0.216.0/fs/mod.ts";
 import {
   basename,
   dirname,
   join,
   relative,
-} from "https://deno.land/std@0.177.0/path/posix.ts";
+} from "https://deno.land/std@0.216.0/path/mod.ts";
 
 import ts from "npm:typescript";
 

--- a/packages/driver/src/adapter.crypto.deno.ts
+++ b/packages/driver/src/adapter.crypto.deno.ts
@@ -1,4 +1,4 @@
-import { crypto } from "https://deno.land/std@0.177.0/crypto/mod.ts";
+import { crypto } from "https://deno.land/std@0.216.0/crypto/mod.ts";
 
 import type { CryptoUtils } from "./utils.ts";
 

--- a/packages/driver/src/adapter.deno.ts
+++ b/packages/driver/src/adapter.deno.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import crypto from "node:crypto";
 import url from "node:url";
 import path from "node:path";
-import * as _fs from "https://deno.land/std@0.208.0/fs/mod.ts";
+import * as _fs from "https://deno.land/std@0.216.0/fs/mod.ts";
 import fs from "node:fs/promises";
 import util from "node:util";
 import { isIP as _isIP } from "node:net";

--- a/packages/driver/src/globals.deno.ts
+++ b/packages/driver/src/globals.deno.ts
@@ -7,11 +7,11 @@ export {
   beforeAll,
   afterAll,
   it,
-} from "https://deno.land/std@0.177.0/testing/bdd.ts";
-import { MatchResult } from "https://deno.land/x/expect/matchers.ts";
-import { bold, green, red } from "https://deno.land/std@0.177.0/fmt/colors.ts";
+} from "https://deno.land/std@0.216.0/testing/bdd.ts";
+import { type MatchResult } from "https://deno.land/x/expect/matchers.ts";
+import { bold, green, red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
 
-export { process } from "https://deno.land/std@0.177.0/node/process.ts";
+export { default as process } from "node:process";
 
 const ACTUAL = red(bold("actual"));
 const EXPECTED = green(bold("expected"));

--- a/packages/driver/test/globals.deno.ts
+++ b/packages/driver/test/globals.deno.ts
@@ -7,12 +7,12 @@ export {
   beforeAll,
   afterAll,
   it,
-} from "https://deno.land/std@0.177.0/testing/bdd.ts";
-import { MatchResult } from "https://deno.land/x/expect/matchers.ts";
-import { bold, green, red } from "https://deno.land/std@0.177.0/fmt/colors.ts";
+} from "https://deno.land/std@0.216.0/testing/bdd.ts";
+import { type MatchResult } from "https://deno.land/x/expect/matchers.ts";
+import { bold, green, red } from "https://deno.land/std@0.216.0/fmt/colors.ts";
 
-export { Buffer } from "https://deno.land/std@0.177.0/node/buffer.ts";
-export { process } from "https://deno.land/std@0.177.0/node/process.ts";
+export { Buffer } from "node:buffer";
+export { default as process } from "node:process";
 
 const ACTUAL = red(bold("actual"));
 const EXPECTED = green(bold("expected"));

--- a/packages/generate/buildDeno.ts
+++ b/packages/generate/buildDeno.ts
@@ -8,7 +8,7 @@ await run({
   importRewriteRules: [
     {
       match: /^@iarna\/toml$/,
-      replace: "https://deno.land/std@0.208.0/toml/mod.ts",
+      replace: "https://deno.land/std@0.216.0/toml/mod.ts",
     },
     {
       match: /^edgedb\/dist\//,

--- a/packages/generate/makeSyntax.ts
+++ b/packages/generate/makeSyntax.ts
@@ -104,7 +104,7 @@ async function run() {
     cwd: srcSyntax,
     contentTx: content => {
       if (content.indexOf("Buffer") !== -1) {
-        content = `import {Buffer} from "https://deno.land/std@0.177.0/node/buffer.ts";\n\n${content}`;
+        content = `import { Buffer } from "node:buffer";\n\n${content}`;
       }
       return content
         .replace(reDriver, `"edgedb/_src$1.ts"`)


### PR DESCRIPTION
This brings our minimum Deno version to 1.30 which is now a year old. This seems like a fair trade off to prepare for compatibility with the upcoming 2.0 release from Deno.

Closes #844 