### PR TITLE
Fix CLI wrapper loop when PM uses a shell script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,10 @@ jobs:
           - os: ubuntu-latest
             node-version: "20"
             edgedb-version: "2"
-          - os: macos-latest
-            node-version: "20"
-            edgedb-version: "stable"
+          # XXX: macOS is currently unsupported by setup-edgedb
+          # - os: macos-latest
+          #   node-version: "20"
+          #   edgedb-version: "stable"
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -85,6 +85,7 @@ async function whichEdgeDbCli() {
     }
 
     const lowerCaseLocation = actualLocation.toLowerCase();
+    // n.b. Windows package binaries are actual scripts
     if (
       lowerCaseLocation.endsWith(".cmd") ||
       lowerCaseLocation.endsWith(".ps1")
@@ -92,6 +93,15 @@ async function whichEdgeDbCli() {
       debug("  - CLI found in PATH is a Windows script. Ignoring.");
       continue;
     }
+
+    // n.b. pnpm uses a shell script for package binaries instead of symlinks
+    if (lowerCaseLocation.includes("node_modules/.bin")) {
+      debug(
+        "  - CLI found in PATH is in a node_modules/.bin directory. Ignoring."
+      );
+      continue;
+    }
+
     return location;
   }
   debug("  - No CLI found in PATH.");

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -202,7 +202,7 @@ export const startServer = async (
       port: runtimeData.port,
       user: "edgedb",
       password: "edgedbtest",
-      database: "edgedb",
+      branch: "main",
       tlsSecurity: "no_host_verification",
     };
 

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -202,7 +202,6 @@ export const startServer = async (
       port: runtimeData.port,
       user: "edgedb",
       password: "edgedbtest",
-      branch: "main",
       tlsSecurity: "no_host_verification",
     };
 


### PR DESCRIPTION
Some package managers, notably pnpm, but also npm with Windows, use scripts rather than links to link to the wrapper script, so the check to ensure we're not calling the wrapper recursively was not catching the self-reference since it was being called through the shell script.

Closes #974 