### PR TITLE
Support `isolatedModules` in interfaces generator

### DIFF
--- a/integration-tests/lts/tsconfig.json
+++ b/integration-tests/lts/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -74,7 +74,7 @@
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */

--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -211,7 +211,7 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
         ]);
       }
       plainTypesCode.writeln([
-        `export {${typeRefs
+        `export type {${typeRefs
           .map((typeRef) => typeRef.slice(module.internalName.length + 1))
           .join(", ")}};`,
       ]);

--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -210,11 +210,15 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
           )} = ${typeRef};`,
         ]);
       }
+      plainTypesCode.writeln([t`export type {`]);
+      plainTypesCode.increaseIndent();
       plainTypesCode.writeln([
-        `export type {${typeRefs
+        typeRefs
           .map((typeRef) => typeRef.slice(module.internalName.length + 1))
-          .join(", ")}};`,
+          .join(",\n"),
       ]);
+      plainTypesCode.decreaseIndent();
+      plainTypesCode.writeln([t`};`]);
     }
   };
 


### PR DESCRIPTION
Types must be exported as `export type {}` instead of `export {}`.