### PR TITLE
Fix `$infer` for `e.shape`

### DIFF
--- a/packages/generate/src/syntax/external.ts
+++ b/packages/generate/src/syntax/external.ts
@@ -1,5 +1,3 @@
-import type { TypeSet, setToTsType } from "./typesystem";
-
 export { literal } from "./literal";
 export {} from "./path";
 export { set } from "./set";
@@ -27,4 +25,4 @@ export { optional, params } from "./params";
 export { detached } from "./detached";
 export {} from "./toEdgeQL";
 
-export type $infer<A extends TypeSet> = setToTsType<A>;
+export type { setToTsType as $infer } from "./typesystem";

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -849,25 +849,17 @@ function $shape<
   Expr extends ObjectTypeExpression,
   Element extends Expr["__element__"],
   Shape extends objectTypeToSelectShape<Element> & SelectModifiers<Element>,
-  SelectCard extends ComputeSelectCardinality<Expr, Modifiers>,
-  SelectShape extends normaliseShape<Shape, SelectModifierNames>,
   Scope extends $scopify<Element> &
     $linkPropify<{
       [k in keyof Expr]: k extends "__cardinality__"
         ? Cardinality.One
         : Expr[k];
     }>,
-  Modifiers extends UnknownSelectModifiers = Pick<Shape, SelectModifierNames>,
 >(
-  expr: Expr,
-  _shape: (scope: Scope) => Readonly<Shape>,
-): ((scope: unknown) => Readonly<Shape>) &
-  TypeSet<
-    ObjectType<Element["__name__"], Element["__pointers__"], SelectShape>,
-    SelectCard
-  >;
-function $shape(_a: unknown, b: (...args: any) => any) {
-  return b;
+  _expr: Expr,
+  shape: (scope: Scope) => Readonly<Shape>,
+): (scope: Scope) => Readonly<Shape> {
+  return shape;
 }
 export { $shape as shape };
 

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -10,6 +10,13 @@ import type {
 import { TypeKind } from "edgedb/dist/reflection/index";
 import type { cardutil } from "./cardinality";
 import type { Range, MultiRange } from "edgedb";
+import type {
+  ComputeSelectCardinality,
+  SelectModifierNames,
+  SelectModifiers,
+  normaliseShape,
+  objectTypeToSelectShape,
+} from "./select";
 
 //////////////////
 // BASETYPE
@@ -724,10 +731,53 @@ export type BaseTypeToTsType<
                   ? computeObjectShape<Type["__pointers__"], Type["__shape__"]>
                   : never;
 
-export type setToTsType<Set extends TypeSet> = computeTsType<
-  Set["__element__"],
-  Set["__cardinality__"]
->;
+type shapeFnToTsType<ShapeFn> = ShapeFn extends (
+  scope: infer Scope,
+) => Readonly<infer Shape>
+  ? Scope extends $scopify<ObjectType>
+    ? Shape extends objectTypeToSelectShape<Scope["__element__"]> &
+        SelectModifiers<Scope["__element__"]>
+      ? computeTsType<
+          ObjectType<
+            Scope["__element__"]["__name__"],
+            Scope["__element__"]["__pointers__"],
+            normaliseShape<Shape>
+          >,
+          ComputeSelectCardinality<
+            {
+              __element__: Scope["__element__"];
+              // TODO: Drop this explicit cardinality in a breaking change version
+              // A previous implementation of this acted this way, so we need to
+              // keep it for compatibility.
+              __cardinality__: Cardinality.Many;
+            },
+            Pick<Shape, SelectModifierNames>
+          >
+        >
+      : never
+    : never
+  : never;
+
+type portableShapeToTsType<PortableShape> = PortableShape extends (
+  expr: infer Expr extends ObjectTypeExpression,
+  shape: (scope: unknown) => Readonly<infer Shape>,
+) => (scope: unknown) => void
+  ? Shape extends objectTypeToSelectShape<Expr["__element__"]> &
+      SelectModifiers<Expr["__element__"]>
+    ? computeTsType<
+        ObjectType<
+          Expr["__element__"]["__name__"],
+          Expr["__element__"]["__pointers__"],
+          normaliseShape<Shape>
+        >,
+        ComputeSelectCardinality<Expr, Pick<Shape, SelectModifierNames>>
+      >
+    : never
+  : shapeFnToTsType<PortableShape>;
+
+export type setToTsType<Set> = Set extends TypeSet
+  ? computeTsType<Set["__element__"], Set["__cardinality__"]>
+  : portableShapeToTsType<Set>;
 
 export type computeTsTypeCard<T, C extends Cardinality> = Cardinality extends C
   ? unknown


### PR DESCRIPTION
We were "faking" a `TypeSet` as part of the return type of `e.shape` to allow using `$infer` on `e.shape` expressions, but it turns out that caused the recent change to allow setting properties on a shape to a `TypeSet` as long as it agrees with the cardinality of the pointer to break.

There are some lingering issues here that we should clean up, such as making the cardinality of `$infer<typeof someShape>` something reasonable rather than trying to infer it from the shape since that will depend on it's actual usage. In practice, most people want the `Cardinality.ONE` version (so, without `null` and not an array) so perhaps we can change this in a break version in the future.