### PR TITLE
Use more robust raw string quoting

### DIFF
--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -24,39 +24,19 @@ describe("insert", () => {
   });
 
   test("basic insert", async () => {
-    const data = [{ title: "Black Widow $$$*", genre: "Action", rating: 5 }];
-    const q1 = e.params(
-      {
-        data: e.json,
-      },
-      (params) =>
-        e.for(e.json_array_unpack(params.data), (j) =>
-          e.insert(e.Movie, {
-            title: e.cast(e.str, e.json_get(j, "title")),
-            genre: e.cast(e.Genre, e.json_get(j, "genre")),
-            rating: e.cast(e.int16, e.json_get(j, "rating")),
-          }),
-        ),
-    );
+    const q1 = e.insert(e.Movie, {
+      title: "Black Widow",
+      genre: e.Genre.Action,
+      rating: 5,
+    });
 
-    assert.deepEqual(q1.__cardinality__, $.Cardinality.Many);
-    tc.assert<tc.IsExact<(typeof q1)["__cardinality__"], $.Cardinality.Many>>(
+    assert.deepEqual(q1.__cardinality__, $.Cardinality.One);
+    tc.assert<tc.IsExact<(typeof q1)["__cardinality__"], $.Cardinality.One>>(
       true,
     );
 
-    await q1.run(client, { data });
-    await client.execute(`DELETE Movie FILTER .title = 'Black Widow $$$*';`);
-
-    const q2 = e.for(e.json_array_unpack(e.json(data)), (j) =>
-      e.insert(e.Movie, {
-        title: e.cast(e.str, e.json_get(j, "title")),
-        genre: e.cast(e.Genre, e.json_get(j, "genre")),
-        rating: e.cast(e.int16, e.json_get(j, "rating")),
-      }),
-    );
-
-    await q2.run(client);
-    await client.execute(`DELETE Movie FILTER .title = 'Black Widow $$$*';`);
+    await q1.run(client);
+    await client.execute(`DELETE Movie FILTER .title = 'Black Widow';`);
   });
 
   test("insert with keyword enum", async () => {

--- a/integration-tests/lts/literals.test.ts
+++ b/integration-tests/lts/literals.test.ts
@@ -51,8 +51,8 @@ describe("literals", () => {
     assert.equal(e.year("1234").toEdgeQL(), `<default::year>1234`);
 
     assert.equal(
-      e.std.json("asdf").toEdgeQL(),
-      `to_json($jsonliteral$"asdf"$jsonliteral$)`,
+      e.std.json("asdf$$$*").toEdgeQL(),
+      `to_json($jsonliteral$"asdf$$$*"$jsonliteral$)`,
     );
     assert.equal(
       e.std.json({ a: 123, b: "some string", c: [true, false] }).toEdgeQL(),

--- a/integration-tests/lts/literals.test.ts
+++ b/integration-tests/lts/literals.test.ts
@@ -50,10 +50,13 @@ describe("literals", () => {
     );
     assert.equal(e.year("1234").toEdgeQL(), `<default::year>1234`);
 
-    assert.equal(e.std.json("asdf").toEdgeQL(), `to_json($$"asdf"$$)`);
+    assert.equal(
+      e.std.json("asdf").toEdgeQL(),
+      `to_json($jsonliteral$"asdf"$jsonliteral$)`,
+    );
     assert.equal(
       e.std.json({ a: 123, b: "some string", c: [true, false] }).toEdgeQL(),
-      'to_json($${"a":123,"b":"some string","c":[true,false]}$$)',
+      'to_json($jsonliteral${"a":123,"b":"some string","c":[true,false]}$jsonliteral$)',
     );
 
     assert.equal(e.std.str(`asdfaf`).toEdgeQL(), `"asdfaf"`);

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1568,4 +1568,14 @@ SELECT __scope_0_defaultPerson {
     const result = await q.run(client);
     assert.deepEqual(result, { jsonLiteral: "$jsonliteral$delete Person" });
   });
+
+  test("select json literal: counter overflow", async () => {
+    let testString = "$jsonliteral$";
+    for (let i = 0; i < 100; i++) {
+      testString += `$jsonliteral${i}$`;
+    }
+    const q = e.select(e.json(testString));
+
+    assert.rejects(() => q.run(client), edgedb.InputDataError);
+  });
 });

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1559,4 +1559,13 @@ SELECT __scope_0_defaultPerson {
       >
     >(true);
   });
+
+  test("select json literal", async () => {
+    const q = e.select({
+      jsonLiteral: e.json("asdf$$$*"),
+    });
+
+    const result = await q.run(client);
+    assert.deepEqual(result, { jsonLiteral: "asdf$$$*" });
+  });
 });

--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1562,10 +1562,10 @@ SELECT __scope_0_defaultPerson {
 
   test("select json literal", async () => {
     const q = e.select({
-      jsonLiteral: e.json("asdf$$$*"),
+      jsonLiteral: e.json("$jsonliteral$delete Person"),
     });
 
     const result = await q.run(client);
-    assert.deepEqual(result, { jsonLiteral: "asdf$$$*" });
+    assert.deepEqual(result, { jsonLiteral: "$jsonliteral$delete Person" });
   });
 });

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1453,7 +1453,7 @@ function makeLabel(stringified: string): string {
   const MAX_ITERATIONS = 100;
   const prefix = "jsonliteral";
   let counter = 0;
-  let label = `${prefix}${counter}`;
+  let label = `${prefix}`;
 
   while (stringified.includes(`$${label}$`) && counter < MAX_ITERATIONS) {
     label = `${prefix}${counter}`;

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1456,7 +1456,7 @@ function makeLabel(stringified: string): string {
     label = `${label}${counter}`;
     counter++;
   }
-  if (counter === MAX_ITERATIONS) {
+  if (counter >= MAX_ITERATIONS) {
     throw new Error("Counter reached 100 without finding a unique label.");
   }
   return label;

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1454,7 +1454,7 @@ function literalToEdgeQL(type: BaseType, val: any): string {
   let stringRep;
   if (typename === "std::json") {
     skipCast = true;
-    stringRep = `to_json($$${JSON.stringify(val)}$$)`;
+    stringRep = `to_json($jsonliteral$${JSON.stringify(val)}$jsonliteral$)`;
   } else if (typeof val === "string") {
     if (numericalTypes[typename]) {
       skipCast = typename === type.__name__;

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -6,6 +6,7 @@ import {
   RelativeDuration,
   DateDuration,
   Range,
+  InputDataError,
 } from "edgedb";
 import {
   Cardinality,
@@ -1450,14 +1451,19 @@ const numericalTypes: Record<string, boolean> = {
 
 function makeLabel(stringified: string): string {
   const MAX_ITERATIONS = 100;
-  let label = `jsonliteral`;
+  const prefix = "jsonliteral";
   let counter = 0;
+  let label = `${prefix}${counter}`;
+
   while (stringified.includes(`$${label}$`) && counter < MAX_ITERATIONS) {
-    label = `${label}${counter}`;
+    label = `${prefix}${counter}`;
     counter++;
   }
+
   if (counter >= MAX_ITERATIONS) {
-    throw new Error("Counter reached 100 without finding a unique label.");
+    throw new InputDataError(
+      "Counter reached 100 without finding a unique label.",
+    );
   }
   return label;
 }

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -1454,7 +1454,21 @@ function literalToEdgeQL(type: BaseType, val: any): string {
   let stringRep;
   if (typename === "std::json") {
     skipCast = true;
-    stringRep = `to_json($jsonliteral$${JSON.stringify(val)}$jsonliteral$)`;
+    const stringified = JSON.stringify(val);
+    const buildLabel = (
+      dataStr: string,
+      currentLabel: string = "jsonliteral",
+    ) => {
+      if (dataStr.includes(`$${currentLabel}$`)) {
+        const randomAscii = String.fromCharCode(
+          Math.floor(Math.random() * (126 - 32 + 1)) + 32,
+        );
+        return buildLabel(dataStr, currentLabel + randomAscii);
+      }
+      return currentLabel;
+    };
+    const label = `$${buildLabel(stringified)}$`;
+    stringRep = `to_json(${label}${JSON.stringify(val)}${label})`;
   } else if (typeof val === "string") {
     if (numericalTypes[typename]) {
       skipCast = typename === type.__name__;


### PR DESCRIPTION
Input data is likely to contain the string `"$$"`, so use an interstitial label to make it less likely to collide with typical JSON data.

Closes #1097
