### PR TITLE
Use Node compatibility for Deno Buffer

### DIFF
--- a/packages/driver/src/adapter.deno.ts
+++ b/packages/driver/src/adapter.deno.ts
@@ -7,8 +7,9 @@ import fs from "node:fs/promises";
 import util from "node:util";
 import { isIP as _isIP } from "node:net";
 import { EventEmitter } from "node:events";
+import { Buffer } from "node:buffer";
 
-export { path, process, util, fs };
+export { path, process, util, fs, Buffer };
 
 export async function readFileUtf8(...pathParts: string[]): Promise<string> {
   return await Deno.readTextFile(path.join(...pathParts));

--- a/packages/driver/src/adapter.node.ts
+++ b/packages/driver/src/adapter.node.ts
@@ -4,12 +4,13 @@ import * as net from "net";
 import * as os from "os";
 import * as path from "path";
 import * as tls from "tls";
+import { Buffer } from "node:buffer";
 
 import process from "process";
 import * as readline from "readline";
 import { Writable } from "stream";
 
-export { path, net, fs, tls, process };
+export { path, net, fs, tls, process, Buffer };
 
 export async function readFileUtf8(...pathParts: string[]): Promise<string> {
   return await fs.readFile(path.join(...pathParts), { encoding: "utf8" });

--- a/packages/driver/src/primitives/buffer.ts
+++ b/packages/driver/src/primitives/buffer.ts
@@ -19,6 +19,7 @@
 import type char from "./chars";
 import * as chars from "./chars";
 import { LegacyHeaderCodes } from "../ifaces";
+import { Buffer } from "../adapter.node";
 
 /* WriteBuffer over-allocation */
 const BUFFER_INC_SIZE = 4096;
@@ -28,34 +29,15 @@ const EMPTY_BUFFER = new Uint8Array(0);
 export const utf8Encoder = new TextEncoder();
 export const utf8Decoder = new TextDecoder("utf8");
 
-let decodeB64: (b64: string) => Uint8Array;
-let encodeB64: (data: Uint8Array) => string;
-
-if (typeof globalThis.Buffer === "function") {
-  decodeB64 = (b64: string): Uint8Array => {
-    return globalThis.Buffer.from(b64, "base64");
-  };
-  encodeB64 = (data: Uint8Array): string => {
-    const buf = globalThis.Buffer.isBuffer(data)
-      ? data
-      : globalThis.Buffer.from(data.buffer, data.byteOffset, data.byteLength);
-    return buf.toString("base64");
-  };
-} else {
-  decodeB64 = (b64: string): Uint8Array => {
-    const binaryString = atob(b64);
-    const size = binaryString.length;
-    const bytes = new Uint8Array(size);
-    for (let i = 0; i < size; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
-  };
-  encodeB64 = (data: Uint8Array): string => {
-    const binaryString = String.fromCharCode(...data);
-    return btoa(binaryString);
-  };
-}
+const decodeB64 = (b64: string): Uint8Array => {
+  return Buffer.from(b64, "base64");
+};
+const encodeB64 = (data: Uint8Array): string => {
+  const buf = Buffer.isBuffer(data)
+    ? data
+    : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  return buf.toString("base64");
+};
 
 export { decodeB64, encodeB64 };
 

--- a/packages/driver/src/primitives/buffer.ts
+++ b/packages/driver/src/primitives/buffer.ts
@@ -21,7 +21,7 @@ import * as chars from "./chars";
 import { LegacyHeaderCodes } from "../ifaces";
 
 /* WriteBuffer over-allocation */
-const BUFFER_INC_SIZE: number = 4096;
+const BUFFER_INC_SIZE = 4096;
 
 const EMPTY_BUFFER = new Uint8Array(0);
 
@@ -31,18 +31,14 @@ export const utf8Decoder = new TextDecoder("utf8");
 let decodeB64: (b64: string) => Uint8Array;
 let encodeB64: (data: Uint8Array) => string;
 
-// @ts-ignore: Buffer is not defined in Deno
-if (Buffer === "function") {
+if (typeof globalThis.Buffer === "function") {
   decodeB64 = (b64: string): Uint8Array => {
-    // @ts-ignore: Buffer is not defined in Deno
-    return Buffer.from(b64, "base64");
+    return globalThis.Buffer.from(b64, "base64");
   };
   encodeB64 = (data: Uint8Array): string => {
-    // @ts-ignore: Buffer is not defined in Deno
-    const buf = !Buffer.isBuffer(data)
-      ? // @ts-ignore: Buffer is not defined in Deno
-        Buffer.from(data.buffer, data.byteOffset, data.byteLength)
-      : data;
+    const buf = globalThis.Buffer.isBuffer(data)
+      ? data
+      : globalThis.Buffer.from(data.buffer, data.byteOffset, data.byteLength);
     return buf.toString("base64");
   };
 } else {

--- a/packages/driver/test/deno.test.ts
+++ b/packages/driver/test/deno.test.ts
@@ -25,7 +25,8 @@ test("run deno test", async () => {
       "deno",
       [
         "test",
-        "--unstable",
+        "--reload",
+        "--check",
         "--allow-net",
         "--allow-env",
         "--allow-read",

--- a/packages/driver/test/deno.test.ts
+++ b/packages/driver/test/deno.test.ts
@@ -54,9 +54,7 @@ test("deno check", async () => {
   return await new Promise<void>((resolve, reject) => {
     return execFile(
       "deno",
-      // TODO: remove unstable flag when deno stdlib node/process module
-      // doesn't need it
-      ["eval", "--unstable", 'import * as edgedb from "./mod.ts"'],
+      ["eval", 'import * as edgedb from "./mod.ts"'],
       {
         env: process.env,
         timeout: 60_000,


### PR DESCRIPTION
Instead of manually implementing the base64 encoding when the buffer
global is not defined, explicitly import `node:buffer` in both the
node-like case, and the deno-like case.

Closes #1003 

Note about 1003: This doesn't _directly_ address the issue with Cloudflare Workers but it kind of leans into the fact that we already depend on their Node compatibility shim anyway. Once we get around to supporting WinterCG-like runtimes more directly, we'll work on that more directly.