### PR TITLE
Use specific type-level marker to `e.shape`

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -4,6 +4,7 @@ import * as $ from "../../packages/generate/src/syntax/reflection";
 
 import e, { type $infer } from "./dbschema/edgeql-js";
 import { setupTests, teardownTests, tc, type TestData } from "./setupTeardown";
+
 let client: edgedb.Client;
 let data: TestData;
 
@@ -1358,8 +1359,8 @@ SELECT __scope_0_defaultPerson {
       name: true,
       id: true,
     }));
-    const heroShape = e.shape(e.Hero, () => ({
-      villains: true,
+    const personShape = e.shape(e.Person, () => ({
+      name: true,
     }));
     const villainShape = e.shape(e.Villain, () => ({
       nemesis: true,
@@ -1422,9 +1423,7 @@ SELECT __scope_0_defaultPerson {
 
     const cast = e.select(query, () => ({ characters: true }));
     const freeObjWithShape = e.select({
-      heros: e.select(cast.characters.is(e.Hero), (h) => {
-        return heroShape(h);
-      }),
+      heros: e.select(cast.characters.is(e.Hero), personShape),
       villains: e.select(cast.characters.is(e.Villain), villainShape),
     });
     type FreeObjWithShape = $infer<typeof freeObjWithShape>;
@@ -1432,7 +1431,7 @@ SELECT __scope_0_defaultPerson {
       tc.IsExact<
         FreeObjWithShape,
         {
-          heros: { villains: { id: string }[] }[];
+          heros: { name: string }[];
           villains: { nemesis: { id: string } | null }[];
         }
       >


### PR DESCRIPTION
Introduces a type-level marker to the return value of the $shape function. This marker is used solely for type inference to carry element, cardinality, and shape information and is not present at runtime.

We now detect this specific construct in the `setToTsType` (which is the actual type we alias as `$infer`) and just short-circuit to calculating the object shape as if the shape was wrapped in a select.