### PR TITLE
Add test for exclusive filter in queries generator

### DIFF
--- a/integration-tests/lts/dbschema/queries/exclusive.edgeql
+++ b/integration-tests/lts/dbschema/queries/exclusive.edgeql
@@ -1,0 +1,1 @@
+select Hero {*} filter .id = <uuid>$id;


### PR DESCRIPTION
Add a test query to ensure queries generator generates the correct cardinality given a select filtering on an exclusive constraint.

Closes #930 