### PR TITLE
Fix collision in QB with nested object & module names

### DIFF
--- a/integration-tests/lts/dbschema/default.esdl
+++ b/integration-tests/lts/dbschema/default.esdl
@@ -220,4 +220,17 @@ module User {
   scalar type Status extending enum<"Active", "Disabled">;
 
   type User extending default::User;
+
+  type Profile {
+    link address -> User::Profile::MailingAddress;
+  }
+
+  module Profile {
+    type MailingAddress {
+      property street -> str;
+      property city -> str;
+      property state -> str;
+      property zip -> str;
+    }
+  }
 }

--- a/integration-tests/lts/dbschema/migrations/00025.edgeql
+++ b/integration-tests/lts/dbschema/migrations/00025.edgeql
@@ -1,0 +1,14 @@
+CREATE MIGRATION m1rjlewu5fimvn4lf4xguullcbvlttuxmtxyl4yz4dmsbyw5shva7a
+    ONTO m13x34vijy2dlwl3x5jewnjcxb6tysyo7pr2zbbljadjdi2y5w3cja
+{
+  CREATE MODULE User::Profile IF NOT EXISTS;
+  CREATE TYPE User::Profile::MailingAddress {
+      CREATE PROPERTY city: std::str;
+      CREATE PROPERTY state: std::str;
+      CREATE PROPERTY street: std::str;
+      CREATE PROPERTY zip: std::str;
+  };
+  CREATE TYPE User::Profile {
+      CREATE LINK address: User::Profile::MailingAddress;
+  };
+};

--- a/packages/generate/src/builders.ts
+++ b/packages/generate/src/builders.ts
@@ -488,12 +488,22 @@ class BuilderImportsExports {
       exports.push(`export type { ${exportTypes.join(", ")} };\n`);
     }
     if (refsDefault.length || forceDefaultExport) {
+      const refsByExportAs = [...groupToMapBy(refsDefault, (x) => x.as)].map(
+        ([as, group]) => ({
+          as,
+          refs: group.map(({ ref }) => ref).reverse(),
+        })
+      );
       if (mode === "ts" || mode === "dts") {
         exports.push(
           `${
             mode === "dts" ? "declare " : ""
-          }type __defaultExports = {\n${refsDefault
-            .map(({ ref, as }) => `  ${genutil.quote(as)}: typeof ${ref}`)
+          }type __defaultExports = {\n${refsByExportAs
+            .map(({ refs, as }) => {
+              const key = genutil.quote(as);
+              const value = refs.map((ref) => `typeof ${ref}`).join(" & ");
+              return `  ${key}: ${value}`;
+            })
             .join(";\n")}\n};`
         );
       }
@@ -501,8 +511,17 @@ class BuilderImportsExports {
         exports.push(
           `const __defaultExports${
             mode === "ts" ? ": __defaultExports" : ""
-          } = {\n${refsDefault
-            .map(({ ref, as }) => `  ${genutil.quote(as)}: ${ref}`)
+          } = {\n${refsByExportAs
+            .map(({ refs, as }) => {
+              const key = genutil.quote(as);
+              const value =
+                refs.length === 1
+                  ? refs
+                  : `Object.freeze({ ${refs
+                      .map((ref) => `...${ref}`)
+                      .join(", ")} })`;
+              return `  ${key}: ${value}`;
+            })
             .join(",\n")}\n};`
         );
       }
@@ -847,3 +866,14 @@ export class DirBuilder {
     }
   }
 }
+
+const groupToMapBy = <K, V>(
+  items: Iterable<V>,
+  by: (item: V) => K
+): ReadonlyMap<K, readonly V[]> =>
+  [...items].reduce((map, item) => {
+    const groupKey = by(item);
+    const prev = map.get(groupKey) ?? [];
+    map.set(groupKey, [...prev, item]);
+    return map;
+  }, new Map<K, V[]>());

--- a/packages/generate/src/builders.ts
+++ b/packages/generate/src/builders.ts
@@ -603,15 +603,16 @@ export class CodeBuilder {
 
     let prefix = "";
     if (ref.dir !== this.dir) {
-      const mod = path.posix.basename(ref.dir, path.posix.extname(ref.dir));
-      prefix = `_${mod}`;
+      const namespaceParts = identRef.name.split("::").slice(0, -1);
+      prefix = `_${namespaceParts.join("")}`;
+      const moduleFileName = namespaceParts.at(-1)!;
 
       let importPath = path.posix.join(
         path.posix.relative(
           path.posix.dirname(this.dir),
           path.posix.dirname(ref.dir)
         ),
-        mod
+        moduleFileName
       );
 
       if (!importPath.startsWith("../")) {


### PR DESCRIPTION
Probably need tests, but wanted to get this up before the weekend.

## Use full namespace in import

Previously these FQNs
```edgeql
A::X::Y
B::X::Y
```
were emitted as:
```ts
import _X from './A/X';
import _X from './B/X';
```

now they are emitted as:
```ts
import _AX from './A/X';
import _BX from './B/X';
```

I opted to use `indentRef.name` instead of path logic.
It just seemed easier, but I understand this is a deviation.
I'm open to changing.

## Merged nested objects with nested modules (just like top level)

Previously these FQNs
```edgeql
A::B
A::B::C
```
were emitted as:
```ts
type __defaultExports = {
  "B": typeof B;
  "B": typeof _module__B;
};
```
Now these types & values are merged, just as in `generateIndex`.