### PR TITLE
Create PKCE session for verification with email

### DIFF
--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -211,11 +211,14 @@ export class Auth {
   }
 
   async resendVerificationEmailForEmail(email: string, verifyUrl: string) {
+    const { verifier, challenge } = await pkce.createVerifierChallengePair();
     await this._post("resend-verification-email", {
       provider: emailPasswordProviderName,
       email,
       verify_url: verifyUrl,
+      challenge,
     });
+    return { verifier };
   }
 
   async sendPasswordResetEmail(email: string, resetUrl: string) {

--- a/packages/auth-nextjs/src/pages/client.ts
+++ b/packages/auth-nextjs/src/pages/client.ts
@@ -54,6 +54,11 @@ export class NextPagesClientAuth extends NextAuthHelpers {
       | {
           verification_token: string;
         }
+      | {
+          email: string;
+          verify_url: string;
+          challenge: string;
+        }
       | FormData
   ) {
     return await apiRequest(

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -506,15 +506,44 @@ export abstract class NextAuth extends NextAuthHelpers {
           case "emailpassword/resend-verification-email": {
             const data = await _getReqBody(req);
             const isAction = _isAction(data);
-            const [verificationToken] = _extractParams(
-              data,
-              ["verification_token"],
-              "verification_token missing from request body"
-            );
-            (await this.core).resendVerificationEmail(verificationToken);
-            return isAction
-              ? Response.json({ _data: null })
-              : new Response(null, { status: 204 });
+            const verificationToken =
+              data instanceof FormData
+                ? data.get("verification_token")?.toString()
+                : data.verification_token;
+            const email =
+              data instanceof FormData
+                ? data.get("email")?.toString()
+                : data.email;
+
+            if (verificationToken) {
+              await (
+                await this.core
+              ).resendVerificationEmail(verificationToken.toString());
+              return isAction
+                ? Response.json({ _data: null })
+                : new Response(null, { status: 204 });
+            } else if (email) {
+              const { verifier } = await (
+                await this.core
+              ).resendVerificationEmailForEmail(
+                email.toString(),
+                `${this._authRoute}/emailpassword/verify`
+              );
+              cookies().set({
+                name: this.options.pkceVerifierCookieName,
+                value: verifier,
+                httpOnly: true,
+                sameSite: "strict",
+                path: "/",
+              });
+              return isAction
+                ? Response.json({ _data: null })
+                : new Response(null, { status: 204 });
+            } else {
+              throw new InvalidDataError(
+                "verification_token or email missing from request body"
+              );
+            }
           }
           default:
             return new Response("Unknown auth route", {
@@ -550,7 +579,9 @@ export class NextAuthSession {
   }
 }
 
-function _getReqBody(req: NextRequest) {
+function _getReqBody(
+  req: NextRequest
+): Promise<FormData | Record<string, unknown>> {
   return req.headers.get("Content-Type") === "application/json"
     ? req.json()
     : req.formData();


### PR DESCRIPTION
Blocked by https://github.com/edgedb/edgedb/pull/7037

The current email verification flow always assumes that it ends in a PKCE code exchange. However, currently, if you send just the email, we do not start a PKCE flow, so it just ends in a redirect or `204 No Content` response. The above linked PR to the auth server allows specifying a `challenge` in the body along with the email which will trigger a PKCE flow.