### PR TITLE
Use temporary directory for CLI test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,8 +154,8 @@ jobs:
 
       - name: Test CLI wrapper with npm
         run: |
-          mkdir temp-npm
-          cd temp-npm
+          mkdir ${{ runner.temp }}/temp-npm
+          cd ${{ runner.temp }}/temp-npm
           npm init -y
           npm install ${{ github.workspace }}/edgedb-cli.tar.gz
           npm exec edgedb -- project init --non-interactive
@@ -164,8 +164,8 @@ jobs:
 
       - name: Test CLI wrapper with yarn
         run: |
-          mkdir temp-yarn
-          cd temp-yarn
+          mkdir ${{ runner.temp }}/temp-yarn
+          cd ${{ runner.temp }}/temp-yarn
           yarn init -y
           yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
           yarn edgedb project init --non-interactive
@@ -178,8 +178,8 @@ jobs:
           cache: false
       - name: Test CLI wrapper with yarn-berry
         run: |
-          mkdir temp-yarn-berry
-          cd temp-yarn-berry
+          mkdir ${{ runner.temp }}/temp-yarn-berry
+          cd ${{ runner.temp }}/temp-yarn-berry
           yarn set version berry
           yarn init -y
           touch yarn.lock
@@ -194,8 +194,8 @@ jobs:
           run_install: false
       - name: Test CLI wrapper with pnpm
         run: |
-          mkdir temp-pnpm
-          cd temp-pnpm
+          mkdir ${{ runner.temp }}/temp-pnpm
+          cd ${{ runner.temp}}/temp-pnpm
           pnpm init
           pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
           pnpm exec edgedb project init --non-interactive


### PR DESCRIPTION
A recent update of pnpm (9.8.0) started to cause failures. I believe this is due to the "temporary" projects being made within the main repo's directory, causing some weird "project" detection in pnpm.