### PR TITLE
Use ESLint flat config in base recipe

### DIFF
--- a/packages/create/src/recipes/_base/template/eslint.config.js
+++ b/packages/create/src/recipes/_base/template/eslint.config.js
@@ -1,24 +1,11 @@
-import { FlatCompat } from "@eslint/eslintrc";
-import js from "@eslint/js";
+// @ts-check
 
-const compat = new FlatCompat();
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import eslintConfigPrettier from "eslint-config-prettier";
 
-export default [
-  {
-    ...compat
-      .extends(
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended-type-checked",
-        "plugin:@typescript-eslint/stylistic-type-checked",
-        "prettier"
-      )
-      .map((c) => ({
-        ...c,
-        files: ["**/*.{ts,tsx,mts}"],
-      })),
-  },
-  {
-    files: ["**/*.{js,jsx,cjs,mjs}"],
-    ...js.configs.recommended,
-  },
-];
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier
+);

--- a/packages/create/src/recipes/_base/template/package.json
+++ b/packages/create/src/recipes/_base/template/package.json
@@ -7,12 +7,11 @@
   },
   "devDependencies": {
     "@edgedb/generate": "0.x",
-    "@typescript-eslint/eslint-plugin": "6.x",
-    "@typescript-eslint/parser": "6.x",
-    "@eslint/eslintrc": "2.x",
-    "eslint": "8.x",
+    "@eslint/js": "9.x",
+    "eslint": "9.x",
     "eslint-config-prettier": "9.x",
     "prettier": "3.x",
-    "typescript": "5.x"
+    "typescript": "5.x",
+    "typescript-eslint": "7.x"
   }
 }


### PR DESCRIPTION
We tried to write something that would be easy to adopt the new flat config format in 8.x, but since then, 9.x has been released and the config has settled a bit. Adopt the simplified format here.