### PR TITLE
Export default module interface types directly

### DIFF
--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -203,22 +203,11 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
           (nestedMod) => nestedMod.fullInternalName
         ),
       ];
+      const sliceTo = module.internalName.length + 1;
       for (const typeRef of typeRefs) {
-        plainTypesCode.writeln([
-          `import ${typeRef.slice(
-            module.internalName.length + 1
-          )} = ${typeRef};`,
-        ]);
+        const aliased = typeRef.slice(sliceTo);
+        plainTypesCode.writeln([`export type ${aliased} = ${typeRef};\n`]);
       }
-      plainTypesCode.writeln([t`export type {`]);
-      plainTypesCode.increaseIndent();
-      plainTypesCode.writeln([
-        typeRefs
-          .map((typeRef) => typeRef.slice(module.internalName.length + 1))
-          .join(",\n"),
-      ]);
-      plainTypesCode.decreaseIndent();
-      plainTypesCode.writeln([t`};`]);
     }
   };
 

--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -197,16 +197,25 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
     plainTypesCode.addExport(module.internalName, { modes: ["js"] });
 
     if (module.isRoot && module.name === "default") {
-      const typeRefs = [
-        ...module.types.values(),
-        ...[...module.nestedModules.values()].map(
-          (nestedMod) => nestedMod.fullInternalName
-        ),
-      ];
       const sliceTo = module.internalName.length + 1;
-      for (const typeRef of typeRefs) {
+      for (const typeRef of module.types.values()) {
         const aliased = typeRef.slice(sliceTo);
         plainTypesCode.writeln([`export type ${aliased} = ${typeRef};\n`]);
+      }
+
+      for (const nestedMod of module.nestedModules.values()) {
+        plainTypesCode.writeln([
+          `export namespace ${nestedMod.internalName} {`,
+        ]);
+        plainTypesCode.increaseIndent();
+        for (const typeRef of nestedMod.types.values()) {
+          const aliased = typeRef.slice(
+            sliceTo + nestedMod.internalName.length + 1
+          );
+          plainTypesCode.writeln([`export type ${aliased} = ${typeRef};`]);
+        }
+        plainTypesCode.decreaseIndent();
+        plainTypesCode.writeln([`}`]);
       }
     }
   };


### PR DESCRIPTION
We were using an obscure CommonJS syntax for what was essentially a type alias for the default modules and then exporting them in a large object-like export. Instead, just `export type` directly in the aliasing. Note the extra rebuilding of the nested namespace-modules: I couldn't find a clean way to re-export namespaces using ESM-only syntax.

I think the correct fix here is to use actual modules (like the query builder) and export an index, but we can look into that at a future date.

Closes #978 

---

In our integration test suite:

```ts
export type User = $default.User;
export type Person = $default.Person;
export type Hero = $default.Hero;
export type A = $default.A;
export type AdminUser = $default.AdminUser;
export type HasName = $default.HasName;
export type HasAge = $default.HasAge;
export type Bag = $default.Bag;
export type Genre = $default.Genre;
export type Movie = $default.Movie;
export type MovieShape = $default.MovieShape;
export type PgVectorTest = $default.PgVectorTest;
export type Profile = $default.Profile;
export type $S0x20p0x20a0x20M = $default.$S0x20p0x20a0x20M;
export type Simple = $default.Simple;
export type Villain = $default.Villain;
export type W = $default.W;
export type X = $default.X;
export type Y = $default.Y;
export type Z = $default.Z;
export type $0x141ukasz = $default.$0x141ukasz;
export namespace nested {
  export type Test = $default.nested.Test;
}
```