### PR TITLE
Fix camelify to not alter first char

### DIFF
--- a/packages/generate/src/genutil.ts
+++ b/packages/generate/src/genutil.ts
@@ -482,9 +482,7 @@ export type Version = {
 };
 
 export function camelify(str: string): string {
-  const base = str
+  return str
     .replace(/[-_][A-Za-z]/g, (m) => m[1].toUpperCase())
     .replace(/^[^A-Za-z_]|\W/g, "_");
-
-  return base.charAt(0).toLowerCase() + base.slice(1);
 }


### PR DESCRIPTION
The original change was to support snake_case, and the change for camelCase did not need to also change the case of the first character.