### PR TITLE
Replace `Error.source` with standardized `cause`

### DIFF
--- a/packages/driver/src/errors/base.ts
+++ b/packages/driver/src/errors/base.ts
@@ -1,7 +1,6 @@
 import { utf8Decoder } from "../primitives/buffer";
 
 export class EdgeDBError extends Error {
-  source?: Error;
   protected static tags: object = {};
   private _message: string;
   private _query?: string;

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -152,7 +152,7 @@ export class RawConnection extends BaseRawConnection {
       this.buffer.takeMessage() &&
       this.buffer.getMessageType() === chars.$E
     ) {
-      newErr.source = this._parseErrorMessage();
+      newErr.cause = this._parseErrorMessage();
     }
 
     this._abortWithError(newErr);
@@ -162,7 +162,7 @@ export class RawConnection extends BaseRawConnection {
     const newErr = new errors.ClientConnectionClosedError(
       `network error: ${err}`
     );
-    newErr.source = err;
+    newErr.cause = err;
 
     try {
       this._abortWaiters(newErr);
@@ -335,7 +335,7 @@ export class RawConnection extends BaseRawConnection {
             );
             break;
         }
-        err.source = e;
+        err.cause = e;
         throw err;
       }
     } finally {

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -152,7 +152,10 @@ export class RawConnection extends BaseRawConnection {
       this.buffer.takeMessage() &&
       this.buffer.getMessageType() === chars.$E
     ) {
-      newErr.cause = this._parseErrorMessage();
+      Object.defineProperty(newErr, "cause", {
+        enumerable: false,
+        value: this._parseErrorMessage(),
+      });
     }
 
     this._abortWithError(newErr);
@@ -162,7 +165,10 @@ export class RawConnection extends BaseRawConnection {
     const newErr = new errors.ClientConnectionClosedError(
       `network error: ${err}`
     );
-    newErr.cause = err;
+    Object.defineProperty(newErr, "cause", {
+      enumerable: false,
+      value: err,
+    });
 
     try {
       this._abortWaiters(newErr);
@@ -335,7 +341,10 @@ export class RawConnection extends BaseRawConnection {
             );
             break;
         }
-        err.cause = e;
+        Object.defineProperty(err, "cause", {
+          enumerable: false,
+          value: e,
+        });
         throw err;
       }
     } finally {

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -163,12 +163,9 @@ export class RawConnection extends BaseRawConnection {
 
   protected _onError(err: Error): void {
     const newErr = new errors.ClientConnectionClosedError(
-      `network error: ${err}`
+      `network error: ${err}`,
+      { cause: err }
     );
-    Object.defineProperty(newErr, "cause", {
-      enumerable: false,
-      value: err,
-    });
 
     try {
       this._abortWaiters(newErr);
@@ -341,10 +338,6 @@ export class RawConnection extends BaseRawConnection {
             );
             break;
         }
-        Object.defineProperty(err, "cause", {
-          enumerable: false,
-          value: e,
-        });
         throw err;
       }
     } finally {

--- a/packages/driver/src/transaction.ts
+++ b/packages/driver/src/transaction.ts
@@ -75,9 +75,9 @@ export class Transaction implements Executor {
     const abortError = this._rawConn.getConnAbortError();
     if (
       abortError instanceof errors.EdgeDBError &&
-      abortError.source instanceof errors.TransactionTimeoutError
+      abortError.cause instanceof errors.TransactionTimeoutError
     ) {
-      throw abortError.source;
+      throw abortError.cause;
     } else {
       throw abortError;
     }

--- a/packages/driver/test/connection.test.ts
+++ b/packages/driver/test/connection.test.ts
@@ -49,7 +49,7 @@ test("connect: refused", async () => {
     throw new Error("connection isn't refused");
   } catch (e: any) {
     expect(e).toBeInstanceOf(errors.ClientConnectionClosedError);
-    expect(e.source.code).toMatch("ECONNREFUSED");
+    expect(e.cause.code).toMatch("ECONNREFUSED");
   } finally {
     if (typeof client !== "undefined") {
       await client.close();
@@ -68,8 +68,8 @@ test("connect: invalid name", async () => {
     throw new Error("name was resolved");
   } catch (e: any) {
     expect(e).toBeInstanceOf(errors.ClientConnectionClosedError);
-    expect(e.source.code).toMatch("ENOTFOUND");
-    expect(e.source.syscall).toMatch("getaddrinfo");
+    expect(e.cause.code).toMatch("ENOTFOUND");
+    expect(e.cause.syscall).toMatch("getaddrinfo");
   } finally {
     if (typeof client !== "undefined") {
       await client.close();


### PR DESCRIPTION
`Error.cause` is now supported across all of our supported platforms. Use that instead of the custom `source` property.

See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)