### PR TITLE
Remove from object shape keys with value never

### DIFF
--- a/integration-tests/lts/dbschema/default.esdl
+++ b/integration-tests/lts/dbschema/default.esdl
@@ -31,6 +31,7 @@ module default {
       constraint exclusive;
     };
     property height -> decimal;
+    property isAdult -> bool;
   }
 
   type Villain extending Person {

--- a/integration-tests/lts/dbschema/migrations/00026-m1wb2dg.edgeql
+++ b/integration-tests/lts/dbschema/migrations/00026-m1wb2dg.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1wb2dgjeppqex272zwvqnsdfzdvvppub4iwa5vaxu3xxigyjlruka
+    ONTO m1rjlewu5fimvn4lf4xguullcbvlttuxmtxyl4yz4dmsbyw5shva7a
+{
+  ALTER TYPE default::Person {
+      CREATE PROPERTY isAdult: std::bool;
+  };
+};

--- a/integration-tests/lts/interfaces.test.ts
+++ b/integration-tests/lts/interfaces.test.ts
@@ -24,6 +24,7 @@ export interface BaseObject {
 export interface test_Person extends BaseObject {
   name: string;
   height?: string | null;
+  isAdult?: boolean | null;
 }
 export interface test_Movie extends BaseObject {
   characters: test_Person[];

--- a/integration-tests/lts/objectTypes.test.ts
+++ b/integration-tests/lts/objectTypes.test.ts
@@ -206,6 +206,7 @@ describe("object types", () => {
         id: true,
         name: true,
         height: true,
+        isAdult: true,
         secret_identity: true,
         number_of_movies: true,
       });

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -295,7 +295,6 @@ describe("select", () => {
           id: string;
           secret_identity: string | null;
           nemesis: { id: string; computable: 1234 } | null;
-          computable: never;
         }[]
       >
     >(true);
@@ -336,6 +335,7 @@ describe("select", () => {
         {
           name: string;
           height: string | null;
+          isAdult: boolean | null;
           number_of_movies: number | null;
           secret_identity: string | null;
         }[]
@@ -1523,5 +1523,40 @@ SELECT __scope_0_defaultPerson {
       active: e.User.Status.Active,
     }));
     await query.run(client);
+  });
+
+  test("False shape pointers are not returned", () => {
+    const q = e.select(e.Movie, () => ({
+      title: true,
+      rating: true,
+      genre: false,
+    }));
+
+    tc.assert<
+      tc.IsExact<
+        $infer<typeof q>,
+        {
+          title: string;
+          rating: number | null;
+        }[]
+      >
+    >(true);
+  });
+
+  test("Select assignment works", () => {
+    const q = e.select(e.Person, () => ({
+      name: true,
+      isAdult: e.bool(false),
+    }));
+
+    tc.assert<
+      tc.IsExact<
+        $infer<typeof q>,
+        {
+          name: string;
+          isAdult: false;
+        }[]
+      >
+    >(true);
   });
 });

--- a/packages/generate/src/syntax/typesystem.ts
+++ b/packages/generate/src/syntax/typesystem.ts
@@ -363,7 +363,7 @@ export type computeObjectShape<
 > = typeutil.flatten<
   keyof Shape extends never
     ? { id: string }
-    : {
+    : typeutil.stripNever<{
         [k in keyof Shape]: Shape[k] extends $expr_PolyShapeElement<
           infer PolyType,
           infer ShapeEl
@@ -385,7 +385,7 @@ export type computeObjectShape<
             : [k] extends [keyof Pointers]
               ? shapeElementToTs<Pointers[k], Shape[k]>
               : never;
-      }
+      }>
 >;
 
 export type PrimitiveType =


### PR DESCRIPTION
Hey, I am not sure if this is 100% what we need in order to fix #1037 .

It works okay with the test mentioned in the issue.

<img width="436" alt="Screenshot 2024-07-05 at 18 39 56" src="https://github.com/edgedb/edgedb-js/assets/18357201/7040f1dc-cbd8-4314-8c2d-1ac1094f4421">
<img width="468" alt="Screenshot 2024-07-05 at 18 39 33" src="https://github.com/edgedb/edgedb-js/assets/18357201/7bf255eb-9385-468d-abaf-3059714370d3">
