### PR TITLE
Add WebAuthn sign in and sign up flows

### DIFF
--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -10,6 +10,16 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./webauthn": {
+      "types": "./dist/webauthn.d.ts",
+      "default": "./dist/webauthn.js"
+    }
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "files": [

--- a/packages/auth-core/src/consts.ts
+++ b/packages/auth-core/src/consts.ts
@@ -12,3 +12,4 @@ export type BuiltinOAuthProviderNames =
   (typeof builtinOAuthProviderNames)[number];
 
 export const emailPasswordProviderName = "builtin::local_emailpassword";
+export const webAuthnProviderName = "builtin::local_webauthn";

--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -8,7 +8,13 @@ import {
   emailPasswordProviderName,
   webAuthnProviderName,
 } from "./consts";
-import { type Serialized, requestGET, requestPOST } from "./utils";
+import { requestGET, requestPOST } from "./utils";
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+} from "./types";
 
 export interface TokenData {
   auth_token: string;
@@ -58,10 +64,7 @@ export class Auth {
   }
 
   /** @internal */
-  public async _post<T = unknown>(
-    path: string,
-    body?: object
-  ): Promise<T> {
+  public async _post<T = unknown>(path: string, body?: object): Promise<T> {
     return requestPOST<T>(new URL(path, this.baseUrl).href, body);
   }
 
@@ -76,8 +79,8 @@ export class Auth {
 
   async getWebAuthnSignupOptions(
     email: string
-  ): Promise<Serialized<PublicKeyCredentialCreationOptions>> {
-    return this._get<Serialized<PublicKeyCredentialCreationOptions>>(
+  ): Promise<PublicKeyCredentialCreationOptionsJSON> {
+    return this._get<PublicKeyCredentialCreationOptionsJSON>(
       `webauthn/register/options`,
       { email }
     );
@@ -85,7 +88,7 @@ export class Auth {
 
   async signupWithWebAuthn(
     email: string,
-    credentials: Serialized<PublicKeyCredential>,
+    credentials: RegistrationResponseJSON,
     verifyUrl: string
   ): Promise<SignupResponse> {
     credentials.rawId;
@@ -111,8 +114,8 @@ export class Auth {
 
   async getWebAuthnSigninOptions(
     email: string
-  ): Promise<Serialized<PublicKeyCredentialRequestOptions>> {
-    return this._get<Serialized<PublicKeyCredentialRequestOptions>>(
+  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+    return this._get<PublicKeyCredentialRequestOptionsJSON>(
       `webauthn/authenticate/options`,
       { email }
     );
@@ -120,7 +123,7 @@ export class Auth {
 
   async signinWithWebAuthn(
     email: string,
-    assertion: Serialized<PublicKeyCredential>
+    assertion: AuthenticationResponseJSON
   ): Promise<TokenData> {
     const { challenge, verifier } = await pkce.createVerifierChallengePair();
     const { code } = await this._post<{ code: string }>(

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -1,11 +1,3 @@
-/* eslint @typescript-eslint/no-var-requires: ["off"] */
-
-// TODO: Drop when Node 18 is EOL: 2025-04-30
-if (!globalThis.crypto) {
-  // tslint:disable-next-line: no-var-requires
-  globalThis.crypto = require("node:crypto").webcrypto;
-}
-
 const BASE64_URL_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
@@ -62,9 +54,6 @@ export function base64UrlToBytes(base64url: string): Uint8Array {
 
   return new Uint8Array(outputArray);
 }
-
-
-
 
 export async function sha256(
   source: BufferSource | string

--- a/packages/auth-core/src/crypto.ts
+++ b/packages/auth-core/src/crypto.ts
@@ -35,6 +35,37 @@ export function bytesToBase64Url(bytes: Uint8Array): string {
   return base64url;
 }
 
+export function base64UrlToBytes(base64url: string): Uint8Array {
+  // Add padding if necessary
+  let paddedBase64url = base64url;
+  const padLength = base64url.length % 4;
+  if (padLength) {
+    paddedBase64url += "=".repeat(4 - padLength);
+  }
+
+  const outputArray = [];
+
+  for (let i = 0; i < paddedBase64url.length; i += 4) {
+    const enc1 = BASE64_URL_CHARS.indexOf(paddedBase64url.charAt(i));
+    const enc2 = BASE64_URL_CHARS.indexOf(paddedBase64url.charAt(i + 1));
+    const enc3 = BASE64_URL_CHARS.indexOf(paddedBase64url.charAt(i + 2));
+    const enc4 = BASE64_URL_CHARS.indexOf(paddedBase64url.charAt(i + 3));
+
+    const b1 = (enc1 << 2) | (enc2 >> 4);
+    const b2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+    const b3 = ((enc3 & 3) << 6) | enc4;
+
+    outputArray.push(b1);
+    if (enc3 !== -1) outputArray.push(b2);
+    if (enc4 !== -1) outputArray.push(b3);
+  }
+
+  return new Uint8Array(outputArray);
+}
+
+
+
+
 export async function sha256(
   source: BufferSource | string
 ): Promise<Uint8Array> {

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./core";
 export * from "./pkce";
 export * from "./consts";
+export * from "./types";

--- a/packages/auth-core/src/types.ts
+++ b/packages/auth-core/src/types.ts
@@ -1,0 +1,71 @@
+export interface PublicKeyCredentialCreationOptionsJSON {
+  rp: PublicKeyCredentialRpEntity;
+  user: PublicKeyCredentialUserEntityJSON;
+  challenge: Base64URLString;
+  pubKeyCredParams: PublicKeyCredentialParameters[];
+  timeout?: number;
+  excludeCredentials?: PublicKeyCredentialDescriptorJSON[];
+  authenticatorSelection?: AuthenticatorSelectionCriteria;
+  attestation?: AttestationConveyancePreference;
+  extensions?: AuthenticationExtensionsClientInputs;
+}
+
+export interface PublicKeyCredentialRequestOptionsJSON {
+  challenge: Base64URLString;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials?: PublicKeyCredentialDescriptorJSON[];
+  userVerification?: UserVerificationRequirement;
+  extensions?: AuthenticationExtensionsClientInputs;
+}
+
+export interface RegistrationResponseJSON {
+  id: Base64URLString;
+  rawId: Base64URLString;
+  response: AuthenticatorAttestationResponseJSON;
+  authenticatorAttachment?: AuthenticatorAttachment;
+  clientExtensionResults: AuthenticationExtensionsClientOutputs;
+  type: PublicKeyCredentialType;
+}
+
+export interface AuthenticationResponseJSON {
+  id: Base64URLString;
+  rawId: Base64URLString;
+  response: AuthenticatorAssertionResponseJSON;
+  authenticatorAttachment?: AuthenticatorAttachment;
+  clientExtensionResults: AuthenticationExtensionsClientOutputs;
+  type: PublicKeyCredentialType;
+}
+
+type Base64URLString = string;
+
+export interface PublicKeyCredentialUserEntityJSON {
+  id: Base64URLString;
+  name: string;
+  displayName: string;
+}
+
+export interface PublicKeyCredentialDescriptorJSON {
+  id: Base64URLString;
+  type: PublicKeyCredentialType;
+  transports?: AuthenticatorTransport[];
+}
+
+export interface AuthenticatorAttestationResponseJSON {
+  clientDataJSON: Base64URLString;
+  attestationObject: Base64URLString;
+  // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
+  authenticatorData?: Base64URLString;
+  // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
+  transports?: AuthenticatorTransport[];
+  // Optional in L2, but becomes required in L3. Play it safe until L3 becomes Recommendation
+  publicKeyAlgorithm?: COSEAlgorithmIdentifier;
+  publicKey?: Base64URLString;
+}
+
+export interface AuthenticatorAssertionResponseJSON {
+  clientDataJSON: Base64URLString;
+  authenticatorData: Base64URLString;
+  signature: Base64URLString;
+  userHandle?: string;
+}

--- a/packages/auth-core/src/types.ts
+++ b/packages/auth-core/src/types.ts
@@ -69,3 +69,18 @@ export interface AuthenticatorAssertionResponseJSON {
   signature: Base64URLString;
   userHandle?: string;
 }
+
+export interface TokenData {
+  auth_token: string;
+  identity_id: string | null;
+  provider_token: string | null;
+  provider_refresh_token: string | null;
+}
+
+export type RegistrationResponse =
+  | { code: string }
+  | { verification_email_sent_at: string };
+
+export type SignupResponse =
+  | { status: "complete"; verifier: string; tokenData: TokenData }
+  | { status: "verificationRequired"; verifier: string };

--- a/packages/auth-core/src/utils.ts
+++ b/packages/auth-core/src/utils.ts
@@ -1,0 +1,90 @@
+export type Serialized<T> = {
+  [P in keyof T]-?: T[P] extends BufferSource
+    ? string
+    : T[P] extends (infer U)[]
+    ? Serialized<U>[]
+    : T[P] extends object | undefined
+    ? Serialized<T[P]>
+    : T[P];
+};
+
+export async function requestGET<ResponseT>(
+  href: string,
+  searchParams?: Record<string, string>,
+  onFailure?: (errorMessage: string) => Promise<ResponseT>
+): Promise<ResponseT> {
+  const url = new URL(href);
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.append(key, value);
+    }
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const bodyText = await response.text();
+      if (onFailure) {
+        return onFailure(bodyText);
+      }
+      throw new Error(`Failed to fetch ${href}: ${bodyText}`);
+    }
+
+    if (response.headers.get("content-type")?.includes("application/json")) {
+      return response.json();
+    }
+
+    return response.text() as ResponseT;
+  } catch (err) {
+    if (onFailure) {
+      return onFailure((err as Error).message);
+    }
+    throw err;
+  }
+}
+
+export async function requestPOST<ResponseT>(
+  href: string,
+  body?: object,
+  onFailure?: (errorMessage: string) => Promise<ResponseT>
+): Promise<ResponseT> {
+  try {
+    const response = await fetch(href, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      ...(body != null
+        ? {
+            body: JSON.stringify(body),
+            headers: { "Content-Type": "application/json" },
+          }
+        : undefined),
+    });
+
+    if (!response.ok) {
+      const bodyText = await response.text();
+      if (onFailure) {
+        return onFailure(bodyText);
+      }
+      throw new Error(`Failed to fetch ${href}: ${bodyText}`);
+    }
+
+    if (response.headers.get("content-type")?.includes("application/json")) {
+      return response.json();
+    }
+    return response.text() as ResponseT;
+  } catch (err) {
+    if (onFailure) {
+      return onFailure((err as Error).message);
+    }
+    throw err;
+  }
+}

--- a/packages/auth-core/src/utils.ts
+++ b/packages/auth-core/src/utils.ts
@@ -54,7 +54,6 @@ export async function requestPOST<ResponseT>(
       ...(body != null
         ? {
             body: JSON.stringify(body),
-            headers: { "Content-Type": "application/json" },
           }
         : undefined),
     });

--- a/packages/auth-core/src/utils.ts
+++ b/packages/auth-core/src/utils.ts
@@ -1,13 +1,3 @@
-export type Serialized<T> = {
-  [P in keyof T]-?: T[P] extends BufferSource
-    ? string
-    : T[P] extends (infer U)[]
-    ? Serialized<U>[]
-    : T[P] extends object | undefined
-    ? Serialized<T[P]>
-    : T[P];
-};
-
 export async function requestGET<ResponseT>(
   href: string,
   searchParams?: Record<string, string>,

--- a/packages/auth-core/src/webauthn.ts
+++ b/packages/auth-core/src/webauthn.ts
@@ -1,0 +1,115 @@
+import { base64UrlToBytes, bytesToBase64Url } from "./crypto";
+import { webAuthnProviderName } from "./consts";
+import { type Serialized, requestGET, requestPOST } from "./utils";
+
+export class WebAuthnClient {
+  private readonly signupOptionsUrl: string;
+  private readonly signupUrl: string;
+  private readonly signinOptionsUrl: string;
+  private readonly signinUrl: string;
+
+  constructor(
+    public readonly baseUrl: string,
+    public readonly verifyUrl: string
+  ) {
+    this.signupOptionsUrl = `${baseUrl}/webauthn/signup/options`;
+    this.signupUrl = `${baseUrl}/webauthn/signup`;
+    this.signinOptionsUrl = `${baseUrl}/webauthn/signin/options`;
+    this.signinUrl = `${baseUrl}/webauthn/signin`;
+  }
+
+  public async signUp(email: string): Promise<{ code?: string }> {
+    const options = await requestGET<
+      Serialized<PublicKeyCredentialCreationOptions>
+    >(this.signupOptionsUrl, { email }, async (errorMessage) => {
+      throw new Error(`Failed to get sign-up options: ${errorMessage}`);
+    });
+
+    const credentials = await navigator.credentials.create({
+      publicKey: {
+        ...options,
+        challenge: base64UrlToBytes(options.challenge),
+        user: {
+          ...options.user,
+          id: base64UrlToBytes(options.user.id),
+        },
+        excludeCredentials: options.excludeCredentials?.map((credential) => ({
+          ...credential,
+          id: base64UrlToBytes(credential.id),
+        })),
+      },
+    });
+
+    return await requestPOST<{ code?: string }>(
+      this.signupUrl,
+      {
+        email,
+        credentials,
+        provider: webAuthnProviderName,
+        verify_url: this.verifyUrl,
+      },
+      async (errorMessage) => {
+        throw new Error(`Failed to sign up: ${errorMessage}`);
+      }
+    );
+  }
+
+  async signIn(email: string): Promise<{ code?: string }> {
+    const options = await requestGET<
+      Serialized<PublicKeyCredentialRequestOptions>
+    >(this.signinOptionsUrl, { email }, async (errorMessage) => {
+      throw new Error(`Failed to get sign-in options: ${errorMessage}`);
+    });
+
+    const assertion = (await navigator.credentials.get({
+      publicKey: {
+        ...options,
+        challenge: base64UrlToBytes(options.challenge),
+        allowCredentials: options.allowCredentials?.map((credential) => ({
+          ...credential,
+          id: base64UrlToBytes(credential.id),
+        })),
+      },
+    })) as PublicKeyCredential;
+
+    if (!assertion) {
+      throw new Error("Failed to sign in");
+    }
+
+    const assertionResponse =
+      assertion.response as AuthenticatorAssertionResponse;
+
+    const encodedAssertion = {
+      ...assertion,
+      rawId: bytesToBase64Url(new Uint8Array(assertion.rawId)),
+      response: {
+        ...assertion.response,
+        authenticatorData: bytesToBase64Url(
+          new Uint8Array(assertionResponse.authenticatorData)
+        ),
+        clientDataJSON: bytesToBase64Url(
+          new Uint8Array(assertionResponse.clientDataJSON)
+        ),
+        signature: bytesToBase64Url(
+          new Uint8Array(assertionResponse.signature)
+        ),
+        userHandle: assertionResponse.userHandle
+          ? bytesToBase64Url(new Uint8Array(assertionResponse.userHandle))
+          : null,
+      },
+    };
+
+    return await requestPOST<{ code?: string }>(
+      this.signinUrl,
+      {
+        email,
+        assertion: encodedAssertion,
+        verify_url: this.verifyUrl,
+        provider: webAuthnProviderName,
+      },
+      (errorMessage: string) => {
+        throw new Error(`Failed to sign in: ${errorMessage}`);
+      }
+    );
+  }
+}

--- a/packages/auth-core/test/crypto.test.ts
+++ b/packages/auth-core/test/crypto.test.ts
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
-import { bytesToBase64Url, sha256, randomBytes } from "../src/crypto";
+import {
+  bytesToBase64Url,
+  base64UrlToBytes,
+  sha256,
+  randomBytes,
+} from "../src/crypto";
 
 describe("crypto", () => {
   describe("bytesToBase64Url", () => {
@@ -7,6 +12,28 @@ describe("crypto", () => {
       for (let i = 0; i < 100; i++) {
         const buffer = crypto.randomBytes(32);
         expect(buffer.toString("base64url")).toEqual(bytesToBase64Url(buffer));
+      }
+    });
+  });
+
+  describe("base64UrlToBytes", () => {
+    test("Equivalent to Buffer implementation", () => {
+      for (let i = 0; i < 100; i++) {
+        const buffer = crypto.randomBytes(32);
+        const encoded = buffer.toString("base64url");
+        expect(new Uint8Array(Buffer.from(encoded, "base64url"))).toEqual(
+          base64UrlToBytes(encoded)
+        );
+      }
+    });
+  });
+
+  describe("round trip base64url", () => {
+    test("bytesToBase64Url and base64UrlToBytes", () => {
+      for (let i = 0; i < 100; i++) {
+        const buffer = new Uint8Array(crypto.randomBytes(32));
+        const base64url = bytesToBase64Url(buffer);
+        expect(buffer).toEqual(base64UrlToBytes(base64url));
       }
     });
   });


### PR DESCRIPTION
There are a few parts here due to how WebAuthn works:

- The "relying party" is the application itself, including both the web application server and the client.
- The "client" is the user's browser.
- An "authenticator" is a piece of software and/or hardware that is capable to generating and storing compatible credentials.

WebAuthn requires scripts that run on both the relying party server and client and that communicate back and forth with each other. The RP client gets an email to identify the user, and then sends that to the RP server, which responds with an "options" object. The RP client then triggers the authenticator "ceremony" (registration or authentication) it's trying to do, and sends that back to the RP server.

The RP server functionality is broken up into four methods on the `Auth` class:

- `getWebAuthnSignupOptionsUrl(email: string): string`: returns the URL to the EdgeDB server for getting the signup options. Applications use this to redirect the client to the correct URL on the EdgeDB server to get the registration/signup options.
- `async signupWithWebAuthn(
    email: string,
    credentials: RegistrationResponseJSON,
    verifyUrl: string,
    userHandle: string
  ): Promise<SignupResponse>`: Sends the credentials that the authenticator generated to the EdgeDB server to create the appropriate `LocalIdentity` and `WebAuthnFactor`.
- `getWebAuthnSigninOptionsUrl(email: string)`: returns the URL to the EdgeDB server gor getting the signin options. Applications use this to redirect the client to the correct URL on the EdgeDB server to get the authentication/signin options.
- `async signinWithWebAuthn(
    email: string,
    assertion: AuthenticationResponseJSON
  ): Promise<TokenData>`: Sends the assertion that the authenticator generated to the EdgeDB server for validation. When successful, returns the `TokenData`

On the RP client, we have the `@edgedb/auth-core/webauthn` script which is used to fetch the options and trigger the signin or signup ceremonies. These functions would be used in client code to be triggered by button clicks or form submission. You'd call these functions with the `email` from a form, and then if successful redirect the user to the appropriate place or show an error.