### PR TITLE
Add Auth to Remix create & small fixes

### DIFF
--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -51,7 +51,7 @@ $ yarn build
 Run a local version:
 
 ```bash
-$ yarn create
+$ yarn run create
 ```
 
 ### Testing

--- a/packages/create/src/recipes/express/README.md
+++ b/packages/create/src/recipes/express/README.md
@@ -43,7 +43,7 @@ $ yarn build
 Run a local version:
 
 ```bash
-$ yarn create
+$ yarn run create
 ```
 
 Then choose the **"Express"** template.

--- a/packages/create/src/recipes/nextjs/README.md
+++ b/packages/create/src/recipes/nextjs/README.md
@@ -45,7 +45,7 @@ $ yarn build
 Run a local version:
 
 ```bash
-$ yarn create
+$ yarn run create
 ```
 
 Then choose the **"Next.js"** template.

--- a/packages/create/src/recipes/nextjs/README.md
+++ b/packages/create/src/recipes/nextjs/README.md
@@ -2,7 +2,7 @@
 
 This recipe provides a starting point for building a [Next.js](https://nextjs.org/) application with EdgeDB as the database. It is based on the official Next.js starter template.
 
-We try to actively monitor and incorporate significant changes from the original "create-app" templates to to ensure developers have access to the latest features and best practices. However, we might not cover every possible configuration or permutation due to the vast scope of possibilities.
+We try to actively monitor and incorporate significant changes from the original "create-app" templates to ensure developers have access to the latest features and best practices. However, we might not cover every possible configuration or permutation due to the vast scope of possibilities.
 
 ✨ Check out the [`@edgedb/create` package](https://github.com/edgedb/edgedb-js/blob/master/packages/create/README.md) for more information.
 

--- a/packages/create/src/recipes/remix/README.md
+++ b/packages/create/src/recipes/remix/README.md
@@ -45,7 +45,7 @@ $ yarn build
 Run a local version:
 
 ```bash
-$ yarn create
+$ yarn run create
 ```
 
 Then choose the **"Remix"** template.

--- a/packages/create/src/recipes/remix/index.ts
+++ b/packages/create/src/recipes/remix/index.ts
@@ -15,7 +15,16 @@ const recipe: Recipe = {
     logger("Running remix recipe");
 
     const dirname = path.dirname(new URL(import.meta.url).pathname);
-    await copyTemplateFiles(path.resolve(dirname, "./template"), projectDir);
+
+    let tags;
+
+    if (useEdgeDBAuth) {
+      tags = new Set<string>(["auth"]);
+    }
+
+    await copyTemplateFiles(path.resolve(dirname, "./template"), projectDir, {
+      tags,
+    });
 
     await updatePackage(projectDir, {
       sideEffects: false,
@@ -41,10 +50,15 @@ const recipe: Recipe = {
         "@remix-run/dev": "*",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
+        "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@typescript-eslint/parser": "^6.7.4",
+        eslint: "^8.38.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        typescript: "^5.1.6",
       },
       engines: {
         node: ">=18.0.0",

--- a/packages/create/src/recipes/remix/template/.eslintrc.cjs
+++ b/packages/create/src/recipes/remix/template/.eslintrc.cjs
@@ -43,10 +43,13 @@ module.exports = {
           { name: "Link", linkAttribute: "to" },
           { name: "NavLink", linkAttribute: "to" },
         ],
+        "import/resolver": {
+          typescript: {},
+        },
       },
     },
 
-    // TypeScript
+    // Typescript
     {
       files: ["**/*.{ts,tsx}"],
       plugins: ["@typescript-eslint", "import"],
@@ -71,7 +74,7 @@ module.exports = {
 
     // Node
     {
-      files: [".eslintrc.js"],
+      files: [".eslintrc.cjs"],
       env: {
         node: true,
       },

--- a/packages/create/src/recipes/remix/template/.eslintrc.cjs
+++ b/packages/create/src/recipes/remix/template/.eslintrc.cjs
@@ -49,7 +49,7 @@ module.exports = {
       },
     },
 
-    // Typescript
+    // TypeScript
     {
       files: ["**/*.{ts,tsx}"],
       plugins: ["@typescript-eslint", "import"],

--- a/packages/create/src/recipes/remix/template/app/routes/_index.__auth.tsx
+++ b/packages/create/src/recipes/remix/template/app/routes/_index.__auth.tsx
@@ -1,0 +1,78 @@
+import type { MetaFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import auth, { client } from "~/services/auth.server";
+import clientAuth from "~/services/auth";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "New Remix App" },
+    { name: "description", content: "Welcome to Remix!" },
+  ];
+};
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const session = auth.getSession(request);
+  const isSignedIn = await session.isSignedIn();
+
+  const builtinUIEnabled = await client.queryRequiredSingle<boolean>(
+    `select exists ext::auth::UIConfig`
+  );
+
+  return json({
+    isSignedIn,
+    builtinUIEnabled,
+  });
+};
+
+export default function Index() {
+  const { isSignedIn, builtinUIEnabled } = useLoaderData<typeof loader>();
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
+      <h1>Welcome to Remix</h1>
+      {isSignedIn ? (
+        <p>
+          You are signed in. <a href={clientAuth.getSignoutUrl()}>Sign Out</a>
+        </p>
+      ) : (
+        <>
+          <p> You are not signed in. </p>
+          <a href={clientAuth.getBuiltinUIUrl()}>Sign In with Builtin UI</a>
+          {!builtinUIEnabled && (
+            <p>
+              In order to signin you need to firstly enable the built-in UI in
+              the auth config.
+            </p>
+          )}
+        </>
+      )}
+
+      <ul>
+        <li>
+          <a
+            target="_blank"
+            href="https://remix.run/tutorials/blog"
+            rel="noreferrer"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target="_blank"
+            href="https://remix.run/tutorials/jokes"
+            rel="noreferrer"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target="_blank" href="https://remix.run/docs" rel="noreferrer">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/packages/create/src/recipes/remix/template/app/routes/auth.__auth.$.ts
+++ b/packages/create/src/recipes/remix/template/app/routes/auth.__auth.$.ts
@@ -1,0 +1,24 @@
+import { redirect } from "@remix-run/node";
+import auth from "~/services/auth.server";
+
+export const { loader } = auth.createAuthRouteHandlers({
+  async onBuiltinUICallback({ error, tokenData, isSignUp }) {
+    if (error) {
+      //
+    }
+
+    if (!tokenData) {
+      //
+    }
+
+    if (isSignUp) {
+      //
+    }
+
+    redirect("/");
+  },
+
+  async onSignout() {
+    return redirect("/");
+  },
+});

--- a/packages/create/src/recipes/remix/template/app/services.__auth/auth.server.ts
+++ b/packages/create/src/recipes/remix/template/app/services.__auth/auth.server.ts
@@ -1,0 +1,12 @@
+import createServerAuth from "@edgedb/auth-remix/server";
+import { createClient } from "edgedb";
+import { options } from "./auth";
+
+export const client = createClient({
+  //Note: when developing locally you will need to set tls  security to insecure, because the dev server uses  self-signed certificates which will cause api calls with the fetch api to fail.
+  tlsSecurity: "insecure",
+});
+
+const auth = createServerAuth(client, options);
+
+export default auth;

--- a/packages/create/src/recipes/remix/template/app/services.__auth/auth.ts
+++ b/packages/create/src/recipes/remix/template/app/services.__auth/auth.ts
@@ -1,0 +1,11 @@
+import createClientAuth, {
+  type RemixAuthOptions,
+} from "@edgedb/auth-remix/client";
+
+export const options: RemixAuthOptions = {
+  baseUrl: "http://localhost:3000",
+};
+
+const auth = createClientAuth(options);
+
+export default auth;

--- a/packages/create/src/recipes/sveltekit/README.md
+++ b/packages/create/src/recipes/sveltekit/README.md
@@ -45,7 +45,7 @@ $ yarn build
 Run a local version:
 
 ```bash
-$ yarn create
+$ yarn run create
 ```
 
 Then choose the **"Sveltekit"** template.

--- a/packages/create/src/recipes/sveltekit/README.md
+++ b/packages/create/src/recipes/sveltekit/README.md
@@ -1,6 +1,6 @@
 # Sveltekit Integration Recipe for EdgeDB
 
-This recipe provides a starting point for building a [Svelteki](https://kit.svelte.dev/) application with EdgeDB as the database.
+This recipe provides a starting point for building a [Sveltekit](https://kit.svelte.dev/) application with EdgeDB as the database.
 
 We try to actively monitor and incorporate significant changes from the original "create-app" templates to ensure developers have access to the latest features and best practices. However, we might not cover every possible configuration or permutation due to the vast scope of possibilities.
 

--- a/packages/create/src/recipes/sveltekit/README.md
+++ b/packages/create/src/recipes/sveltekit/README.md
@@ -1,6 +1,6 @@
-# Remix Integration Recipe for EdgeDB
+# Sveltekit Integration Recipe for EdgeDB
 
-This recipe provides a starting point for building a [Remix](https://remix.run/) application with EdgeDB as the database. It is based on the official Remix starter template.
+This recipe provides a starting point for building a [Svelteki](https://kit.svelte.dev/) application with EdgeDB as the database.
 
 We try to actively monitor and incorporate significant changes from the original "create-app" templates to ensure developers have access to the latest features and best practices. However, we might not cover every possible configuration or permutation due to the vast scope of possibilities.
 
@@ -18,7 +18,7 @@ pnpm create @edgedb
 bun create @edgedb
 ```
 
-After running the command, you will be prompted to provide a project name and choose the **"Remix"** template. You can also specify whether to use EdgeDB Auth, initialize a git repository, and install dependencies.
+After running the command, you will be prompted to provide a project name and choose the **"Sveltekit"** template. You can also specify whether to use EdgeDB Auth, initialize a git repository, and install dependencies.
 
 The tool will then create a new directory with the specified name and set up the project.
 
@@ -48,4 +48,4 @@ Run a local version:
 $ yarn create
 ```
 
-Then choose the **"Remix"** template.
+Then choose the **"Sveltekit"** template.

--- a/packages/create/src/recipes/sveltekit/index.ts
+++ b/packages/create/src/recipes/sveltekit/index.ts
@@ -47,8 +47,8 @@ const recipe: Recipe<SveltekitOptions> = {
     logger("Running Sveltekit recipe");
 
     const dirname = path.dirname(new URL(import.meta.url).pathname);
-    let tags;
 
+    let tags;
     if (useEdgeDBAuth) {
       tags = new Set<string>(["auth"]);
     }

--- a/packages/create/src/recipes/sveltekit/template/js/src/routes/+page.__auth.svelte
+++ b/packages/create/src/recipes/sveltekit/template/js/src/routes/+page.__auth.svelte
@@ -1,15 +1,26 @@
 <script>
+  import clientAuth from "$lib/auth";
+
   export let data;
 </script>
 
 <main>
   <h1>Welcome to SvelteKit</h1>
-  <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
   <p>
-    {#if data.isSignedIn}
-      You are signed in.
-    {:else}
-      You are not signed in.
-    {/if}
+    Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
   </p>
+
+  {#if data.isSignedIn}
+    <p>You are signed in. <a href={clientAuth.getSignoutUrl()}>Sign Out</a></p>
+  {:else}
+    <br />
+    <p>You are not signed in.</p>
+    <a href={clientAuth.getBuiltinUIUrl()}>Sign In with Builtin UI</a>
+    {#if !data.builtinUIEnabled}
+      <p>
+        In order to signin you need to firstly enable the built-in UI in the
+        auth config.
+      </p>
+    {/if}
+  {/if}
 </main>

--- a/packages/create/src/recipes/sveltekit/template/js/src/routes/+page.server.__auth.js
+++ b/packages/create/src/recipes/sveltekit/template/js/src/routes/+page.server.__auth.js
@@ -1,8 +1,14 @@
 export async function load({ locals }) {
   const session = locals.auth.session;
   const isSignedIn = await session.isSignedIn();
+  const { client } = session;
+
+  const builtinUIEnabled = await client.queryRequiredSingle(
+    `select exists ext::auth::UIConfig`
+  );
 
   return {
     isSignedIn,
+    builtinUIEnabled,
   };
 }

--- a/packages/create/src/recipes/sveltekit/template/jsdoc/src/routes/+page.__auth.svelte
+++ b/packages/create/src/recipes/sveltekit/template/jsdoc/src/routes/+page.__auth.svelte
@@ -1,16 +1,26 @@
 <script>
+  import clientAuth from "$lib/auth";
+
   export let data;
 </script>
 
 <main>
   <h1>Welcome to SvelteKit</h1>
-  <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
   <p>
-    {#if data.isSignedIn}
-      You are signed in.
-    {:else}
-      You are not signed in.
-    {/if}
+    Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
   </p>
-</main>
 
+  {#if data.isSignedIn}
+    <p>You are signed in. <a href={clientAuth.getSignoutUrl()}>Sign Out</a></p>
+  {:else}
+    <br />
+    <p>You are not signed in.</p>
+    <a href={clientAuth.getBuiltinUIUrl()}>Sign In with Builtin UI</a>
+    {#if !data.builtinUIEnabled}
+      <p>
+        In order to signin you need to firstly enable the built-in UI in the
+        auth config.
+      </p>
+    {/if}
+  {/if}
+</main>

--- a/packages/create/src/recipes/sveltekit/template/jsdoc/src/routes/+page.server.__auth.js
+++ b/packages/create/src/recipes/sveltekit/template/jsdoc/src/routes/+page.server.__auth.js
@@ -1,8 +1,14 @@
 export async function load({ locals }) {
   const session = locals.auth.session;
   const isSignedIn = await session.isSignedIn();
+  const { client } = session;
+
+  const builtinUIEnabled = await client.queryRequiredSingle(
+    `select exists ext::auth::UIConfig`
+  );
 
   return {
     isSignedIn,
+    builtinUIEnabled,
   };
 }

--- a/packages/create/src/recipes/sveltekit/template/ts/src/routes/+page.__auth.svelte
+++ b/packages/create/src/recipes/sveltekit/template/ts/src/routes/+page.__auth.svelte
@@ -1,16 +1,26 @@
 <script>
+  import clientAuth from "$lib/auth";
+
   export let data;
 </script>
 
 <main>
   <h1>Welcome to SvelteKit</h1>
-  <p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
   <p>
-    {#if data.isSignedIn}
-      You are signed in.
-    {:else}
-      You are not signed in.
-    {/if}
+    Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
   </p>
-</main>
 
+  {#if data.isSignedIn}
+    <p>You are signed in. <a href={clientAuth.getSignoutUrl()}>Sign Out</a></p>
+  {:else}
+    <br />
+    <p>You are not signed in.</p>
+    <a href={clientAuth.getBuiltinUIUrl()}>Sign In with Builtin UI</a>
+    {#if !data.builtinUIEnabled}
+      <p>
+        In order to signin you need to firstly enable the built-in UI in the
+        auth config.
+      </p>
+    {/if}
+  {/if}
+</main>

--- a/packages/create/src/recipes/sveltekit/template/ts/src/routes/+page.server.__auth.ts
+++ b/packages/create/src/recipes/sveltekit/template/ts/src/routes/+page.server.__auth.ts
@@ -1,8 +1,14 @@
 export async function load({ locals }) {
   const session = locals.auth.session;
   const isSignedIn = await session.isSignedIn();
+  const { client } = session;
+
+  const builtinUIEnabled = await client.queryRequiredSingle<boolean>(
+    `select exists ext::auth::UIConfig`
+  );
 
   return {
     isSignedIn,
+    builtinUIEnabled,
   };
 }


### PR DESCRIPTION
- I updated Readmes to use `yarn run create` instead of `yarn create` when running locally because yarn create is used for creating new projects from create starter kits, it will not run our create scripts but it expects create-starter-kit as an argument. 

Maybe I used something wrong, if this works on your side @jaclarke @scotttrinh I can revert this changes.

- Added auth files to Remix template since it was missing it.

- Updated Remix and Sveltekit index pages to show link to builtin UI if enabled.
