### PR TITLE
Use given cardinality in select expression

### DIFF
--- a/integration-tests/lts/bench.ts
+++ b/integration-tests/lts/bench.ts
@@ -225,6 +225,13 @@ bench("select: with offset", () => {
   return {} as typeof query;
 }).types([8891, "instantiations"]);
 
+bench("select: with pointer override", () => {
+  const query = e.select(e.Hero, (h) => ({
+    height: e.decimal("10.0"),
+  }));
+  return {} as typeof query;
+}).types([2160, "instantiations"]);
+
 bench("params select", () => {
   const query = e.params({ name: e.str }, (params) =>
     e.select(e.Hero, (hero) => ({

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1173,6 +1173,7 @@ SELECT __scope_0_defaultPerson {
   test("nested matching scopes", async () => {
     const q = e.select(e.Hero, (h) => ({
       name: h.name,
+      height: e.decimal("10.0"),
       otherHeros: e.select(e.Hero, (h2) => ({
         name: true,
         name_one: h.name,
@@ -1182,6 +1183,8 @@ SELECT __scope_0_defaultPerson {
       })),
       order_by: h.name,
     }));
+    type h = $infer<typeof q.__element__.__shape__.height>;
+    type Q = $infer<typeof q>;
 
     const result = await q.run(client);
 

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1170,10 +1170,59 @@ SELECT __scope_0_defaultPerson {
     assert.equal(res4, 1);
   });
 
+  test("overriding pointers", async () => {
+    const q = e.select(e.Hero, () => ({
+      height: e.decimal("10.0"),
+    }));
+    type Height = $infer<typeof q.__element__.__shape__.height>;
+    type Q = $infer<typeof q>;
+    tc.assert<
+      tc.IsExact<
+        Q,
+        {
+          height: Height;
+        }[]
+      >
+    >(true);
+
+    await assert.rejects(
+      async () =>
+        e
+          // @ts-expect-error cannot assign multi cardinality if point is single
+          .select(e.Hero, () => ({
+            height: e.set(e.decimal("10.0"), e.decimal("11.0")),
+          }))
+          .run(client),
+      (err) => {
+        if (err && typeof err === "object" && "message" in err && typeof err.message === "string") {
+          assert.match(err.message, /possibly more than one element returned/);
+          return true;
+        } else {
+          assert.fail("Expected error to be an object with a message");
+        }
+      },
+    );
+  });
+
+  test("coalescing pointers", () => {
+    const q = e.select(e.Hero, (h) => ({
+      height: e.op(h.height, "??", e.decimal("10.0")),
+    }));
+    type Height = $infer<typeof q.__element__.__shape__.height>;
+    type Q = $infer<typeof q>;
+    tc.assert<
+      tc.IsExact<
+        Q,
+        {
+          height: Height;
+        }[]
+      >
+    >(true);
+  });
+
   test("nested matching scopes", async () => {
     const q = e.select(e.Hero, (h) => ({
       name: h.name,
-      height: e.decimal("10.0"),
       otherHeros: e.select(e.Hero, (h2) => ({
         name: true,
         name_one: h.name,
@@ -1183,8 +1232,6 @@ SELECT __scope_0_defaultPerson {
       })),
       order_by: h.name,
     }));
-    type h = $infer<typeof q.__element__.__shape__.height>;
-    type Q = $infer<typeof q>;
 
     const result = await q.run(client);
 

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1194,7 +1194,12 @@ SELECT __scope_0_defaultPerson {
           }))
           .run(client),
       (err) => {
-        if (err && typeof err === "object" && "message" in err && typeof err.message === "string") {
+        if (
+          err &&
+          typeof err === "object" &&
+          "message" in err &&
+          typeof err.message === "string"
+        ) {
           assert.match(err.message, /possibly more than one element returned/);
           return true;
         } else {

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -311,10 +311,9 @@ export type stripNonInsertables<T extends ObjectTypePointers> = {
       : T[k];
 };
 
-type shapeElementToTs<
-  Pointer extends PropertyDesc | LinkDesc,
+type shapeElementToTs<Pointer extends PropertyDesc | LinkDesc, Element> = [
   Element,
-> = [Element] extends [true]
+] extends [true]
   ? pointerToTsType<Pointer>
   : [Element] extends [false]
     ? never

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -374,10 +374,16 @@ export type computeObjectShape<
                 ShapeEl
               > | null
             : never
-          : [k] extends [keyof Pointers]
-            ? shapeElementToTs<Pointers[k], Shape[k]>
-            : Shape[k] extends TypeSet
-              ? setToTsType<Shape[k]>
+          : Shape[k] extends TypeSet
+            ? [k] extends [keyof Pointers]
+              ? Shape[k]["__cardinality__"] extends cardutil.assignable<
+                  Pointers[k]["cardinality"]
+                >
+                ? setToTsType<Shape[k]>
+                : never
+              : setToTsType<Shape[k]>
+            : [k] extends [keyof Pointers]
+              ? shapeElementToTs<Pointers[k], Shape[k]>
               : never;
       }
 >;

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -311,16 +311,18 @@ export type stripNonInsertables<T extends ObjectTypePointers> = {
       : T[k];
 };
 
-type shapeElementToTs<Pointer extends PropertyDesc | LinkDesc, Element> = [
+type shapeElementToTs<
+  Pointer extends PropertyDesc | LinkDesc,
   Element,
-] extends [true]
+  Card extends Cardinality = Pointer["cardinality"],
+> = [Element] extends [true]
   ? pointerToTsType<Pointer>
   : [Element] extends [false]
     ? never
     : [Element] extends [boolean]
       ? pointerToTsType<Pointer> | undefined
       : Element extends TypeSet
-        ? setToTsType<TypeSet<Element["__element__"], Pointer["cardinality"]>>
+        ? setToTsType<TypeSet<Element["__element__"], Card>>
         : Pointer extends LinkDesc
           ? Element extends object
             ? computeTsTypeCard<
@@ -328,7 +330,7 @@ type shapeElementToTs<Pointer extends PropertyDesc | LinkDesc, Element> = [
                   Pointer["target"]["__pointers__"] & Pointer["properties"],
                   Element
                 >,
-                Pointer["cardinality"]
+                Card
               >
             : never
           : never;

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -314,7 +314,6 @@ export type stripNonInsertables<T extends ObjectTypePointers> = {
 type shapeElementToTs<
   Pointer extends PropertyDesc | LinkDesc,
   Element,
-  Card extends Cardinality = Pointer["cardinality"],
 > = [Element] extends [true]
   ? pointerToTsType<Pointer>
   : [Element] extends [false]
@@ -322,7 +321,7 @@ type shapeElementToTs<
     : [Element] extends [boolean]
       ? pointerToTsType<Pointer> | undefined
       : Element extends TypeSet
-        ? setToTsType<TypeSet<Element["__element__"], Card>>
+        ? setToTsType<TypeSet<Element["__element__"], Pointer["cardinality"]>>
         : Pointer extends LinkDesc
           ? Element extends object
             ? computeTsTypeCard<
@@ -330,7 +329,7 @@ type shapeElementToTs<
                   Pointer["target"]["__pointers__"] & Pointer["properties"],
                   Element
                 >,
-                Card
+                Pointer["cardinality"]
               >
             : never
           : never;


### PR DESCRIPTION
Previously, if you made a select expression with a constant or coalescing expression, we _always_ calculated the cardinality of a object key based on the pointer's cardinality, rather than allowing you to return something _assignable_ to that cardinality. This change will check if the assignment is possible, and override the cardinality when converting the query builder expression to a TS type.