### PR TITLE
Set auth cookies to be `SameSite: lax`

### DIFF
--- a/packages/auth-express/src/index.ts
+++ b/packages/auth-express/src/index.ts
@@ -95,7 +95,7 @@ export class ExpressAuth {
     res.cookie(this.options.pkceVerifierCookieName, verifier, {
       httpOnly: true,
       path: "/",
-      sameSite: "strict",
+      sameSite: "lax",
       expires,
       secure: this.isSecure,
     });
@@ -106,7 +106,7 @@ export class ExpressAuth {
     res.cookie(this.options.authCookieName, authToken, {
       httpOnly: true,
       path: "/",
-      sameSite: "strict",
+      sameSite: "lax",
       expires: expires ?? undefined,
       secure: this.isSecure,
     });

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -116,7 +116,7 @@ export abstract class NextAuth extends NextAuthHelpers {
       value: verifier,
       httpOnly: true,
       path: "/",
-      sameSite: "strict",
+      sameSite: "lax",
       secure: this.isSecure,
       expires: Date.now() + 1000 * 60 * 60 * 24 * 7, // In 7 days
     });
@@ -128,7 +128,7 @@ export abstract class NextAuth extends NextAuthHelpers {
       name: this.options.authCookieName,
       value: token,
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "lax",
       path: "/",
       secure: this.isSecure,
       expires: expirationDate ?? undefined,

--- a/packages/auth-remix/src/server.ts
+++ b/packages/auth-remix/src/server.ts
@@ -127,7 +127,7 @@ export class RemixServerAuth extends RemixClientAuth {
     const expires = new Date(Date.now() + 1000 * 60 * 24 * 7); // In 7 days
     return cookie.serialize(this.options.pkceVerifierCookieName, verifier, {
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "lax",
       path: "/",
       expires,
       secure: this.isSecure,
@@ -138,7 +138,7 @@ export class RemixServerAuth extends RemixClientAuth {
     const expires = Auth.getTokenExpiration(authToken);
     return cookie.serialize(this.options.authCookieName, authToken, {
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "lax",
       path: "/",
       expires: expires ?? undefined,
       secure: this.isSecure,

--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -136,7 +136,7 @@ export class ServerRequestAuth extends ClientAuth {
     const expires = new Date(Date.now() + 1000 * 60 * 24 * 7); // In 7 days
     this.cookies.set(this.config.pkceVerifierCookieName, verifier, {
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "lax",
       path: "/",
       expires,
       secure: this.isSecure,
@@ -147,7 +147,7 @@ export class ServerRequestAuth extends ClientAuth {
     const expires = Auth.getTokenExpiration(authToken);
     this.cookies.set(this.config.authCookieName, authToken, {
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "lax",
       path: "/",
       expires: expires ?? undefined,
       secure: this.isSecure,


### PR DESCRIPTION
Since there are some cases where we are navigating from links, we need to use `lax` as our SameSite.