### PR TITLE
Release `@edgedb/auth-express` v0.2.0-beta.3

### DIFF
--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edgedb/auth-express",
   "description": "Helper library to integrate the EdgeDB Auth extension with Express",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "type": "module",
   "author": "EdgeDB <info@edgedb.com>",
   "repository": {
@@ -41,6 +41,6 @@
     "express": "^4.18.2"
   },
   "dependencies": {
-    "@edgedb/auth-core": "0.2.0-beta.1"
+    "@edgedb/auth-core": "0.2.0-beta.2"
   }
 }


### PR DESCRIPTION
Correctly depend on `@edgedb/auth-core@0.2.0-beta.2` which has the webauthn and magic link specific code