### PR TITLE
Fix Bun tab in Docs Generators

### DIFF
--- a/docs/generation.rst
+++ b/docs/generation.rst
@@ -39,10 +39,10 @@ Run a generator with the following command.
       --unstable \
       https://deno.land/x/edgedb/generate.ts <generator> [options]
 
-    .. code-tab:: bash
-      :caption: bun
+  .. code-tab:: bash
+    :caption: bun
 
-      $ bunx @edgedb/generate <generator> [options]
+    $ bunx @edgedb/generate <generator> [options]
 
 The value of ``<generator>`` should be one of the following:
 


### PR DESCRIPTION
Hi,

Corrects tab display, Bun tab is wrong, see ([link](https://docs.edgedb.com/libraries/js/generation#generators)) :

<img width="746" alt="Capture d’écran 2024-04-27 à 16 28 35" src="https://github.com/edgedb/edgedb-js/assets/3640689/601f3f5e-b49a-4cc2-b14f-0753df1f6ed4">
