### PR TITLE
Keep verifier cookie in built-in signup

### DIFF
--- a/packages/auth-express/src/index.ts
+++ b/packages/auth-express/src/index.ts
@@ -418,7 +418,8 @@ export class ExpressAuth {
         const isSignUp = searchParams.get("isSignUp") === "true";
         const tokenData = await (await this.core).getToken(code, verifier);
         this.createAuthCookie(res, tokenData.auth_token);
-        res.clearCookie(this.options.pkceVerifierCookieName);
+        // n.b. we need to keep the verifier cookie around for the email
+        // verification flow which uses the same PKCE session
 
         req.session = new ExpressAuthSession(this.client, tokenData.auth_token);
         req.tokenData = tokenData;

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -491,7 +491,8 @@ export abstract class NextAuth extends NextAuthHelpers {
               );
             }
             this.setAuthCookie(tokenData.auth_token);
-            cookies().delete(this.options.pkceVerifierCookieName);
+            // n.b. we need to keep the verifier cookie around for the email
+            // verification flow which uses the same PKCE session
 
             return onBuiltinUICallback(
               {

--- a/packages/auth-remix/src/server.ts
+++ b/packages/auth-remix/src/server.ts
@@ -376,13 +376,8 @@ export class RemixServerAuth extends RemixClientAuth {
               "Set-Cookie",
               this.createAuthCookie(tokenData.auth_token),
             );
-            headers.append(
-              "Set-Cookie",
-              cookie.serialize(this.options.pkceVerifierCookieName, "", {
-                maxAge: 0,
-                path: "/",
-              }),
-            );
+            // n.b. we need to keep the verifier cookie around for the email
+            // verification flow which uses the same PKCE session
             return cbCall(
               onBuiltinUICallback,
               {

--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -613,7 +613,8 @@ async function handleAuthRoutes(
 
       setAuthCookie(cookies, config, tokenData.auth_token);
 
-      deleteCookie(cookies, config.pkceVerifierCookieName);
+      // n.b. we need to keep the verifier cookie around for the email
+      // verification flow which uses the same PKCE session
 
       return onBuiltinUICallback({
         error: null,


### PR DESCRIPTION
When `require_verification` is false (which is the case here), we should not delete the PKCE session since we still need it for verifying emails even though it's not required. We still send the email, and the verification flow requires that the same PKCE session is valid in the browser.

Closes #1094 