### PR TITLE
Properly quote binary path

### DIFF
--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -158,10 +158,10 @@ async function downloadCliPackage() {
 
 function runEdgeDbCli(
   args: string[],
-  pathToCli: string | null,
+  pathToCli: string,
   execOptions: ExecSyncOptions = { stdio: "inherit" }
 ) {
-  const cliCommand = `"${pathToCli ?? "edgedb"}"`;
+  const cliCommand = `"${pathToCli}"`;
   const command = `${cliCommand} ${args.join(" ")}`;
   debug(`Running EdgeDB CLI: ${command}`);
   return execSync(command, execOptions);

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -161,7 +161,7 @@ function runEdgeDbCli(
   pathToCli: string | null,
   execOptions: ExecSyncOptions = { stdio: "inherit" }
 ) {
-  const cliCommand = pathToCli ?? "edgedb";
+  const cliCommand = `"${pathToCli ?? "edgedb"}"`;
   const command = `${cliCommand} ${args.join(" ")}`;
   debug(`Running EdgeDB CLI: ${command}`);
   return execSync(command, execOptions);


### PR DESCRIPTION
The typical path on macOS contains a space, but I was mostly testing the flow on linux/Docker where the path does not.