### PR TITLE
Add test for FreeObject with nested select

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -179,6 +179,21 @@ describe("select", () => {
     >(true);
   });
 
+  test("nested free object", async () => {
+    const hero = e.select(e.Hero, () => ({ limit: 1 }));
+    const villain = e.select(e.Villain, () => ({ limit: 1 }));
+
+    const q = await e
+      .select({
+        hero,
+        villain,
+      })
+      .run(client);
+
+    assert.ok(q.hero);
+    assert.ok(q.villain);
+  });
+
   test("compositionality", () => {
     // selecting a select statement should
     // default to { id }


### PR DESCRIPTION
Came up in a troubleshooting session and thought it would be worth keeping the test.