### PR TITLE
Extract driver fetch configuration for reuse

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -43,7 +43,7 @@
     "build:cli": "tsc --project tsconfig.cli.json",
     "build:cjs": "tsc --project tsconfig.json",
     "build:deno": "deno run --unstable --allow-all ./buildDeno.ts",
-    "test": "npx --node-options='--experimental-fetch' jest --detectOpenHandles",
+    "test": "npx jest --detectOpenHandles",
     "lint": "tslint 'packages/*/src/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "gen-errors": "edb gen-errors-json --client | node genErrors.mjs",

--- a/packages/driver/src/browserClient.ts
+++ b/packages/driver/src/browserClient.ts
@@ -1,4 +1,4 @@
-import { BaseClientPool, Client, ConnectOptions } from "./baseClient";
+import { BaseClientPool, Client, type ConnectOptions } from "./baseClient";
 import { getConnectArgumentsParser } from "./conUtils";
 import cryptoUtils from "./browserCrypto";
 import { EdgeDBError } from "./errors";

--- a/packages/driver/src/nodeClient.ts
+++ b/packages/driver/src/nodeClient.ts
@@ -1,4 +1,4 @@
-import { BaseClientPool, Client, ConnectOptions } from "./baseClient";
+import { BaseClientPool, Client, type ConnectOptions } from "./baseClient";
 import { parseConnectArguments } from "./conUtils.server";
 import cryptoUtils from "./adapter.crypto.node";
 import { Options } from "./options";

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -19,8 +19,7 @@
 import { net, tls } from "./adapter.node";
 import { PROTO_VER, PROTO_VER_MIN, BaseRawConnection } from "./baseConn";
 import type { CodecsRegistry } from "./codecs/registry";
-import {
-  Address,
+import type {
   NormalizedConnectConfig,
   ResolvedConnectConfig,
 } from "./conUtils";
@@ -253,13 +252,12 @@ export class RawConnection extends BaseRawConnection {
 
   /** @internal */
   static async connectWithTimeout(
-    addr: Address,
     config: NormalizedConnectConfig,
     registry: CodecsRegistry,
-    useTls: boolean = true
+    useTls = true
   ): Promise<RawConnection> {
     const sock = this.newSock(
-      addr,
+      config.connectionParams.address,
       useTls ? getTlsOptions(config.connectionParams) : undefined
     );
     const conn = new this(sock, config, registry);
@@ -303,7 +301,7 @@ export class RawConnection extends BaseRawConnection {
               // connecting over tls failed
               // try to connect using clear text
               try {
-                return this.connectWithTimeout(addr, config, registry, false);
+                return this.connectWithTimeout(config, registry, false);
               } catch {
                 // pass
               }

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -310,7 +310,8 @@ export class RawConnection extends BaseRawConnection {
             err = new errors.ClientConnectionFailedError(
               `${e.message}\n` +
                 `Attempted to connect using the following credentials:\n` +
-                `${config.connectionParams.explainConfig()}\n`
+                `${config.connectionParams.explainConfig()}\n`,
+              { cause: e }
             );
             break;
           case "ECONNREFUSED":
@@ -321,14 +322,16 @@ export class RawConnection extends BaseRawConnection {
             err = new errors.ClientConnectionFailedTemporarilyError(
               `${e.message}\n` +
                 `Attempted to connect using the following credentials:\n` +
-                `${config.connectionParams.explainConfig()}\n`
+                `${config.connectionParams.explainConfig()}\n`,
+              { cause: e }
             );
             break;
           default:
             err = new errors.ClientConnectionFailedError(
               `${e.message}\n` +
                 `Attempted to connect using the following credentials:\n` +
-                `${config.connectionParams.explainConfig()}\n`
+                `${config.connectionParams.explainConfig()}\n`,
+              { cause: e }
             );
             break;
         }

--- a/packages/driver/src/retry.ts
+++ b/packages/driver/src/retry.ts
@@ -16,14 +16,13 @@
  * limitations under the License.
  */
 
-import { BaseRawConnection } from "./baseConn";
-import { CodecsRegistry } from "./codecs/registry";
-import { Address, NormalizedConnectConfig } from "./conUtils";
+import type { BaseRawConnection } from "./baseConn";
+import type { CodecsRegistry } from "./codecs/registry";
+import type { NormalizedConnectConfig } from "./conUtils";
 import * as errors from "./errors";
 import { sleep } from "./utils";
 
 export type ConnectWithTimeout = (
-  addr: Address,
   config: NormalizedConnectConfig,
   registry: CodecsRegistry
 ) => Promise<BaseRawConnection>;
@@ -41,11 +40,7 @@ export async function retryingConnect(
       : Date.now() + config.connectionParams.waitUntilAvailable;
   while (true) {
     try {
-      return await connectWithTimeout(
-        config.connectionParams.address,
-        config,
-        registry
-      );
+      return await connectWithTimeout(config, registry);
     } catch (e) {
       if (e instanceof errors.ClientConnectionError) {
         if (e.hasTag(errors.SHOULD_RECONNECT)) {

--- a/packages/driver/src/utils.ts
+++ b/packages/driver/src/utils.ts
@@ -88,8 +88,8 @@ export async function makeFetch(
   const baseUrl = `${protocol}://${address[0]}:${address[1]}`;
   const databaseUrl = `${baseUrl}/db/${database}/${basePath ?? ""}`;
 
-  if (!token) {
-    token = await httpSCRAMAuth(baseUrl, config.user, config.password ?? "");
+  if (!token && config.password != null) {
+    token = await httpSCRAMAuth(baseUrl, config.user, config.password);
     _tokens.set(config, token);
   }
 

--- a/packages/driver/src/utils.ts
+++ b/packages/driver/src/utils.ts
@@ -70,16 +70,16 @@ export interface CryptoUtils {
 
 const _tokens = new WeakMap<ResolvedConnectConfig, string>();
 
-export type FetchWrapper = (
+export type AuthenticatedFetch = (
   path: string,
   init: RequestInit
 ) => Promise<Response>;
 
-export async function makeFetch(
+export async function getAuthenticatedFetch(
   config: ResolvedConnectConfig,
   httpSCRAMAuth: HttpSCRAMAuth,
   basePath?: string
-): Promise<FetchWrapper> {
+): Promise<AuthenticatedFetch> {
   let token = config.secretKey ?? _tokens.get(config);
 
   const { address, tlsSecurity, database } = config;

--- a/packages/driver/test/client.test.ts
+++ b/packages/driver/test/client.test.ts
@@ -2072,7 +2072,10 @@ function _decodeResultBuffer(outCodec: _ICodec, resultData: Uint8Array) {
 if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
   test("binary protocol over http", async () => {
     const codecsRegistry = new _CodecsRegistry();
-    const config = await parseConnectArguments(getConnectOptions());
+    const config = await parseConnectArguments({
+      ...getConnectOptions(),
+      tlsSecurity: "insecure",
+    });
 
     const fetchConn = AdminUIFetchConnection.create(
       await getAuthenticatedFetch(
@@ -2105,7 +2108,10 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
 
   test("binary protocol over http failing auth", async () => {
     const codecsRegistry = new _CodecsRegistry();
-    const config = await parseConnectArguments(getConnectOptions());
+    const config = await parseConnectArguments({
+      ...getConnectOptions(),
+      tlsSecurity: "insecure",
+    });
     const fetchConn = AdminUIFetchConnection.create(
       await getAuthenticatedFetch(
         config.connectionParams,

--- a/packages/driver/test/client.test.ts
+++ b/packages/driver/test/client.test.ts
@@ -51,6 +51,7 @@ import {
 import { PG_VECTOR_MAX_DIM } from "../src/codecs/pgvector";
 import { getHTTPSCRAMAuth } from "../src/httpScram";
 import cryptoUtils from "../src/adapter.crypto.node";
+import { makeFetch } from "../src/utils";
 
 function setCustomCodecs(codecs: (keyof CustomCodecSpec)[], client: Client) {
   // @ts-ignore
@@ -2081,13 +2082,7 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
     );
 
     const fetchConn = AdminUIFetchConnection.create(
-      {
-        address: config.connectionParams.address,
-        database: config.connectionParams.database,
-        user: config.connectionParams.user,
-        tlsSecurity: "insecure",
-        token: token,
-      },
+      await makeFetch(config.connectionParams, getHTTPSCRAMAuth(cryptoUtils)),
       codecsRegistry
     );
 
@@ -2116,13 +2111,7 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
     const codecsRegistry = new _CodecsRegistry();
     const config = await parseConnectArguments(getConnectOptions());
     const fetchConn = AdminUIFetchConnection.create(
-      {
-        address: config.connectionParams.address,
-        database: config.connectionParams.database,
-        tlsSecurity: "insecure",
-        user: config.connectionParams.user,
-        token: "invalid token",
-      },
+      await makeFetch(config.connectionParams, async () => "invalid token"),
       codecsRegistry
     );
 

--- a/packages/driver/test/client.test.ts
+++ b/packages/driver/test/client.test.ts
@@ -2074,13 +2074,6 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
     const codecsRegistry = new _CodecsRegistry();
     const config = await parseConnectArguments(getConnectOptions());
 
-    const { address, user, password } = config.connectionParams;
-    const token = await getHTTPSCRAMAuth(cryptoUtils)(
-      `http://${address[0]}:${address[1]}`,
-      user,
-      password!
-    );
-
     const fetchConn = AdminUIFetchConnection.create(
       await makeFetch(config.connectionParams, getHTTPSCRAMAuth(cryptoUtils)),
       codecsRegistry

--- a/packages/driver/test/client.test.ts
+++ b/packages/driver/test/client.test.ts
@@ -51,7 +51,7 @@ import {
 import { PG_VECTOR_MAX_DIM } from "../src/codecs/pgvector";
 import { getHTTPSCRAMAuth } from "../src/httpScram";
 import cryptoUtils from "../src/adapter.crypto.node";
-import { makeFetch } from "../src/utils";
+import { getAuthenticatedFetch } from "../src/utils";
 
 function setCustomCodecs(codecs: (keyof CustomCodecSpec)[], client: Client) {
   // @ts-ignore
@@ -2075,7 +2075,10 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
     const config = await parseConnectArguments(getConnectOptions());
 
     const fetchConn = AdminUIFetchConnection.create(
-      await makeFetch(config.connectionParams, getHTTPSCRAMAuth(cryptoUtils)),
+      await getAuthenticatedFetch(
+        config.connectionParams,
+        getHTTPSCRAMAuth(cryptoUtils)
+      ),
       codecsRegistry
     );
 
@@ -2104,7 +2107,10 @@ if (!isDeno && getAvailableFeatures().has("binary-over-http")) {
     const codecsRegistry = new _CodecsRegistry();
     const config = await parseConnectArguments(getConnectOptions());
     const fetchConn = AdminUIFetchConnection.create(
-      await makeFetch(config.connectionParams, async () => "invalid token"),
+      await getAuthenticatedFetch(
+        config.connectionParams,
+        async () => "invalid token"
+      ),
       codecsRegistry
     );
 

--- a/tslint.json
+++ b/tslint.json
@@ -27,7 +27,7 @@
     "no-empty": false,
     "arrow-parens": false,
     "no-string-literal": false,
-    "typedef": [true, "property-declaration", "parameter"],
+    "typedef": false,
     "whitespace": [
       true,
       "check-branch",


### PR DESCRIPTION
AI ext and all other exts except the 'auth' one go through authentication.
We extract driver's authenticated fetch into a reusable util.     
The util creates db path that it uses for the url, and adds headers to the fetch req.