### PR TITLE
Do not manually quote install-dir command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,11 +166,6 @@ jobs:
         with:
           deno-version: v1.x
 
-      - name: Install EdgeDB
-        uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
-        with:
-          cli-version: stable
-
       - name: Install dev deps
         run: |
           yarn --frozen-lockfile

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -212,7 +212,8 @@ async function writeCliLocationToCache(cliLocation: string) {
 
 async function selfInstallFromTempCli(): Promise<string | null> {
   debug("Self-installing EdgeDB CLI...");
-  runEdgeDbCli(["_self_install"], TEMPORARY_CLI_PATH);
+  const cmd = IS_TTY ? ["_self_install"] : ["_self_install", "--quiet"];
+  runEdgeDbCli(cmd, TEMPORARY_CLI_PATH);
   debug("  - CLI self-installed successfully.");
   return getCliLocationFromCache();
 }

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -379,7 +379,7 @@ function getBaseDist(arch: string, platform: string, libc = ""): string {
 
 function getInstallDir(cliPath: string): string {
   debug("Getting install directory for CLI path:", cliPath);
-  const installDir = runEdgeDbCli(["info", "--get", "'install-dir'"], cliPath, {
+  const installDir = runEdgeDbCli(["info", "--get", "install-dir"], cliPath, {
     stdio: "pipe",
   })
     .toString()


### PR DESCRIPTION
Since we are now quoting the arguments directly in the `runEdegDbCli` function, we do not need to quote this argument manually.