### PR TITLE
Use CLI wrapper to initialize project

### DIFF
--- a/packages/create/src/recipes/_edgedb/index.ts
+++ b/packages/create/src/recipes/_edgedb/index.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import debug from "debug";
 
 import type { BaseOptions, Recipe } from "../types.js";
-import { copyTemplateFiles, execInLoginShell } from "../../utils.js";
+import { copyTemplateFiles, execInPackageManager } from "../../utils.js";
 
 const logger = debug("@edgedb/create:recipe:edgedb");
 
@@ -33,53 +33,12 @@ const recipe: Recipe<EdgeDBOptions> = {
     const spinner = p.spinner();
 
     if (initializeProject) {
-      let edgedbCliVersion: string | null = null;
-      let shouldInstallCli: boolean | symbol = true;
-      try {
-        const { stdout } = await execInLoginShell("edgedb --version");
-        edgedbCliVersion = stdout.trim();
-        logger(edgedbCliVersion);
-      } catch (error) {
-        logger("No EdgeDB CLI detected");
-        shouldInstallCli = await p.confirm({
-          message:
-            "The EdgeDB CLI is required to initialize a project. Install now?",
-          initialValue: true,
-        });
-      }
-
-      if (edgedbCliVersion === null) {
-        if (shouldInstallCli === false) {
-          logger("User declined to install EdgeDB CLI");
-          throw new Error("EdgeDB CLI is required");
-        }
-
-        logger("Installing EdgeDB CLI");
-
-        spinner.start("Installing EdgeDB CLI");
-        const { stdout, stderr } = await execInLoginShell(
-          "curl --proto '=https' --tlsv1.2 -sSf https://sh.edgedb.com | sh -s -- -y"
-        );
-        logger({ stdout, stderr });
-        spinner.stop("EdgeDB CLI installed");
-      }
-
-      try {
-        const { stdout } = await execInLoginShell("edgedb --version");
-        edgedbCliVersion = stdout.trim();
-        logger(edgedbCliVersion);
-      } catch (error) {
-        logger("EdgeDB CLI could not be installed.");
-        logger(error);
-        throw new Error("EdgeDB CLI could not be installed.");
-      }
-
       spinner.start("Initializing EdgeDB project");
       try {
-        await execInLoginShell("edgedb project init --non-interactive", {
+        await execInPackageManager("edgedb project init --non-interactive", {
           cwd: projectDir,
         });
-        const { stdout, stderr } = await execInLoginShell(
+        const { stdout, stderr } = await execInPackageManager(
           "edgedb query 'select sys::get_version_as_str()'",
           { cwd: projectDir }
         );
@@ -122,10 +81,10 @@ const recipe: Recipe<EdgeDBOptions> = {
         logger("Creating and applying initial migration");
         spinner.start("Creating and applying initial migration");
         try {
-          await execInLoginShell("edgedb migration create", {
+          await execInPackageManager("edgedb migration create", {
             cwd: projectDir,
           });
-          await execInLoginShell("edgedb migrate", { cwd: projectDir });
+          await execInPackageManager("edgedb migrate", { cwd: projectDir });
           spinner.stop("Initial migration created and applied");
         } catch (error) {
           logger(error);

--- a/packages/create/src/recipes/index.ts
+++ b/packages/create/src/recipes/index.ts
@@ -18,6 +18,6 @@ export const recipes: Recipe<any>[] = [
   remix,
   sveltekit,
   // init
-  _edgedbInit,
   _install,
+  _edgedbInit,
 ];

--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -151,3 +151,28 @@ stdout: ${stdout}`
     });
   });
 }
+
+export async function execInPackageManager(
+  cmd: string,
+  options?: SpawnOptionsWithoutStdio
+): Promise<{ stdout: string; stderr: string }> {
+  const packageManager = getPackageManager();
+  let command;
+  switch (packageManager) {
+    case "yarn":
+      command = `yarn exec '${cmd}'`;
+      break;
+    case "bun":
+      command = `bun run --bun '${cmd}'`;
+      break;
+    case "pnpm":
+      command = `pnpm exec '${cmd}'`;
+      break;
+    case "npm":
+      command = `npm exec -- '${cmd}'`;
+      break;
+    default:
+      command = cmd;
+  }
+  return execInLoginShell(command, options);
+}


### PR DESCRIPTION
Now that we have the `edgedb` CLI wrapper script that handles installing the CLI if it's missing, the wrapper takes care of installing the correct version or finding the already installed binary.