### PR TITLE
Ensure cardinality is a valid `Cardinality`

### DIFF
--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -26,5 +26,7 @@
     "ts-jest": "^29.1.0",
     "typescript": "^5.4.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "edgedb": "^1.5.0"
+  }
 }

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -191,6 +191,14 @@ export function generateFiles(params: {
     `${baseFileName}.query`
   );
 
+  const validCardinalities = Object.values($.Cardinality);
+  if (!validCardinalities.includes(params.types.cardinality)) {
+    throw new Error(
+      `Invalid cardinality: ${
+        params.types.cardinality
+      }. Expected one of ${validCardinalities.join(", ")}.`
+    );
+  }
   const method =
     params.types.cardinality === $.Cardinality.One
       ? "queryRequiredSingle"


### PR DESCRIPTION
Raises an error if the `params.types.cardinality` isn't a valid `Cardinality` enum member, rather than blissfully using `query`.