### PR TITLE
Add support for SNI when connecting to the instance

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,7 +138,7 @@ app:
   $ npm init -y # initialize a new npm project
   $ npm i edgedb
   $ npm i -D typescript @types/node @edgedb/generate tsx
-  $ npx tsc --init # initialize basic a basic TypeScript project
+  $ npx tsc --init # initialize a basic TypeScript project
 
 Client
 ^^^^^^

--- a/packages/driver/src/conUtils.ts
+++ b/packages/driver/src/conUtils.ts
@@ -643,7 +643,7 @@ async function parseConnectDsnAndArgs(
           secretKey: `'EDGEDB_SECRET_KEY' environment variable`,
           tlsCA: `'EDGEDB_TLS_CA' environment variable`,
           tlsCAFile: `'EDGEDB_TLS_CA_FILE' environment variable`,
-          tlsServerName: `EDGEDB_TLS_SERVER_NAME environment variable`,
+          tlsServerName: `'EDGEDB_TLS_SERVER_NAME' environment variable`,
           tlsSecurity: `'EDGEDB_CLIENT_TLS_SECURITY' environment variable`,
           waitUntilAvailable: `'EDGEDB_WAIT_UNTIL_AVAILABLE' environment variable`,
         },
@@ -679,7 +679,7 @@ async function parseConnectDsnAndArgs(
       .catch(() => null);
 
     if (instName !== null) {
-      const [cloudProfile, database] = await Promise.all([
+      const [cloudProfile, database, branch] = await Promise.all([
         serverUtils
           .readFileUtf8(stashDir, "cloud-profile")
           .then((name) => name.trim())
@@ -696,11 +696,12 @@ async function parseConnectDsnAndArgs(
 
       await resolveConfigOptions(
         resolvedConfig,
-        { instanceName: instName, cloudProfile, database },
+        { instanceName: instName, cloudProfile, database, branch },
         {
           instanceName: `project linked instance ('${instName}')`,
           cloudProfile: `project defined cloud instance ('${cloudProfile}')`,
           database: `project default database`,
+          branch: `project default branch`,
         },
         "",
         serverUtils,

--- a/packages/driver/src/conUtils.ts
+++ b/packages/driver/src/conUtils.ts
@@ -587,7 +587,7 @@ async function parseConnectDsnAndArgs(
       tlsCA: `'tlsCA' option`,
       tlsCAFile: `'tlsCAFile' option`,
       tlsSecurity: `'tlsSecurity' option`,
-      tlsServerName: `tlsServerName option`,
+      tlsServerName: `'tlsServerName' option`,
       serverSettings: `'serverSettings' option`,
       waitUntilAvailable: `'waitUntilAvailable' option`,
     },

--- a/packages/driver/src/conUtils.ts
+++ b/packages/driver/src/conUtils.ts
@@ -679,7 +679,7 @@ async function parseConnectDsnAndArgs(
       .catch(() => null);
 
     if (instName !== null) {
-      const [cloudProfile, database, branch] = await Promise.all([
+      const [cloudProfile, _database, branch] = await Promise.all([
         serverUtils
           .readFileUtf8(stashDir, "cloud-profile")
           .then((name) => name.trim())
@@ -693,6 +693,18 @@ async function parseConnectDsnAndArgs(
           .then((name) => name.trim())
           .catch(() => undefined),
       ]);
+
+      let database = _database;
+
+      if (database !== undefined && branch !== undefined) {
+        if (database !== branch) {
+          throw new InterfaceError(
+            "Both database and branch exist in the config dir and don't match.",
+          );
+        } else {
+          database = undefined;
+        }
+      }
 
       await resolveConfigOptions(
         resolvedConfig,

--- a/packages/driver/src/rawConn.ts
+++ b/packages/driver/src/rawConn.ts
@@ -59,7 +59,7 @@ function getTlsOptions(config: ResolvedConnectConfig): tls.ConnectionOptions {
   if (!isIPAddress) {
     // XXX Deno doesn't support this and that means it won't
     // work with EdgeDB Cloud.
-    tlsOptions.servername = config.address[0];
+    tlsOptions.servername = config.tlsServerName || config.address[0];
   }
 
   _tlsOptions.set(config, tlsOptions);

--- a/packages/driver/test/connection-config.test.ts
+++ b/packages/driver/test/connection-config.test.ts
@@ -192,6 +192,7 @@ interface ConnectionResult {
   password: string | null;
   tlsCAData: string | null;
   tlsSecurity: boolean;
+  tlsServerName: string | null;
   serverSettings: { [key: string]: string };
   waitUntilAvailable: string;
 }
@@ -254,6 +255,7 @@ async function runConnectionTest(testcase: ConnectionTestCase): Promise<void> {
             user: connectionParams.user,
             password: connectionParams.password ?? null,
             secretKey: connectionParams.secretKey ?? null,
+            tlsServerName: connectionParams.tlsServerName ?? null,
             tlsCAData: connectionParams._tlsCAData,
             tlsSecurity: connectionParams.tlsSecurity,
             serverSettings: connectionParams.serverSettings,
@@ -456,6 +458,7 @@ test("logging, inProject, fromProject, fromEnv", async () => {
     password: null,
     tlsCAData: null,
     tlsSecurity: "strict",
+    tlsServerName: null,
     serverSettings: {},
   };
 
@@ -608,6 +611,7 @@ test("logging, inProject, fromProject, fromEnv", async () => {
           user: connectionParams.user,
           password: connectionParams.password ?? null,
           tlsCAData: connectionParams._tlsCAData,
+          tlsServerName: connectionParams.tlsServerName ?? null,
           tlsSecurity: connectionParams.tlsSecurity,
           serverSettings: connectionParams.serverSettings,
         }).toEqual(testcase.result);


### PR DESCRIPTION
I will try to add these tomorrow:

Documentation is missing:
- SNI,
- Cloud Profile,
- tlsCA maybe should be documented too,
- `credentials` is not documented.

**More things to be done**: add SNI to credentials.json in the cli, and later read it from there: `Oh and to address this specifically, although very marginal, we may want to update the CLI to include tls_server_name in credentials.json if --tls-server-name was specified while linking an instance.`

Atm CLOUD_PROFILE is taken from env var when using options. And when using env vars it is not used at all?