### PR TITLE
Loosen type of `e.shape`'s returned scope

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,14 @@ jobs:
 
       - name: Typecheck
         run: |
-          yarn workspaces run typecheck
+          yarn workspace edgedb run typecheck
+          yarn workspace @edgedb/generate run typecheck
+          yarn workspace @edgedb/auth-core run typecheck
+          yarn workspace @edgedb/ai run typecheck
+          yarn workspace @edgedb/auth-remix run typecheck
+          yarn workspace @edgedb/auth-nextjs run typecheck
+          yarn workspace @edgedb/auth-express run typecheck
+          yarn workspace @edgedb/auth-sveltekit run typecheck
 
       # - name: Compile for Deno
       #   run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,10 +73,6 @@ jobs:
         run: |
           yarn run format
 
-      - name: ESLint (ignore failures for now)
-        run: |
-          yarn eslint || echo "ESLint still failing... Fine for now!"
-
       - name: Build
         run: |
           yarn workspace edgedb build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,20 +80,11 @@ jobs:
           yarn workspace @edgedb/auth-core build
           yarn workspace @edgedb/ai build
 
-      - name: Typecheck
-        run: |
-          yarn workspace edgedb run typecheck
-          yarn workspace @edgedb/generate run typecheck
-          yarn workspace @edgedb/auth-core run typecheck
-          yarn workspace @edgedb/ai run typecheck
+          # Only typecheck the following since nothing depends on these packages
           yarn workspace @edgedb/auth-remix run typecheck
           yarn workspace @edgedb/auth-nextjs run typecheck
           yarn workspace @edgedb/auth-express run typecheck
           yarn workspace @edgedb/auth-sveltekit run typecheck
-
-      # - name: Compile for Deno
-      #   run: |
-      #     yarn build:deno
 
       - name: Install EdgeDB
         uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1358,6 +1358,12 @@ SELECT __scope_0_defaultPerson {
       name: true,
       id: true,
     }));
+    const heroShape = e.shape(e.Hero, () => ({
+      villains: true,
+    }));
+    const villainShape = e.shape(e.Villain, () => ({
+      nemesis: true,
+    }));
     const profileShape = e.shape(e.Profile, () => ({
       slug: true,
     }));
@@ -1413,6 +1419,25 @@ SELECT __scope_0_defaultPerson {
     assert.ok(result.title);
     assert.ok(result.rating);
     assert.ok(result.characters);
+
+    const cast = e.select(query, () => ({ characters: true }));
+    const freeObjWithShape = e.select({
+      heros: e.select(cast.characters.is(e.Hero), (h) => {
+        return heroShape(h);
+      }),
+      villains: e.select(cast.characters.is(e.Villain), villainShape),
+    });
+    type FreeObjWithShape = $infer<typeof freeObjWithShape>;
+    tc.assert<
+      tc.IsExact<
+        FreeObjWithShape,
+        {
+          heros: { villains: { id: string }[] }[];
+          villains: { nemesis: { id: string } | null }[];
+        }
+      >
+    >(true);
+    assert.ok(freeObjWithShape);
   });
 
   test("filter_single id", async () => {

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -856,18 +856,15 @@ function $shape<
         ? Cardinality.One
         : Expr[k];
     }>,
-  AnyElement extends Omit<Element, "__shape__"> & { __shape__: any },
+  ElementOfAnyShape extends Omit<Element, "__shape__"> & { __shape__: any },
 >(
   _expr: Expr,
   shape: (scope: Scope) => Readonly<Shape>,
 ): (
   scope: Omit<Scope, "__element__" | "assert_single"> & {
-    __element__: AnyElement;
-    assert_single(): assert_single<AnyElement, Cardinality.AtMostOne>;
+    __element__: ElementOfAnyShape;
+    assert_single(): assert_single<ElementOfAnyShape, Cardinality.AtMostOne>;
   },
-  /*
-  scope: Scope,
-  */
 ) => Readonly<Shape>;
 function $shape(_a: unknown, b: (...args: any) => any) {
   return b;

--- a/packages/generate/src/syntax/select.ts
+++ b/packages/generate/src/syntax/select.ts
@@ -36,6 +36,7 @@ import type {
   ExclusiveTuple,
   orLiteralValue,
   EnumType,
+  assert_single,
 } from "./typesystem";
 
 import {
@@ -855,11 +856,21 @@ function $shape<
         ? Cardinality.One
         : Expr[k];
     }>,
+  AnyElement extends Omit<Element, "__shape__"> & { __shape__: any },
 >(
   _expr: Expr,
   shape: (scope: Scope) => Readonly<Shape>,
-): (scope: Scope) => Readonly<Shape> {
-  return shape;
+): (
+  scope: Omit<Scope, "__element__" | "assert_single"> & {
+    __element__: AnyElement;
+    assert_single(): assert_single<AnyElement, Cardinality.AtMostOne>;
+  },
+  /*
+  scope: Scope,
+  */
+) => Readonly<Shape>;
+function $shape(_a: unknown, b: (...args: any) => any) {
+  return b;
 }
 export { $shape as shape };
 

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -177,7 +177,8 @@ export type ExpressionMethods<Set extends TypeSet> = {
     ObjectType<
       T["__element__"]["__name__"],
       T["__element__"]["__pointers__"],
-      { id: true }
+      { id: true },
+      T["__element__"]["__exclusives__"]
     >
   >;
   assert_single(): assert_single<


### PR DESCRIPTION
Type intersection creates an expression with a fixed `__shape__` expression. This was being glossed over before because the parameter type was `unknown`, but once we switched it to match the scopified object expression, it became too strict for use with intersections.

Closes #856 