### PR TITLE
Accept readonly arrays on generated query file args

### DIFF
--- a/integration-tests/lts/dbschema/queries/get_movies_starring.edgeql
+++ b/integration-tests/lts/dbschema/queries/get_movies_starring.edgeql
@@ -11,5 +11,5 @@ select Movie {
   version := sys::get_version(),
   range := range(123, 456),
   local_date := <cal::local_date>'2022-09-08',
-} filter .characters.name = <optional str>$name;
-
+} filter .characters.name = <optional str>$name
+  and .release_year in array_unpack(<array<year>>$years);

--- a/integration-tests/lts/queries.test.ts
+++ b/integration-tests/lts/queries.test.ts
@@ -22,7 +22,10 @@ describe("queries", () => {
   });
 
   test("basic select", async () => {
-    const result = await getMoviesStarring(client, { name: "Iron Man" });
+    const result = await getMoviesStarring(client, {
+      name: "Iron Man",
+      years: [2012, 2016] as const, // readonly arrays accepted
+    });
 
     type result = typeof result;
     tc.assert<
@@ -58,6 +61,7 @@ describe("queries", () => {
         GetMoviesStarringArgs,
         {
           name?: string | null;
+          years: readonly number[];
         }
       >
     >(true);


### PR DESCRIPTION
Same as #884, but for query files instead of the query builder