### PR TITLE
Change default value for the src/ dir in create nextjs app

### DIFF
--- a/packages/create/src/recipes/nextjs/index.ts
+++ b/packages/create/src/recipes/nextjs/index.ts
@@ -3,7 +3,7 @@ import * as p from "@clack/prompts";
 import debug from "debug";
 import { updatePackage } from "write-package";
 
-import { BaseOptions, Recipe } from "../types.js";
+import type { BaseOptions, Recipe } from "../types.js";
 import { copyTemplateFiles } from "../../utils.js";
 
 const logger = debug("@edgedb/create:recipe:nextjs");
@@ -50,6 +50,7 @@ const recipe: Recipe<NextjsOptions> = {
       useSrcDir: () =>
         p.confirm({
           message: "Use `src/` directory?",
+          initialValue: false,
         }),
     });
   },


### PR DESCRIPTION
It defaults to `no` in the official `create-next-app`. 