### PR TITLE
Update TS version in the monorepo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.44.4
+          deno-version: v1.x
 
       - name: Install dev deps
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v1.44.4
 
       - name: Install dev deps
         run: |

--- a/integration-tests/legacy/package.json
+++ b/integration-tests/legacy/package.json
@@ -15,7 +15,7 @@
     "conditional-type-checks": "^1.0.6",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -24,7 +24,7 @@
     "jest": "^29.7.0",
     "superjson": "1.13.3",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "edgedb": "^1.5.0",

--- a/integration-tests/nightly/package.json
+++ b/integration-tests/nightly/package.json
@@ -15,7 +15,7 @@
     "conditional-type-checks": "^1.0.6",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {}
 }

--- a/integration-tests/stable/package.json
+++ b/integration-tests/stable/package.json
@@ -15,7 +15,7 @@
     "conditional-type-checks": "^1.0.6",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@eslint/js": "^9.3.0",
     "eslint": "^9.3.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "typescript-eslint": "^8.0.0-alpha.22"
   },
   "scripts": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -37,7 +37,7 @@
     "edgedb": "^1.5.0",
     "jest": "29.7.0",
     "ts-jest": "29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "edgedb": "^1.5.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -37,7 +37,7 @@
     "edgedb": "^1.5.0",
     "jest": "29.7.0",
     "ts-jest": "29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-express/package.json
+++ b/packages/auth-express/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^20.12.13",
     "edgedb": "^1.5.0",
     "express": "^4.19.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "cookie-parser": "^1.4.6",

--- a/packages/auth-nextjs/package.json
+++ b/packages/auth-nextjs/package.json
@@ -28,7 +28,7 @@
     "edgedb": "^1.5.0",
     "next": "14.2.3",
     "react": "^18.3.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6",

--- a/packages/auth-remix/package.json
+++ b/packages/auth-remix/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/node": "^20.12.13",
     "edgedb": "^1.5.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "edgedb": "^1.3.6"

--- a/packages/auth-sveltekit/package.json
+++ b/packages/auth-sveltekit/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^20.12.13",
     "edgedb": "^1.5.0",
     "svelte": "^4.2.17",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "vite": "^5.2.12"
   },
   "peerDependencies": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -23,7 +23,7 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^20.12.13",
     "tsx": "^4.11.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -37,7 +37,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "29.1.4",
     "tsx": "^4.11.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit",

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -29,7 +29,7 @@
     "globby": "^14.0.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",

--- a/packages/generate/src/syntax/group.ts
+++ b/packages/generate/src/syntax/group.ts
@@ -16,7 +16,6 @@ import {
 import { makeType } from "./hydrate";
 
 import { $expressionify, $getScopedExpr } from "./path";
-// @ts-expect-error GENERATED
 import type { $FreeObjectλShape, $str } from "./modules/std";
 import { spec } from "./__spec__";
 import { literal } from "./literal";

--- a/packages/generate/src/syntax/modules/std.ts
+++ b/packages/generate/src/syntax/modules/std.ts
@@ -24,6 +24,9 @@ declare const FreeObject: $expr_PathNode<
   // true
 >;
 
+export type $FreeObjectλShape = any;
+export type $str = ScalarType<"std::str", string>;
+
 export type $bool = ScalarType<"std::bool", boolean>;
 export type $number = ScalarType<"std::number", number>;
 export type $decimal = ScalarType<"std::decimal", string>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,10 +4643,10 @@ typescript-eslint@^8.0.0-alpha.22:
     "@typescript-eslint/parser" "8.0.0-alpha.22"
     "@typescript-eslint/utils" "8.0.0-alpha.22"
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.5.2:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
+  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
Add types for `$FreeObjectλShape`  and `$str` in `packages/generate/src/syntax/modules/std.ts` which will fix type of `$expr_Group` which will fix type of `SomeExpression`.

```
export type $FreeObjectλShape = any;
export type $str = ScalarType<"std::str", string>;
```