### PR TITLE
Reduce type instantiations in `e.literal`

### DIFF
--- a/integration-tests/legacy/package.json
+++ b/integration-tests/legacy/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {}
 }

--- a/integration-tests/legacy/package.json
+++ b/integration-tests/legacy/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -1,6 +1,12 @@
 import { bench } from "@arktype/attest";
 
 import e from "./dbschema/edgeql-js";
+import { type BaseTypeToTsType } from "./dbschema/edgeql-js/typesystem";
+
+bench("BaseTypeToTsType: scalar", () => {
+  const lit = e.int32(42);
+  return {} as BaseTypeToTsType<typeof lit>;
+}).types([601, "instantiations"]);
 
 bench("e.literal: scalar", () => {
   const lit = e.literal(e.int32, 42);
@@ -16,6 +22,11 @@ bench("e.str: scalar", () => {
   const lit = e.str("abcd");
   return {} as typeof lit;
 }).types([894, "instantiations"]);
+
+bench("BaseTypeToTsType: array literal", () => {
+  const lit = e.array([e.str("abcd")]);
+  return {} as BaseTypeToTsType<typeof lit>;
+}).types([2631, "instantiations"]);
 
 bench("e.literal: array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -5,49 +5,49 @@ import e from "./dbschema/edgeql-js";
 bench("e.literal: scalar", () => {
   const lit = e.literal(e.int32, 42);
   return {} as typeof lit;
-}).types([4468, "instantiations"]);
+}).types([992, "instantiations"]);
 
 bench("e.int32: scalar", () => {
   const lit = e.int32(42);
   return {} as typeof lit;
-}).types([558, "instantiations"]);
+}).types([556, "instantiations"]);
 
 bench("e.str: scalar", () => {
   const lit = e.str("abcd");
   return {} as typeof lit;
-}).types([897, "instantiations"]);
+}).types([894, "instantiations"]);
 
 bench("e.literal: array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
   return {} as typeof lit;
-}).types([7568, "instantiations"]);
+}).types([4095, "instantiations"]);
 
 bench("e.array: array literal", () => {
   const lit = e.array([e.str("abcd")]);
   return {} as typeof lit;
-}).types([2606, "instantiations"]);
+}).types([2599, "instantiations"]);
 
 bench("e.literal: named tuple literal", () => {
   const lit = e.literal(e.tuple({ str: e.str }), {
     str: "asdf",
   });
   return {} as typeof lit;
-}).types([16528, "instantiations"]);
+}).types([10996, "instantiations"]);
 
 bench("e.tuple: named tuple literal", () => {
   const lit = e.tuple({ str: e.str("asdf") });
   return {} as typeof lit;
-}).types([9831, "instantiations"]);
+}).types([7796, "instantiations"]);
 
 bench("e.literal: tuple literal", () => {
   const lit = e.literal(e.tuple([e.str, e.int32]), ["asdf", 42]);
   return {} as typeof lit;
-}).types([13125, "instantiations"]);
+}).types([7600, "instantiations"]);
 
 bench("e.tuple: tuple literal", () => {
   const lit = e.tuple([e.str("asdf"), e.int32(42)]);
   return {} as typeof lit;
-}).types([4889, "instantiations"]);
+}).types([4836, "instantiations"]);
 
 bench("e.literal: array of tuples", () => {
   const lit = e.literal(e.array(e.tuple([e.str, e.int32])), [
@@ -55,7 +55,7 @@ bench("e.literal: array of tuples", () => {
     ["qwer", 43],
   ]);
   return {} as typeof lit;
-}).types([15721, "instantiations"]);
+}).types([10191, "instantiations"]);
 
 bench("e.array: array of tuples", () => {
   const lit = e.array([
@@ -63,7 +63,7 @@ bench("e.array: array of tuples", () => {
     e.tuple([e.str("qwer"), e.int32(43)]),
   ]);
   return {} as typeof lit;
-}).types([22894, "instantiations"]);
+}).types([20613, "instantiations"]);
 
 bench("base type: array", () => {
   const baseType = e.array(e.str);
@@ -73,29 +73,29 @@ bench("base type: array", () => {
 bench("base type: named tuple", () => {
   const baseType = e.tuple({ str: e.str });
   return {} as typeof baseType;
-}).types([3545, "instantiations"]);
+}).types([3564, "instantiations"]);
 
 bench("select: scalar", () => {
   const query = e.select(e.int32(42));
   return {} as typeof query;
-}).types([1177, "instantiations"]);
+}).types([1173, "instantiations"]);
 
 bench("select: free object", () => {
   const query = e.select({ meaning: e.int32(42) });
   return {} as typeof query;
-}).types([2033, "instantiations"]);
+}).types([2027, "instantiations"]);
 
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3702, "instantiations"]);
+}).types([3687, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5039, "instantiations"]);
+}).types([5102, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -104,7 +104,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6057, "instantiations"]);
+}).types([6118, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -116,7 +116,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6374, "instantiations"]);
+}).types([6352, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -128,7 +128,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6447, "instantiations"]);
+}).types([6428, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -141,7 +141,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6786, "instantiations"]);
+}).types([6765, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -154,7 +154,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6510, "instantiations"]);
+}).types([6490, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -167,7 +167,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6553, "instantiations"]);
+}).types([6533, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -181,4 +181,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([12010, "instantiations"]);
+}).types([11248, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -193,3 +193,13 @@ bench("params select", () => {
   );
   return {} as typeof query;
 }).types([11290, "instantiations"]);
+
+bench("e.op: str = str", () => {
+  const op = e.op(e.str("a"), "=", e.str("b"));
+  return {} as typeof op;
+}).types([1854, "instantiations"]);
+
+bench("e.op: str ilike str", () => {
+  const op = e.op(e.str("a"), "ilike", e.str("b"));
+  return {} as typeof op;
+}).types([51413, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -2,27 +2,68 @@ import { bench } from "@arktype/attest";
 
 import e from "./dbschema/edgeql-js";
 
-bench("scalar literal", () => {
+bench("e.literal: scalar", () => {
+  const lit = e.literal(e.int32, 42);
+  return {} as typeof lit;
+}).types([4468, "instantiations"]);
+
+bench("e.int32: scalar", () => {
   const lit = e.int32(42);
   return {} as typeof lit;
 }).types([558, "instantiations"]);
 
-bench("array literal", () => {
+bench("e.str: scalar", () => {
+  const lit = e.str("abcd");
+  return {} as typeof lit;
+}).types([897, "instantiations"]);
+
+bench("e.literal: array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
   return {} as typeof lit;
-}).types([4116, "instantiations"]);
+}).types([7568, "instantiations"]);
 
-bench("named tuple literal", () => {
+bench("e.array: array literal", () => {
+  const lit = e.array([e.str("abcd")]);
+  return {} as typeof lit;
+}).types([2606, "instantiations"]);
+
+bench("e.literal: named tuple literal", () => {
   const lit = e.literal(e.tuple({ str: e.str }), {
     str: "asdf",
   });
   return {} as typeof lit;
-}).types([13063, "instantiations"]);
+}).types([16528, "instantiations"]);
 
-bench("tuple literal", () => {
+bench("e.tuple: named tuple literal", () => {
+  const lit = e.tuple({ str: e.str("asdf") });
+  return {} as typeof lit;
+}).types([9831, "instantiations"]);
+
+bench("e.literal: tuple literal", () => {
   const lit = e.literal(e.tuple([e.str, e.int32]), ["asdf", 42]);
   return {} as typeof lit;
-}).types([9668, "instantiations"]);
+}).types([13125, "instantiations"]);
+
+bench("e.tuple: tuple literal", () => {
+  const lit = e.tuple([e.str("asdf"), e.int32(42)]);
+  return {} as typeof lit;
+}).types([4889, "instantiations"]);
+
+bench("e.literal: array of tuples", () => {
+  const lit = e.literal(e.array(e.tuple([e.str, e.int32])), [
+    ["asdf", 42],
+    ["qwer", 43],
+  ]);
+  return {} as typeof lit;
+}).types([15721, "instantiations"]);
+
+bench("e.array: array of tuples", () => {
+  const lit = e.array([
+    e.tuple([e.str("asdf"), e.int32(42)]),
+    e.tuple([e.str("qwer"), e.int32(43)]),
+  ]);
+  return {} as typeof lit;
+}).types([22894, "instantiations"]);
 
 bench("base type: array", () => {
   const baseType = e.array(e.str);
@@ -54,7 +95,7 @@ bench("select: filtered", () => {
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5046, "instantiations"]);
+}).types([5039, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -63,7 +104,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6064, "instantiations"]);
+}).types([6057, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -140,4 +181,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([12005, "instantiations"]);
+}).types([12010, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -6,12 +6,12 @@ import { type BaseTypeToTsType } from "./dbschema/edgeql-js/typesystem";
 bench("BaseTypeToTsType: scalar", () => {
   const lit = e.int32(42);
   return {} as BaseTypeToTsType<typeof lit>;
-}).types([601, "instantiations"]);
+}).types([596, "instantiations"]);
 
 bench("e.literal: scalar", () => {
   const lit = e.literal(e.int32, 42);
   return {} as typeof lit;
-}).types([992, "instantiations"]);
+}).types([755, "instantiations"]);
 
 bench("e.int32: scalar", () => {
   const lit = e.int32(42);
@@ -26,34 +26,34 @@ bench("e.str: scalar", () => {
 bench("BaseTypeToTsType: array literal", () => {
   const lit = e.array([e.str("abcd")]);
   return {} as BaseTypeToTsType<typeof lit>;
-}).types([2631, "instantiations"]);
+}).types([2394, "instantiations"]);
 
 bench("e.literal: array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
   return {} as typeof lit;
-}).types([4095, "instantiations"]);
+}).types([1980, "instantiations"]);
 
 bench("e.array: array literal", () => {
   const lit = e.array([e.str("abcd")]);
   return {} as typeof lit;
-}).types([2599, "instantiations"]);
+}).types([2367, "instantiations"]);
 
 bench("e.literal: named tuple literal", () => {
   const lit = e.literal(e.tuple({ str: e.str }), {
     str: "asdf",
   });
   return {} as typeof lit;
-}).types([10996, "instantiations"]);
+}).types([10765, "instantiations"]);
 
 bench("e.tuple: named tuple literal", () => {
   const lit = e.tuple({ str: e.str("asdf") });
   return {} as typeof lit;
-}).types([7796, "instantiations"]);
+}).types([7564, "instantiations"]);
 
 bench("e.literal: tuple literal", () => {
   const lit = e.literal(e.tuple([e.str, e.int32]), ["asdf", 42]);
   return {} as typeof lit;
-}).types([7600, "instantiations"]);
+}).types([4670, "instantiations"]);
 
 bench("e.tuple: tuple literal", () => {
   const lit = e.tuple([e.str("asdf"), e.int32(42)]);
@@ -66,7 +66,7 @@ bench("e.literal: array of tuples", () => {
     ["qwer", 43],
   ]);
   return {} as typeof lit;
-}).types([10191, "instantiations"]);
+}).types([5664, "instantiations"]);
 
 bench("e.array: array of tuples", () => {
   const lit = e.array([
@@ -74,7 +74,7 @@ bench("e.array: array of tuples", () => {
     e.tuple([e.str("qwer"), e.int32(43)]),
   ]);
   return {} as typeof lit;
-}).types([20613, "instantiations"]);
+}).types([20582, "instantiations"]);
 
 bench("base type: array", () => {
   const baseType = e.array(e.str);
@@ -106,7 +106,7 @@ bench("select: filtered", () => {
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5102, "instantiations"]);
+}).types([5100, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -115,7 +115,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6118, "instantiations"]);
+}).types([6116, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -192,4 +192,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([11248, "instantiations"]);
+}).types([11290, "instantiations"]);

--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -5,51 +5,56 @@ import e from "./dbschema/edgeql-js";
 bench("scalar literal", () => {
   const lit = e.int32(42);
   return {} as typeof lit;
-}).types([555, "instantiations"]);
+}).types([558, "instantiations"]);
 
 bench("array literal", () => {
   const lit = e.literal(e.array(e.str), ["abcd"]);
   return {} as typeof lit;
-}).types([2407, "instantiations"]);
+}).types([4116, "instantiations"]);
 
 bench("named tuple literal", () => {
   const lit = e.literal(e.tuple({ str: e.str }), {
     str: "asdf",
   });
   return {} as typeof lit;
-}).types([11597, "instantiations"]);
+}).types([13063, "instantiations"]);
+
+bench("tuple literal", () => {
+  const lit = e.literal(e.tuple([e.str, e.int32]), ["asdf", 42]);
+  return {} as typeof lit;
+}).types([9668, "instantiations"]);
 
 bench("base type: array", () => {
   const baseType = e.array(e.str);
   return {} as typeof baseType;
-}).types([348, "instantiations"]);
+}).types([351, "instantiations"]);
 
 bench("base type: named tuple", () => {
   const baseType = e.tuple({ str: e.str });
   return {} as typeof baseType;
-}).types([2160, "instantiations"]);
+}).types([3545, "instantiations"]);
 
 bench("select: scalar", () => {
   const query = e.select(e.int32(42));
   return {} as typeof query;
-}).types([1155, "instantiations"]);
+}).types([1177, "instantiations"]);
 
 bench("select: free object", () => {
   const query = e.select({ meaning: e.int32(42) });
   return {} as typeof query;
-}).types([2012, "instantiations"]);
+}).types([2033, "instantiations"]);
 
 bench("select: id only", () => {
   const query = e.select(e.User, () => ({ id: true }));
   return {} as typeof query;
-}).types([3687, "instantiations"]);
+}).types([3702, "instantiations"]);
 
 bench("select: filtered", () => {
   const query = e.select(e.User, () => ({
     filter_single: { id: e.uuid("123") },
   }));
   return {} as typeof query;
-}).types([5019, "instantiations"]);
+}).types([5046, "instantiations"]);
 
 bench("select: nested", () => {
   const user = e.select(e.User, () => ({
@@ -58,7 +63,7 @@ bench("select: nested", () => {
   const query = e.select(user, () => ({ id: true }));
 
   return {} as typeof query;
-}).types([6037, "instantiations"]);
+}).types([6064, "instantiations"]);
 
 bench("select: complex", () => {
   const query = e.select(e.Movie, () => ({
@@ -70,7 +75,7 @@ bench("select: complex", () => {
     }),
   }));
   return {} as typeof query;
-}).types([6342, "instantiations"]);
+}).types([6374, "instantiations"]);
 
 bench("select: with filter", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -82,7 +87,7 @@ bench("select: with filter", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6289, "instantiations"]);
+}).types([6447, "instantiations"]);
 
 bench("select: with order", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -95,7 +100,7 @@ bench("select: with order", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6624, "instantiations"]);
+}).types([6786, "instantiations"]);
 
 bench("select: with limit", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -108,7 +113,7 @@ bench("select: with limit", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6352, "instantiations"]);
+}).types([6510, "instantiations"]);
 
 bench("select: with offset", () => {
   const query = e.select(e.Hero, (hero) => ({
@@ -121,7 +126,7 @@ bench("select: with offset", () => {
     filter_single: e.op(hero.name, "=", "Peter Parker"),
   }));
   return {} as typeof query;
-}).types([6391, "instantiations"]);
+}).types([6553, "instantiations"]);
 
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
@@ -135,4 +140,4 @@ bench("params select", () => {
     }))
   );
   return {} as typeof query;
-}).types([11865, "instantiations"]);
+}).types([12005, "instantiations"]);

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -24,7 +24,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -24,7 +24,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {}
 }

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1162,8 +1162,9 @@ SELECT __scope_0_defaultPerson {
       name: h.name,
       otherHeros: e.select(e.Hero, (h2) => ({
         name: true,
-        // @ts-expect-error - FIXME: union too complex to represent error
-        names: e.op(h.name, "++", h2.name),
+        name_one: h.name,
+        name_two: h2.name,
+        names_match: e.op(h.name, "=", h2.name),
         order_by: h2.name,
       })),
       order_by: h.name,
@@ -1177,7 +1178,9 @@ SELECT __scope_0_defaultPerson {
       name: h.name,
       otherHeros: heros.map((h2) => ({
         name: h2.name,
-        names: h.name + h2.name,
+        name_one: h.name,
+        name_two: h2.name,
+        names_match: h.name === h2.name,
       })),
     }));
 

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1162,6 +1162,7 @@ SELECT __scope_0_defaultPerson {
       name: h.name,
       otherHeros: e.select(e.Hero, (h2) => ({
         name: true,
+        // @ts-expect-error - FIXME: union too complex to represent error
         names: e.op(h.name, "++", h2.name),
         order_by: h2.name,
       })),
@@ -1377,9 +1378,11 @@ SELECT __scope_0_defaultPerson {
 
     const result = await query.run(client);
 
+    type Result = typeof result;
+
     tc.assert<
       tc.IsExact<
-        typeof result,
+        Result,
         { xy: { a: string | null; b: number | null } | null }[]
       >
     >(true);

--- a/integration-tests/nightly/package.json
+++ b/integration-tests/nightly/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {}
 }

--- a/integration-tests/nightly/package.json
+++ b/integration-tests/nightly/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {}
 }

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -16,7 +16,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "scripts": {
     "lint": "tslint 'packages/*/src/**/*.ts'",

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -37,7 +37,7 @@
     "edgedb": "^1.4.0",
     "jest": "29.5.0",
     "ts-jest": "29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -37,7 +37,7 @@
     "edgedb": "^1.4.0",
     "jest": "29.5.0",
     "ts-jest": "29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
     "express": "^4.18.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
     "cookie-parser": "^1.4.6",

--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
     "express": "^4.18.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "cookie-parser": "^1.4.6",

--- a/packages/auth-nextjs/package.json
+++ b/packages/auth-nextjs/package.json
@@ -27,13 +27,13 @@
     "@types/react": "^18.2.42",
     "edgedb": "^1.3.6",
     "next": "13.5.6",
-    "typescript": "^5.2.2",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6",
-    "react": "^18.2.0",
-    "next": ">=13.5.6 <15.0.0"
+    "next": ">=13.5.6 <15.0.0",
+    "react": "^18.2.0"
   },
   "dependencies": {
     "@edgedb/auth-core": "0.2.0-beta.1"

--- a/packages/auth-nextjs/package.json
+++ b/packages/auth-nextjs/package.json
@@ -28,7 +28,7 @@
     "edgedb": "^1.3.6",
     "next": "13.5.6",
     "react": "^18.2.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6",

--- a/packages/auth-remix/package.json
+++ b/packages/auth-remix/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/node": "^20.8.4",
     "edgedb": "^1.4.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-remix/package.json
+++ b/packages/auth-remix/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/node": "^20.8.4",
     "edgedb": "^1.4.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-sveltekit/package.json
+++ b/packages/auth-sveltekit/package.json
@@ -19,11 +19,11 @@
     "build": "tsc --project tsconfig.json"
   },
   "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
-    "typescript": "^5.2.2",
     "svelte": "^4.2.7",
-    "@sveltejs/kit": "^2.0.0",
+    "typescript": "^5.4.2",
     "vite": "^5.0.3"
   },
   "peerDependencies": {

--- a/packages/auth-sveltekit/package.json
+++ b/packages/auth-sveltekit/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^20.8.4",
     "edgedb": "^1.3.6",
     "svelte": "^4.2.7",
-    "typescript": "^5.4.2",
+    "typescript": "^5.4.3",
     "vite": "^5.0.3"
   },
   "peerDependencies": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -23,7 +23,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^20.10.4",
     "tsx": "^4.6.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -23,7 +23,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^20.10.4",
     "tsx": "^4.6.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -34,7 +34,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "29.1.0",
     "tsx": "^3.12.7",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -34,7 +34,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "29.1.0",
     "tsx": "^3.12.7",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit",

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -31,7 +31,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   },
   "dependencies": {},
   "scripts": {

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -31,7 +31,7 @@
     "jest": "^29.5.0",
     "superjson": "^1.12.4",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.4.2"
   },
   "dependencies": {},
   "scripts": {

--- a/packages/generate/src/syntax/literal.ts
+++ b/packages/generate/src/syntax/literal.ts
@@ -35,7 +35,6 @@ export function literal<
     __element__: type,
     __cardinality__: Cardinality.One,
     __kind__: ExpressionKind.Literal,
-    // @ts-expect-error: Type instantiation error
     __value__: value,
   }) as any;
 }

--- a/packages/generate/src/syntax/literal.ts
+++ b/packages/generate/src/syntax/literal.ts
@@ -27,10 +27,10 @@ export type $expr_Literal<Type extends BaseType = BaseType> = Expression<{
   __value__: any;
 }>;
 
-export function literal<T extends BaseType>(
-  type: T,
-  value: BaseTypeToTsType<T>
-): $expr_Literal<T> {
+export function literal<
+  T extends BaseType,
+  TsType extends BaseTypeToTsType<T> = BaseTypeToTsType<T>
+>(type: T, value: TsType): $expr_Literal<T> {
   return $expressionify({
     __element__: type,
     __cardinality__: Cardinality.One,

--- a/packages/generate/src/syntax/literal.ts
+++ b/packages/generate/src/syntax/literal.ts
@@ -35,6 +35,7 @@ export function literal<T extends BaseType>(
     __element__: type,
     __cardinality__: Cardinality.One,
     __kind__: ExpressionKind.Literal,
+    // @ts-expect-error: Type instantiation error
     __value__: value,
   }) as any;
 }

--- a/packages/generate/src/syntax/literal.ts
+++ b/packages/generate/src/syntax/literal.ts
@@ -29,14 +29,15 @@ export type $expr_Literal<Type extends BaseType = BaseType> = Expression<{
 
 export function literal<
   T extends BaseType,
-  TsType extends BaseTypeToTsType<T> = BaseTypeToTsType<T>
->(type: T, value: TsType): $expr_Literal<T> {
+  TsType extends BaseTypeToTsType<T> = BaseTypeToTsType<T>,
+  ExprType extends $expr_Literal<T> = $expr_Literal<T>
+>(type: T, value: TsType): ExprType {
   return $expressionify({
     __element__: type,
     __cardinality__: Cardinality.One,
     __kind__: ExpressionKind.Literal,
     __value__: value,
-  }) as any;
+  }) as ExprType;
 }
 
 export const $nameMapping = new Map<string, string>([

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -77,9 +77,9 @@ export type $pathify<
   // Parent extends PathParent | null = null
 > = Root extends ObjectTypeSet
   ? ObjectTypeSet extends Root
-    ? {} // Root is literally ObjectTypeSet
+    ? unknown // Root is literally ObjectTypeSet
     : pathifyPointers<Root> & pathifyShape<Root> & $linkPropify<Root>
-  : {}; // pathify does nothing on non-object types
+  : unknown; // pathify does nothing on non-object types
 
 export type pathifyPointers<
   Root extends ObjectTypeSet

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -382,16 +382,14 @@ export type ComputeSelectCardinality<
 
 export function is<
   Expr extends ObjectTypeExpression,
-  Shape extends objectTypeToSelectShape<Expr["__element__"]>
->(
-  expr: Expr,
-  shape: Shape
-): {
-  [k in Exclude<
-    keyof Shape,
-    SelectModifierNames | "id"
-  >]: $expr_PolyShapeElement<Expr, normaliseElement<Shape[k]>>;
-} {
+  Shape extends objectTypeToSelectShape<Expr["__element__"]>,
+  ReturnT extends {
+    [k in Exclude<
+      keyof Shape,
+      SelectModifierNames | "id"
+    >]: $expr_PolyShapeElement<Expr, normaliseElement<Shape[k]>>;
+  }
+>(expr: Expr, shape: Shape): ReturnT {
   const mappedShape: any = {};
   for (const [key, value] of Object.entries(shape)) {
     if (key === "id") continue;

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -54,35 +54,26 @@ export type scalarTypeWithConstructor<
   >;
 };
 
-type $jsonDestructure<Set extends TypeSet> =
-  Set extends TypeSet<ScalarType<"std::json">>
-    ? {
-        [path: string]: $expr_Operator<
-          // "[]",
-          // OperatorKind.Infix,
-          // [Set, TypeSet],
-          // TypeSet<
-          Set["__element__"],
-          Set["__cardinality__"]
-          // >
-        >;
-      } & {
-        destructure<T extends TypeSet<ScalarType<"std::str">> | string>(
-          path: T
-        ): $expr_Operator<
-          // "[]",
-          // OperatorKind.Infix,
-          // [Set, TypeSet],
-          // TypeSet<
-          Set["__element__"],
-          cardutil.multiplyCardinalities<
-            Set["__cardinality__"],
-            T extends TypeSet ? T["__cardinality__"] : Cardinality.One
-          >
-          // >
-        >;
-      }
-    : unknown;
+type $jsonDestructure<Set extends TypeSet> = Set extends TypeSet<
+  ScalarType<"std::json">
+>
+  ? {
+      [path: string]: $expr_Operator<
+        Set["__element__"],
+        Set["__cardinality__"]
+      >;
+    } & {
+      destructure<T extends TypeSet<ScalarType<"std::str">> | string>(
+        path: T
+      ): $expr_Operator<
+        Set["__element__"],
+        cardutil.multiplyCardinalities<
+          Set["__cardinality__"],
+          T extends TypeSet ? T["__cardinality__"] : Cardinality.One
+        >
+      >;
+    }
+  : unknown;
 
 ////////////////////
 // SETS AND EXPRESSIONS

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -55,7 +55,7 @@ export type scalarTypeWithConstructor<
 };
 
 type $jsonDestructure<Set extends TypeSet> =
-  Set["__element__"] extends ScalarType<"std::json">
+  Set extends TypeSet<ScalarType<"std::json">>
     ? {
         [path: string]: $expr_Operator<
           // "[]",
@@ -127,7 +127,7 @@ export type Expression<
               run(cxn: Executor): Promise<setToTsType<Set>>;
               runJSON(cxn: Executor): Promise<string>;
             }
-          : {}) &
+          : unknown) &
         $tuplePathify<Set> &
         $arrayLikeIndexify<Set> &
         $jsonDestructure<Set>);
@@ -497,7 +497,6 @@ type $arrayLikeIndexify<Set extends TypeSet> = Set["__element__"] extends
       >;
     }
   : unknown;
-
 export type $expr_Array<
   Type extends ArrayType = ArrayType,
   Card extends Cardinality = Cardinality
@@ -707,7 +706,9 @@ type ArrayTypeToTsType<
 export type BaseTypeToTsType<
   Type extends BaseType,
   isParam extends boolean = false
-> = Type extends ScalarType
+> = Type extends never
+  ? never
+  : Type extends ScalarType
   ? ScalarTypeToTsType<Type, isParam>
   : Type extends EnumType
   ? Type["__tstype__"]
@@ -722,9 +723,7 @@ export type BaseTypeToTsType<
   : Type extends NamedTupleType
   ? NamedTupleTypeToTsType<Type, isParam>
   : Type extends ObjectType
-  ? typeutil.flatten<
-      computeObjectShape<Type["__pointers__"], Type["__shape__"]>
-    >
+  ? computeObjectShape<Type["__pointers__"], Type["__shape__"]>
   : never;
 
 export type setToTsType<Set extends TypeSet> = computeTsType<

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,12 +1157,12 @@
 
 "@next/env@13.5.6":
   version "13.5.6"
-  resolved "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.5.6.tgz#c1148e2e1aa166614f05161ee8f77ded467062bc"
   integrity sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==
 
 "@next/swc-darwin-arm64@13.5.6":
   version "13.5.6"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz#b15d139d8971360fca29be3bdd703c108c9a45fb"
   integrity sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==
 
 "@next/swc-darwin-x64@13.5.6":
@@ -2036,9 +2036,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406:
-  version "1.0.30001554"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001554.tgz"
-  integrity sha512-A2E3U//MBwbJVzebddm1YfNp7Nud5Ip+IPn4BozBmn4KqVX7AvluoIDFWjsv5OkGnKUXQVmMSoMKLa3ScCblcQ==
+  version "1.0.30001597"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz#8be94a8c1d679de23b22fbd944232aa1321639e6"
+  integrity sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==
 
 caniuse-lite@^1.0.30001449:
   version "1.0.30001481"
@@ -2982,7 +2982,7 @@ glob-parent@^6.0.2:
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
@@ -4078,7 +4078,7 @@ negotiator@0.6.3:
 
 next@13.5.6:
   version "13.5.6"
-  resolved "https://registry.npmjs.org/next/-/next-13.5.6.tgz"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.5.6.tgz#e964b5853272236c37ce0dd2c68302973cf010b1"
   integrity sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==
   dependencies:
     "@next/env" "13.5.6"
@@ -5110,10 +5110,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 undici-types@~5.26.4:
   version "5.26.5"
@@ -5217,7 +5217,7 @@ walker@^1.0.8:
 
 watchpack@2.4.0:
   version "2.4.0"
-  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
   dependencies:
     glob-to-regexp "^0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5115,6 +5115,11 @@ typescript@^5.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
   integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
+typescript@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"


### PR DESCRIPTION
TypeScript 5.4 introduced a pretty significant regression in type performance with the `e.literal` expression. The changes here are meant to be no-op performance improvements.

Significant performance improvements observed in the latest benchmark tests:

- `e.literal: scalar`: -77.80%.
- `e.literal: array literal`: -45.89%
- `e.literal: named tuple literal`: -33.47%
- `e.tuple: named tuple literal`: -20.70%
- `e.literal: tuple literal`: -42.10%
- `e.literal: array of tuples`: -35.18%

Minor performance deltas were observed in other benchmarks, with most under 1% change from the baseline. Notably, `e.array: array of tuples` showed a -9.96% delta, and `params select` had a -6.34% delta.