### PR TITLE
Add note for Node 18 flag for crypto global

### DIFF
--- a/packages/auth-express/readme.md
+++ b/packages/auth-express/readme.md
@@ -12,10 +12,15 @@ npm install @edgedb/auth-express
 
 **Note:** We have tested this library against the latest version of Express v4 with the types provided at DefinitelyTyped and have set up `peerDependencies` based on typical usage with npm.
 
-We depend on the following middleware being installed in your Express app:
+## Setup
 
-- `body-parser`: both JSON and urlencoded
-- `cookie-parser`
+**Prerequisites**:
+- Node v18+
+  - **Note**: Due to using the `crypto` global, you will need to start Node with `--experimental-global-webcrypto`. You can add this option to your `NODE_OPTIONS` environment variable, like `NODE_OPTIONS='--experimental-global-webcrypto'` in the appropriate `.env` file.
+- Before adding EdgeDB auth to your Express app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers (you can do this in CLI or EdgeDB UI). Refer to the auth extension docs for details on how to do this.
+- We depend on the following middleware being installed in your Express app:
+  - `body-parser`: both JSON and urlencoded
+  - `cookie-parser`
 
 ```ts
 import express from "express";

--- a/packages/auth-nextjs/readme.md
+++ b/packages/auth-nextjs/readme.md
@@ -4,7 +4,10 @@
 
 ### Setup
 
-**Prerequisites**: Before adding EdgeDB auth to your Next.js app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers. Refer to the auth extension docs for details on how to do this.
+**Prerequisites**:
+- Node v18+
+  - **Note**: Due to using the `crypto` global, you will need to start Node with `--experimental-global-webcrypto`. You can add this option to your `NODE_OPTIONS` environment variable, like `NODE_OPTIONS='--experimental-global-webcrypto'` in the appropriate `.env` file.
+- Before adding EdgeDB auth to your Next.js app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers. Refer to the auth extension docs for details on how to do this.
 
 1. Initialize the auth helper by passing an EdgeDB `Client` object to `createAuth()`, along with some configuration options. This will return a `NextAppAuth` object which you can use across your app. Similarly to the `Client` it's recommended to export this auth object from some root configuration file in your app.
 

--- a/packages/auth-remix/readme.md
+++ b/packages/auth-remix/readme.md
@@ -13,7 +13,10 @@ npm install @edgedb/auth-remix
 
 ## Setup
 
-**Prerequisites**: Before adding EdgeDB auth to your Remix app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers (you can do this in CLI or EdgeDB UI). Refer to the auth extension docs for details on how to do this.
+**Prerequisites**:
+- Node v18+
+  - **Note**: Due to using the `crypto` global, you will need to start Node with `--experimental-global-webcrypto`. You can add this option to your `NODE_OPTIONS` environment variable, like `NODE_OPTIONS='--experimental-global-webcrypto'` in the appropriate `.env` file.
+- Before adding EdgeDB auth to your Remix app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers (you can do this in CLI or EdgeDB UI). Refer to the auth extension docs for details on how to do this.
 
 1. Initialize the client auth helper by passing configuration options to `createClientAuth()`. This will return a `RemixClientAuth` object which you can use in your components. You can skip this part if you find it unnecessary and provide all your data through the loader (the next step), but we suggest having the client auth too and use it directly in your components to get OAuth, BuiltinUI and signout URLs.
 

--- a/packages/auth-sveltekit/readme.md
+++ b/packages/auth-sveltekit/readme.md
@@ -1,6 +1,6 @@
 # @edgedb/auth-sveltekit
 
-This library provides a set of utilities to help you integrate authentication into your [Sveltekit](https://kit.svelte.dev/) application.
+This library provides a set of utilities to help you integrate authentication into your [SvelteKit](https://kit.svelte.dev/) application.
 It supports authentication with various OAuth providers, as well as email/password authentication.
 
 ## Installation
@@ -13,7 +13,10 @@ npm install @edgedb/auth-sveltekit
 
 ## Setup
 
-**Prerequisites**: Before adding EdgeDB auth to your Sveltekit app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers (you can do this in CLI or EdgeDB UI). Refer to the auth extension docs for details on how to do this.
+**Prerequisites**:
+- Node v18+
+  - **Note**: Due to using the `crypto` global, you will need to start Node with `--experimental-global-webcrypto`. You can add this option to your `NODE_OPTIONS` environment variable, like `NODE_OPTIONS='--experimental-global-webcrypto'` in the appropriate `.env` file.
+- Before adding EdgeDB auth to your SvelteKit app, you will first need to enable the `auth` extension in your EdgeDB schema, and have configured the extension with some providers (you can do this in CLI or EdgeDB UI). Refer to the auth extension docs for details on how to do this.
 
 ### Client auth helper
 


### PR DESCRIPTION
[Node 18 requires passing a flag to enable the `globalThis.crypto` global](https://nodejs.org/docs/latest-v18.x/api/globals.html#crypto_1) which our PKCE generation code depends on. We used to shim this, but due to wanting to get away from using `require` directly, decided to drop the shim. We might reintroduce it, but in the meantime, we should note this so implementors are not left guessing about this issue.