### PR TITLE
Update README for turborepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ EdgeDB from [here](https://www.edgedb.com/download) or
 ```bash
 $ git clone git@github.com:edgedb/edgedb-js.git
 $ cd edgedb-js
-$ yarn                           # install dependencies
-$ yarn workspaces run build      # build all packages
-$ yarn workspaces run test       # run tests for all packages
+$ yarn                # install dependencies
+$ yarn run build      # build all packages
+$ yarn run test       # run tests for all packages
 ```
 
 > In order to be able to run all tests you need to have `edgedb-server` in your

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "typecheck": "turbo run typecheck",
     "build": "turbo run build",
-    "text": "turbo run test",
+    "test": "turbo run test",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "format": "prettier --check 'packages/*/(src|test)/**/*.(mts|ts)' 'integration-tests/*/*.(mts|ts)'",


### PR DESCRIPTION
Now that we use turborepo for running monorepo tasks, update the README to indicate that you should use the new turborepo powered run scripts.