### PR TITLE
Do not fail CI on benchmark failues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
         if: ${{ matrix.edgedb-version == '3' || matrix.edgedb-version == 'stable' || matrix.edgedb-version == 'nightly' || matrix.edgedb-version == '5.0-beta.2' }}
         run: |
           yarn workspace @edgedb/integration-lts test:ci
-          yarn workspace @edgedb/integration-lts run bench:types
+          yarn workspace @edgedb/integration-lts run bench:types || echo "Benchmark types script failed, proceeding anyway."
 
       - name: Run query builder integration tests stable
         if: ${{ matrix.edgedb-version == 'stable' || matrix.edgedb-version == 'nightly' || matrix.edgedb-version == '5.0-beta.2' }}


### PR DESCRIPTION
Benchmark has been failing on random CI runs, so going to keep it running, but not fail CI.