### PR TITLE
Add option to skip updating ignore file

### DIFF
--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -236,6 +236,9 @@ const run = async () => {
       case "--force-overwrite":
         options.forceOverwrite = true;
         break;
+      case "--no-update-ignore-file":
+        options.updateIgnoreFile = false;
+        break;
       default:
         exitWithError(`Unknown option: ${flag}`);
     }

--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -438,6 +438,8 @@ OPTIONS:
         When used with the 'queries' generator, also changes output to single-file mode
     --force-overwrite
         Overwrite <path> contents without confirmation
+    --no-update-ignore-file
+        Do not prompt to update gitignore with generated code
 `);
 }
 run();

--- a/packages/generate/src/edgeql-js.ts
+++ b/packages/generate/src/edgeql-js.ts
@@ -316,7 +316,8 @@ project to exclude these files.`
       !RegExp(`^${vcsLine}$`, "m").test(gitIgnoreFile) // not already ignored
     ) {
       if (
-        await promptBoolean(
+        isTTY() &&
+        (await promptBoolean(
           gitIgnoreFile === null
             ? `Checking the generated query builder into version control
 is not recommended. Would you like to create a .gitignore file to ignore
@@ -327,7 +328,7 @@ the query builder directory? The following line will be added:
 
    ${vcsLine}\n\n`,
           true
-        )
+        ))
       ) {
         await fs.appendFile(
           gitIgnorePath,


### PR DESCRIPTION
Facilitate skipping the prompt to update gitignore file for the generated query builder code. We should always check for `isTTY` before prompting, and also added an option to explicitly opt out of checking.

Closes #985 