### PR TITLE
Set Cookies to Secure if app baseUrl is https

### DIFF
--- a/packages/auth-express/src/index.ts
+++ b/packages/auth-express/src/index.ts
@@ -73,6 +73,7 @@ export interface ExpressAuthOptions {
 export class ExpressAuth {
   private readonly options: Required<ExpressAuthOptions>;
   private readonly core: Promise<Auth>;
+  private readonly isSecure: boolean;
 
   constructor(protected readonly client: Client, options: ExpressAuthOptions) {
     this.options = {
@@ -82,6 +83,7 @@ export class ExpressAuth {
         options.pkceVerifierCookieName ?? "edgedb-pkce-verifier",
     };
     this.core = Auth.create(client);
+    this.isSecure = this.options.baseUrl.startsWith("https");
   }
 
   isPasswordResetTokenValid = (resetToken: string) => {
@@ -95,6 +97,7 @@ export class ExpressAuth {
       path: "/",
       sameSite: "strict",
       expires,
+      secure: this.isSecure,
     });
   };
 
@@ -105,6 +108,7 @@ export class ExpressAuth {
       path: "/",
       sameSite: "strict",
       expires: expires ?? undefined,
+      secure: this.isSecure,
     });
   };
 

--- a/packages/auth-remix/src/client.ts
+++ b/packages/auth-remix/src/client.ts
@@ -22,6 +22,7 @@ export class RemixClientAuth {
   > &
     Pick<RemixAuthOptions, OptionalOptions>;
   readonly webAuthnClient: WebAuthnClient;
+  protected readonly isSecure: boolean;
 
   /** @internal */
   constructor(options: RemixAuthOptions) {
@@ -39,6 +40,7 @@ export class RemixClientAuth {
       signinUrl: `${this._authRoute}/webauthn/signin`,
       verifyUrl: `${this._authRoute}/webauthn/verify`,
     });
+    this.isSecure = this.options.baseUrl.startsWith("https");
   }
 
   protected get _authRoute() {

--- a/packages/auth-remix/src/server.ts
+++ b/packages/auth-remix/src/server.ts
@@ -130,6 +130,7 @@ export class RemixServerAuth extends RemixClientAuth {
       sameSite: "strict",
       path: "/",
       expires,
+      secure: this.isSecure,
     });
   }
 
@@ -140,6 +141,7 @@ export class RemixServerAuth extends RemixClientAuth {
       sameSite: "strict",
       path: "/",
       expires: expires ?? undefined,
+      secure: this.isSecure,
     });
   }
 

--- a/packages/auth-sveltekit/src/client.ts
+++ b/packages/auth-sveltekit/src/client.ts
@@ -35,10 +35,12 @@ export default function createClientAuth(options: AuthOptions) {
 
 export class ClientAuth {
   protected readonly config: AuthConfig;
+  protected readonly isSecure: boolean;
 
   /** @internal */
   constructor(options: AuthOptions) {
     this.config = getConfig(options);
+    this.isSecure = this.config.baseUrl.startsWith("https");
   }
 
   getOAuthUrl(providerName: BuiltinOAuthProviderNames) {

--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -139,6 +139,7 @@ export class ServerRequestAuth extends ClientAuth {
       sameSite: "strict",
       path: "/",
       expires,
+      secure: this.isSecure,
     });
   }
 
@@ -149,6 +150,7 @@ export class ServerRequestAuth extends ClientAuth {
       sameSite: "strict",
       path: "/",
       expires: expires ?? undefined,
+      secure: this.isSecure,
     });
   }
 


### PR DESCRIPTION
Mirrors the change in #938 for the other framework helpers.

Closes #937 