### PR TITLE
Avoid calling self in a loop in `npx edgedb`

### DIFF
--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -63,6 +63,11 @@ async function whichEdgeDbCli() {
   const location = await which("edgedb", { nothrow: true });
   if (location) {
     debug(`  - CLI found in PATH at: ${location}`);
+    const scriptLocation = new URL(import.meta.url).pathname;
+    if (location === scriptLocation) {
+      debug("  - CLI found in PATH is the current script. Ignoring.");
+      return null;
+    }
     return location;
   }
   debug("  - No CLI found in PATH.");


### PR DESCRIPTION
`npx` adds the current binary to the PATH in a way that confuses `which` so you end up calling the script in a recursive infinite loop.