### PR TITLE
Test for hard-to-detect recursive CLI calls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           mkdir temp-pnpm
           cd temp-pnpm
-          pnpm init -y
+          pnpm init
           pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
           pnpm exec edgedb -- --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,8 +139,46 @@ jobs:
         run: |
           yarn workspace @edgedb/ai test
 
-      - name: Pack CLI wrapper for local testing
+  # This job exists solely to act as the test job aggregate to be
+  # targeted by branch policies.
+  regression-tests:
+    name: "Regression Tests"
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo OK
+
+  test-cli-wrapper:
+    name: "Test CLI Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Install EdgeDB
+        uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
+        with:
+          cli-version: stable
+          server-version: none
+
+      - name: Install dev deps
         run: |
+          yarn --frozen-lockfile
+
+      - name: Build and pack CLI wrapper
+        run: |
+          yarn workspace edgedb run build
           yarn workspace edgedb pack --filename=${{ github.workspace }}/edgedb-cli.tar.gz
 
       - name: Test CLI wrapper with npm
@@ -193,12 +231,3 @@ jobs:
           bun init
           bun add ${{ github.workspace }}/edgedb-cli.tar.gz
           bun edgedb --version
-
-  # This job exists solely to act as the test job aggregate to be
-  # targeted by branch policies.
-  regression-tests:
-    name: "Regression Tests"
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo OK

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,56 @@ jobs:
         run: |
           yarn workspace @edgedb/ai test
 
+      - name: Pack CLI wrapper for local testing
+        run: |
+          yarn workspace edgedb pack --filename=edgedb-cli.tar.gz
+
+      - name: Test CLI wrapper with npm
+        run: |
+          mkdir temp-npm
+          cd temp-npm
+          npm init -y
+          npm install ../edgedb-cli.tar.gz
+          npm exec edgedb -- --version
+
+      - name: Test CLI wrapper with yarn
+        run: |
+          mkdir temp-yarn
+          cd temp-yarn
+          yarn init -y
+          yarn add ../edgedb-cli.tar.gz
+          yarn edgedb --version
+
+      - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
+        with:
+          version: latest
+      - name: Test CLI wrapper with yarn-berry
+        run: |
+          mkdir temp-yarn-berry
+          cd temp-yarn-berry
+          yarn set version berry
+          yarn init -y
+          yarn add ../edgedb-cli.tar.gz
+          yarn edgedb --version
+
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
+      - name: Test CLI wrapper with pnpm
+        run: |
+          mkdir temp-pnpm
+          cd temp-pnpm
+          pnpm init -y
+          pnpm add ../edgedb-cli.tar.gz
+          pnpm exec edgedb -- --version
+
+      - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
+      - name: Test CLI wrapper with bun
+        run: |
+          mkdir temp-bun
+          cd temp-bun
+          bun init
+          bun add ../edgedb-cli.tar.gz
+          bun edgedb --version
+
   # This job exists solely to act as the test job aggregate to be
   # targeted by branch policies.
   regression-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,9 @@ jobs:
           yarn edgedb --version
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
+        with:
+          version: latest
+          run_install: false
       - name: Test CLI wrapper with pnpm
         run: |
           mkdir temp-pnpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,7 @@ jobs:
       - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
         with:
           version: latest
+          cache: false
       - name: Test CLI wrapper with yarn-berry
         run: |
           mkdir temp-yarn-berry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,14 +141,14 @@ jobs:
 
       - name: Pack CLI wrapper for local testing
         run: |
-          yarn workspace edgedb pack --filename=edgedb-cli.tar.gz
+          yarn workspace edgedb pack --filename=${{ github.workspace }}/edgedb-cli.tar.gz
 
       - name: Test CLI wrapper with npm
         run: |
           mkdir temp-npm
           cd temp-npm
           npm init -y
-          npm install ../edgedb-cli.tar.gz
+          npm install ${{ github.workspace }}/edgedb-cli.tar.gz
           npm exec edgedb -- --version
 
       - name: Test CLI wrapper with yarn
@@ -156,7 +156,7 @@ jobs:
           mkdir temp-yarn
           cd temp-yarn
           yarn init -y
-          yarn add ../edgedb-cli.tar.gz
+          yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
           yarn edgedb --version
 
       - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
@@ -168,7 +168,7 @@ jobs:
           cd temp-yarn-berry
           yarn set version berry
           yarn init -y
-          yarn add ../edgedb-cli.tar.gz
+          yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
           yarn edgedb --version
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
@@ -177,7 +177,7 @@ jobs:
           mkdir temp-pnpm
           cd temp-pnpm
           pnpm init -y
-          pnpm add ../edgedb-cli.tar.gz
+          pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
           pnpm exec edgedb -- --version
 
       - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
@@ -186,7 +186,7 @@ jobs:
           mkdir temp-bun
           cd temp-bun
           bun init
-          bun add ../edgedb-cli.tar.gz
+          bun add ${{ github.workspace }}/edgedb-cli.tar.gz
           bun edgedb --version
 
   # This job exists solely to act as the test job aggregate to be

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,6 +169,7 @@ jobs:
           cd temp-yarn-berry
           yarn set version berry
           yarn init -y
+          touch yarn.lock
           yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
           yarn edgedb --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,7 +183,7 @@ jobs:
           cd temp-pnpm
           pnpm init
           pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
-          pnpm exec edgedb -- --version
+          pnpm exec edgedb --version
 
       - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
       - name: Test CLI wrapper with bun

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -71,7 +71,7 @@ async function main(args: string[]) {
       debug(`  - CLI location: ${cliLocation}`);
       debug(`Updating cache with new CLI location: ${cliLocation}`);
       await writeCliLocationToCache(cliLocation);
-      debug("Cache updated.")
+      debug("Cache updated.");
     }
   } catch (err) {
     if (
@@ -124,7 +124,9 @@ async function whichEdgeDbCli() {
     }
 
     try {
-      runEdgeDbCli(["--succeed-if-cli-bin-wrapper"], actualLocation, { stdio: "ignore" });
+      runEdgeDbCli(["--succeed-if-cli-bin-wrapper"], actualLocation, {
+        stdio: "ignore",
+      });
       debug("  - CLI found in PATH is wrapper script. Ignoring.");
       continue;
     } catch (err) {

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -202,6 +202,8 @@ async function getCliLocationFromTempCli(): Promise<string | null> {
 
 async function writeCliLocationToCache(cliLocation: string) {
   debug("Writing CLI location to cache:", cliLocation);
+  const dir = path.dirname(CLI_LOCATION_CACHE_FILE_PATH);
+  await fs.mkdir(dir, { recursive: true });
   await fs.writeFile(CLI_LOCATION_CACHE_FILE_PATH, cliLocation, {
     encoding: "utf8",
   });

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -39,6 +39,12 @@ await main(args);
 async function main(args: string[]) {
   debug(`Running CLI wrapper from: ${fileURLToPath(import.meta.url)}`);
   debug("Starting main function with args:", args);
+  debug(`  - IS_TTY: ${IS_TTY}`);
+  debug(`  - SCRIPT_LOCATION: ${SCRIPT_LOCATION}`);
+  debug(`  - EDGEDB_PKG_ROOT: ${EDGEDB_PKG_ROOT}`);
+  debug(`  - CACHE_DIR: ${CACHE_DIR}`);
+  debug(`  - TEMPORARY_CLI_PATH: ${TEMPORARY_CLI_PATH}`);
+  debug(`  - CLI_LOCATION_CACHE_FILE_PATH: ${CLI_LOCATION_CACHE_FILE_PATH}`);
 
   // check to see if we are being tested as a CLI binary wrapper
   if (args.length === 1 && args[0] === "--succeed-if-cli-bin-wrapper") {
@@ -46,8 +52,8 @@ async function main(args: string[]) {
   }
 
   const cliLocation =
-    (await whichEdgeDbCli()) ??
     (await getCliLocationFromCache()) ??
+    (await whichEdgeDbCli()) ??
     (await getCliLocationFromTempCli()) ??
     (await selfInstallFromTempCli()) ??
     null;
@@ -116,6 +122,9 @@ async function whichEdgeDbCli() {
       debug("  - CLI found in PATH is not a wrapper script. Using.");
     }
 
+    await fs.writeFile(CLI_LOCATION_CACHE_FILE_PATH, actualLocation, {
+      encoding: "utf8",
+    });
     return location;
   }
   debug("  - No CLI found in PATH.");

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -142,9 +142,29 @@ async function whichEdgeDbCli() {
 async function getCliLocationFromCache(): Promise<string | null> {
   debug("Checking CLI cache...");
   try {
-    const cachedBinaryPath = (
-      await fs.readFile(CLI_LOCATION_CACHE_FILE_PATH, { encoding: "utf8" })
-    ).trim();
+    let cachedBinaryPath: string | null = null;
+    try {
+      cachedBinaryPath = (
+        await fs.readFile(CLI_LOCATION_CACHE_FILE_PATH, { encoding: "utf8" })
+      ).trim();
+    } catch (err: unknown) {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        err.code === "ENOENT"
+      ) {
+        debug("  - Cache file does not exist.");
+      } else if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        err.code === "EACCES"
+      ) {
+        debug("  - No permission to read cache file.");
+      }
+      return null;
+    }
     debug("  - CLI path in cache at:", cachedBinaryPath);
 
     try {

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -39,6 +39,12 @@ await main(args);
 async function main(args: string[]) {
   debug(`Running CLI wrapper from: ${fileURLToPath(import.meta.url)}`);
   debug("Starting main function with args:", args);
+
+  // check to see if we are being tested as a CLI binary wrapper
+  if (args.length === 1 && args[0] === "--succeed-if-cli-bin-wrapper") {
+    process.exit(0);
+  }
+
   const cliLocation =
     (await whichEdgeDbCli()) ??
     (await getCliLocationFromCache()) ??
@@ -100,6 +106,14 @@ async function whichEdgeDbCli() {
         "  - CLI found in PATH is in a node_modules/.bin directory. Ignoring."
       );
       continue;
+    }
+
+    try {
+      runEdgeDbCli(["--succeed-if-cli-bin-wrapper"], actualLocation, { stdio: "ignore" });
+      debug("  - CLI found in PATH is wrapper script. Ignoring.");
+      continue;
+    } catch (err) {
+      debug("  - CLI found in PATH is not a wrapper script. Using.");
     }
 
     return location;


### PR DESCRIPTION
Yarn Berry uses an even different scheme for running bin scripts: it unpacks the script into a temporary directory and adds that temporary directory into the shell's environment.

This mitigate is by far the most expensive, so it's used dead-last to avoid the overhead. Looks like on yarn 4.1.1, the call that succeeds takes an additional 140ms. Updated the call order and caching strategy to cache successful runs of the CLI (if it differs from the current cached value) to speed this up on multiple runs from newer Yarn invocations.