### PR TITLE
Escape double-backslashes in EdgeQL

### DIFF
--- a/integration-tests/lts/dbschema/queries/freeShape.edgeql
+++ b/integration-tests/lts/dbschema/queries/freeShape.edgeql
@@ -4,4 +4,5 @@ select {
   data := <str>$data,
   required multi arg := {'asdf'},
   enums := [Genre.Horror, Genre.Action],
+  regexp := re_match('\\s*(.*)?\\s+BEEP', "     find me BEEP")[0]
 };

--- a/integration-tests/lts/queries.test.ts
+++ b/integration-tests/lts/queries.test.ts
@@ -11,6 +11,7 @@ import {
   type GetMoviesStarringReturns,
   deepArrayInput,
   type DeepArrayInputArgs,
+  freeShape,
 } from "./dbschema/queries";
 import { type TestData, setupTests, teardownTests } from "./setupTeardown";
 
@@ -120,5 +121,19 @@ describe("queries", () => {
     });
 
     assert.equal(missing, null);
+  });
+
+  test("free shape", async () => {
+    const result = await freeShape(client, { data: "123" });
+
+    assert.ok(result);
+    assert.deepEqual(result, {
+      name: "arg",
+      points: 1234n,
+      data: "123",
+      arg: ["asdf"],
+      enums: ["Horror", "Action"],
+      regexp: "find me",
+    });
   });
 });

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -217,7 +217,9 @@ ${hasArgs ? `export type ${argsInterfaceName} = ${params.types.args};\n` : ""}
 export type ${returnsInterfaceName} = ${params.types.result};\
 `;
   const functionBody = `\
-${params.types.query.trim().replace(/`/g, "\\`")}\`${hasArgs ? `, args` : ""});
+${params.types.query.trim().replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\`${
+    hasArgs ? `, args` : ""
+  });
 `;
 
   const tsImports =


### PR DESCRIPTION
These show up in regular expressions, so do a blanket find-and-replace to a quadruple backslash.

Closes #878 