### PR TITLE
Adjust parentheses on QB cast rendering to fix pathing off of it

### DIFF
--- a/integration-tests/lts/casts.test.ts
+++ b/integration-tests/lts/casts.test.ts
@@ -24,21 +24,21 @@ describe("casts", () => {
     >(true);
     assert.equal(
       primitiveCast.toEdgeQL(),
-      `<std::float32>(<std::float64>3.14)`
+      `<std::float32><std::float64>3.14`
     );
   });
 
   test("enums", async () => {
     assert.equal(
       e.cast(e.Genre, e.str("Horror")).toEdgeQL(),
-      `<default::Genre>("Horror")`
+      `<default::Genre>"Horror"`
     );
     const result = await e.cast(e.Genre, e.str("Horror")).run(client);
     assert.equal(result, "Horror");
   });
 
   test("scalar literals", () => {
-    assert.equal(e.cast(e.json, "hello").toEdgeQL(), `<std::json>("hello")`);
+    assert.equal(e.cast(e.json, "hello").toEdgeQL(), `<std::json>"hello"`);
   });
 
   test("object type empty set", () => {
@@ -58,7 +58,7 @@ describe("casts", () => {
 
     assert.equal(
       expr.toEdgeQL(),
-      `<default::Movie>(<std::uuid>("00000000-0000-0000-0000-000000000000"))`
+      `<default::Movie><std::uuid>"00000000-0000-0000-0000-000000000000"`
     );
 
     tc.assert<tc.IsExact<(typeof expr)["__element__"], $Movie>>(true);
@@ -78,10 +78,22 @@ describe("casts", () => {
 
     assert.equal(
       expr.toEdgeQL(),
-      `<default::Movie>(<std::uuid>({ "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002" }))`
+      `<default::Movie><std::uuid>{ "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002" }`
     );
 
     tc.assert<tc.IsExact<(typeof expr)["__element__"], $Movie>>(true);
     tc.assert<tc.IsExact<(typeof expr)["__cardinality__"], $.Cardinality.AtLeastOne>>(true);
+  });
+
+  test("object cast, then path", () => {
+    const expr = e.cast(
+      e.Movie,
+      e.cast(e.uuid, "00000000-0000-0000-0000-000000000000")
+    ).genre;
+
+    assert.equal(
+      expr.toEdgeQL(),
+      `(<default::Movie><std::uuid>"00000000-0000-0000-0000-000000000000").genre`
+    );
   });
 });

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -935,7 +935,12 @@ function renderEdgeQL(
     if (expr.__expr__ === null) {
       return `<${typeName}>{}`;
     }
-    return `<${typeName}>(${renderEdgeQL(expr.__expr__, ctx)})`;
+    const rawInnerExpr = renderEdgeQL(expr.__expr__, ctx);
+    const isCast =
+      (expr.__expr__ as any).__kind__ === ExpressionKind.Cast &&
+      rawInnerExpr[0] === "(";
+    const innerExpr = isCast ? rawInnerExpr.slice(1, -1) : rawInnerExpr;
+    return `(<${typeName}>${innerExpr})`;
   } else if (expr.__kind__ === ExpressionKind.Select) {
     const lines: string[] = [];
     if (isObjectType(expr.__element__)) {


### PR DESCRIPTION
Fixes #917.
I'm not sure when the inner exp would need to be wrapped in parentheses before casting, but I removed that.
Now wrapping the whole expression.
Also removing the parentheses wrapping for multiple cast siblings.