### PR TITLE
Add static method to get a token expiration

### DIFF
--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -237,18 +237,27 @@ export class Auth {
     };
   }
 
-  static checkPasswordResetTokenValid(resetToken: string) {
+  static getTokenExpiration(token: string) {
     try {
-      const payload = jwtDecode(resetToken);
+      const payload = jwtDecode(token);
       if (
         typeof payload !== "object" ||
         payload == null ||
         !("exp" in payload) ||
         typeof payload.exp !== "number"
       ) {
-        return false;
+        return null;
       }
-      return payload.exp < Date.now();
+      return new Date(payload.exp * 1000);
+    } catch {
+      return null;
+    }
+  }
+
+  static checkPasswordResetTokenValid(resetToken: string) {
+    try {
+      const expirationDate = this.getTokenExpiration(resetToken);
+      return expirationDate && expirationDate.getTime() > Date.now();
     } catch {
       return false;
     }


### PR DESCRIPTION
Does not actually test the validity of the JWT, but this is an optimistic measure meant to help client-side systems get relevant data like the expiration date from the token itself without having to round-trip to the auth server.

Also fixes a bug where the expiration time (which is in seconds) was being compared to `Date.now()` (which is in milliseconds), so was always going to be true.