### PR TITLE
Fix GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,12 @@ jobs:
 
       - name: Create 'edgedb' GitHub Release
         if: steps.check_publish_driver.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.check_publish_driver.outputs.version }}
-          release_name: edgedb-js v${{ steps.check_publish_driver.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: edgedb-js v${{ steps.check_publish_driver.outputs.version }}
           body: ${{steps.github_driver_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -143,13 +142,12 @@ jobs:
 
       - name: Create '@edgedb/generate' GitHub Release
         if: steps.check_publish_generate.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: generate-v${{ steps.check_publish_generate.outputs.version }}
-          release_name: \@edgedb/generate v${{ steps.check_publish_generate.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/generate v${{ steps.check_publish_generate.outputs.version }}
           body: ${{steps.github_generate_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -202,13 +200,12 @@ jobs:
 
       - name: Create '@edgedb/auth-core' Release
         if: steps.check_publish_auth_core.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-core-v${{ steps.check_publish_auth_core.outputs.version }}
-          release_name: \@edgedb/auth-core v${{ steps.check_publish_auth_core.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/auth-core v${{ steps.check_publish_auth_core.outputs.version }}
           body: ${{steps.github_auth_core_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -261,13 +258,12 @@ jobs:
 
       - name: Create '@edgedb/auth-nextjs' Release
         if: steps.check_publish_auth_nextjs.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-nextjs-v${{ steps.check_publish_auth_nextjs.outputs.version }}
-          release_name: \@edgedb/auth-nextjs v${{ steps.check_publish_auth_nextjs.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/auth-nextjs v${{ steps.check_publish_auth_nextjs.outputs.version }}
           body: ${{steps.github_auth_nextjs_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -320,13 +316,12 @@ jobs:
 
       - name: Create '@edgedb/auth-express' Release
         if: steps.check_publish_auth_express.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-express-v${{ steps.check_publish_auth_express.outputs.version }}
-          release_name: \@edgedb/auth-express v${{ steps.check_publish_auth_express.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/auth-express v${{ steps.check_publish_auth_express.outputs.version }}
           body: ${{steps.github_auth_express_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -379,13 +374,12 @@ jobs:
 
       - name: Create '@edgedb/auth-remix' Release
         if: steps.check_publish_auth_remix.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-remix-v${{ steps.check_publish_auth_remix.outputs.version }}
-          release_name: \@edgedb/auth-remix v${{ steps.check_publish_auth_remix.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/auth-remix v${{ steps.check_publish_auth_remix.outputs.version }}
           body: ${{steps.github_auth_remix_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -438,13 +432,12 @@ jobs:
 
       - name: Create '@edgedb/auth-sveltekit' Release
         if: steps.check_publish_auth_sveltekit.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-sveltekit-v${{ steps.check_publish_auth_sveltekit.outputs.version }}
-          release_name: \@edgedb/auth-sveltekit v${{ steps.check_publish_auth_sveltekit.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/auth-sveltekit v${{ steps.check_publish_auth_sveltekit.outputs.version }}
           body: ${{steps.github_auth_sveltekit_release.outputs.changelog}}
           draft: true
           prerelease: false
@@ -497,13 +490,12 @@ jobs:
 
       - name: Create '@edgedb/create' Release
         if: steps.check_publish_create.outputs.type != ''
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: create-v${{ steps.check_publish_create.outputs.version }}
-          release_name: \@edgedb/create v${{ steps.check_publish_create.outputs.version }}
-          commitish: ${{ github.ref }}
+          name: \@edgedb/create v${{ steps.check_publish_create.outputs.version }}
           body: ${{steps.github_create_release.outputs.changelog}}
           draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  build_and_publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,14 +33,24 @@ jobs:
           echo "last_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
           echo "curr_commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-      # edgedb
-
       - name: Copy readme
         run: cp README.md packages/driver/README.md
 
       - name: Build edgedb
         run: yarn workspace edgedb run build
 
+      - name: Build @edgedb/generate
+        run: yarn workspace @edgedb/generate run build
+
+      - name: Build @edgedb/auth-core
+        run: yarn workspace @edgedb/auth-core run build
+
+  publish_edgedb:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - id: check_publish_driver
         name: Dry-run publish 'edgedb' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
@@ -94,11 +104,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/generate
-
-      - name: Build @edgedb/generate
-        run: yarn workspace @edgedb/generate run build
-
+  publish_generate:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - id: check_publish_generate
         name: Dry-run publish '@edgedb/generate' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
@@ -152,11 +163,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/auth-core
-
-      - name: Build @edgedb/auth-core
-        run: yarn workspace @edgedb/auth-core run build
-
+  publish_auth_core:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - id: check_publish_auth_core
         name: Dry-run publish '@edgedb/auth-core' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
@@ -210,8 +222,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/auth-nextjs
-
+  publish_auth_nextjs:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Build @edgedb/auth-nextjs
         run: yarn workspace @edgedb/auth-nextjs run build
 
@@ -268,8 +284,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/auth-express
-
+  publish_auth_express:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Build @edgedb/auth-express
         run: yarn workspace @edgedb/auth-express run build
 
@@ -326,8 +346,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/auth-remix
-
+  publish_auth_remix:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Build @edgedb/auth-remix
         run: yarn workspace @edgedb/auth-remix run build
 
@@ -384,8 +408,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/auth-sveltekit
-
+  publish_auth_sveltekit:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Build @edgedb/auth-sveltekit
         run: yarn workspace @edgedb/auth-sveltekit run build
 
@@ -442,8 +470,12 @@ jobs:
           draft: true
           prerelease: false
 
-      # @edgedb/create
-
+  publish_create:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Build @edgedb/create
         run: yarn workspace @edgedb/create run build
 


### PR DESCRIPTION
Looks like the official release action has been deprecated for a few years, and now it fails outright! Yay!

While I was in here, I decided to make the release process parallel.