### PR TITLE
Use shell-quote to properly quote commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,6 @@ jobs:
         uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
         with:
           cli-version: stable
-          server-version: none
 
       - name: Install dev deps
         run: |
@@ -188,6 +187,7 @@ jobs:
           npm init -y
           npm install ${{ github.workspace }}/edgedb-cli.tar.gz
           npm exec edgedb -- --version
+          npm exec edgedb -- query 'select sys::get_version_as_str()'
 
       - name: Test CLI wrapper with yarn
         run: |
@@ -196,6 +196,7 @@ jobs:
           yarn init -y
           yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
           yarn edgedb --version
+          yarn edgedb query 'select sys::get_version_as_str()'
 
       - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
         with:
@@ -210,6 +211,7 @@ jobs:
           touch yarn.lock
           yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
           yarn edgedb --version
+          yarn edgedb query 'select sys::get_version_as_str()'
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
         with:
@@ -222,6 +224,7 @@ jobs:
           pnpm init
           pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
           pnpm exec edgedb --version
+          pnpm exec edgedb query 'select sys::get_version_as_str()'
 
       - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
       - name: Test CLI wrapper with bun
@@ -231,3 +234,4 @@ jobs:
           bun init
           bun add ${{ github.workspace }}/edgedb-cli.tar.gz
           bun edgedb --version
+          bun edgedb query 'select sys::get_version_as_str()'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,6 +186,7 @@ jobs:
           cd temp-npm
           npm init -y
           npm install ${{ github.workspace }}/edgedb-cli.tar.gz
+          npm exec edgedb -- project init --non-interactive
           npm exec edgedb -- --version
           npm exec edgedb -- query 'select sys::get_version_as_str()'
 
@@ -195,6 +196,7 @@ jobs:
           cd temp-yarn
           yarn init -y
           yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
+          yarn edgedb project init --non-interactive
           yarn edgedb --version
           yarn edgedb query 'select sys::get_version_as_str()'
 
@@ -210,6 +212,7 @@ jobs:
           yarn init -y
           touch yarn.lock
           yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
+          yarn edgedb project init --non-interactive
           yarn edgedb --version
           yarn edgedb query 'select sys::get_version_as_str()'
 
@@ -223,6 +226,7 @@ jobs:
           cd temp-pnpm
           pnpm init
           pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
+          pnpm exec edgedb project init --non-interactive
           pnpm exec edgedb --version
           pnpm exec edgedb query 'select sys::get_version_as_str()'
 
@@ -233,5 +237,6 @@ jobs:
           cd temp-bun
           bun init
           bun add ${{ github.workspace }}/edgedb-cli.tar.gz
+          bun edgedb project init --non-interactive
           bun edgedb --version
           bun edgedb query 'select sys::get_version_as_str()'

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@js-temporal/polyfill": "0.4.3",
     "@types/jest": "^29.5.2",
+    "@types/shell-quote": "^1.7.5",
     "@types/which": "^3.0.3",
     "fast-check": "^3.10.0",
     "get-stdin": "^9.0.0",
@@ -54,6 +55,7 @@
     "debug": "^4.3.4",
     "env-paths": "^3.0.0",
     "semver": "^7.6.0",
+    "shell-quote": "^1.8.1",
     "which": "^4.0.0"
   }
 }

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -10,6 +10,7 @@ import * as semver from "semver";
 import envPaths from "env-paths";
 import Debug from "debug";
 import which from "which";
+import { quote } from "shell-quote";
 
 const debug = Debug("edgedb:cli");
 
@@ -242,7 +243,7 @@ function runEdgeDbCli(
   execOptions: ExecSyncOptions = { stdio: "inherit" }
 ) {
   const cliCommand = `"${pathToCli}"`;
-  const command = `${cliCommand} ${args.join(" ")}`;
+  const command = quote([cliCommand, ...args]);
   debug(`Running EdgeDB CLI: ${command}`);
   return execSync(command, execOptions);
 }

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -242,8 +242,7 @@ function runEdgeDbCli(
   pathToCli: string,
   execOptions: ExecSyncOptions = { stdio: "inherit" }
 ) {
-  const cliCommand = `"${pathToCli}"`;
-  const command = quote([cliCommand, ...args]);
+  const command = quote([pathToCli, ...args]);
   debug(`Running EdgeDB CLI: ${command}`);
   return execSync(command, execOptions);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,6 +1595,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/shell-quote@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/shell-quote/-/shell-quote-1.7.5.tgz#6db4704742d307cd6d604e124e3ad6cd5ed943f3"
+  integrity sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
@@ -4665,6 +4670,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
+  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Passing quoted arguments to the wrapper CLI was getting unwrapped and
unquoted when they show up as arguments in the CLI itself. We need to
re-escape and re-wrap the strings when passing them to the underlying
CLI binary.