### PR TITLE
Accept readonly arrays on assignment

### DIFF
--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -391,6 +391,16 @@ describe("insert", () => {
     await query.run(client);
   });
 
+  test("readonly arrays for array and multi properties", async () => {
+    const items: readonly string[] = ["asdf"];
+    const query = e.insert(e.Bag, {
+      stringsMulti: ["asdf", ...items] as const,
+      stringMultiArr: items,
+      stringsArr: items,
+    });
+    await query.run(client);
+  });
+
   test("insert named tuple as shape", async () => {
     const query = e.params(
       {

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -395,7 +395,7 @@ describe("insert", () => {
     const items: readonly string[] = ["asdf"];
     const query = e.insert(e.Bag, {
       stringsMulti: ["asdf", ...items] as const,
-      stringMultiArr: items,
+      stringMultiArr: [items] as const,
       stringsArr: items,
     });
     await query.run(client);

--- a/integration-tests/lts/params.test.ts
+++ b/integration-tests/lts/params.test.ts
@@ -100,10 +100,10 @@ SELECT (SELECT {
           str: string;
           numArr: readonly number[];
           optBool?: boolean | null;
-          tuple: readonly [string, number, boolean[]];
-          namedTuple: Readonly<{ a: number; b: bigint[]; c: string }>;
+          tuple: readonly [string, number, readonly boolean[]];
+          namedTuple: Readonly<{ a: number; b: readonly bigint[]; c: string }>;
           jsonTuple: readonly [unknown];
-          people: Readonly<{ name: string; age: number; tags: string[] }[]>;
+          people: Readonly<{ name: string; age: number; tags: readonly string[] }[]>;
         }
       >
     >(true);

--- a/packages/generate/src/syntax/casting.ts
+++ b/packages/generate/src/syntax/casting.ts
@@ -109,7 +109,7 @@ export type setToAssignmentExpression<
 type getAssignmentLiteral<
   Set extends PrimitiveTypeSet,
   IsSetModifier extends boolean
-> = BaseTypeToTsType<Set["__element__"]> extends infer TsType
+> = BaseTypeToTsType<Set["__element__"], true> extends infer TsType
   ?
       | TsType
       | (Set["__cardinality__"] extends Cardinality.Many

--- a/packages/generate/src/syntax/casting.ts
+++ b/packages/generate/src/syntax/casting.ts
@@ -113,11 +113,11 @@ type getAssignmentLiteral<
   ?
       | TsType
       | (Set["__cardinality__"] extends Cardinality.Many
-          ? TsType[]
+          ? readonly TsType[]
           : Set["__cardinality__"] extends Cardinality.AtLeastOne
           ? IsSetModifier extends true
-            ? TsType[]
-            : [TsType, ...TsType[]]
+            ? readonly TsType[]
+            : readonly [TsType, ...TsType[]]
           : never)
   : never;
 

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -521,7 +521,11 @@ export interface ArrayType<
 type ArrayTypeToTsType<
   Type extends ArrayType,
   isParam extends boolean = false
-> = BaseTypeToTsType<Type["__element__"], isParam>[];
+> = BaseTypeToTsType<Type["__element__"], isParam> extends infer TsType
+  ? isParam extends true
+    ? readonly TsType[]
+    : TsType[]
+  : never;
 
 /////////////////////////
 /// TUPLE TYPE


### PR DESCRIPTION
This is safe because it's saying we expect less.
Rather than giving less on output, which could be a breaking change.