### PR TITLE
Fix sveltekit built in authentication flow due to missing verifier cookie

### DIFF
--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -628,7 +628,8 @@ async function handleAuthRoutes(
     case "builtin/signup": {
       const pkceSession = await core.then((core) => core.createPKCESession());
 
-      deleteCookie(cookies, config.pkceVerifierCookieName);
+      const { verifier } = pkceSession;
+      setVerifierCookie(cookies, config, verifier);
 
       return redirect(
         307,


### PR DESCRIPTION
The built in authentication flow with sveltekit is broken due to a missing verifier cookie.

Aligned with nextjs implementation, see https://github.com/edgedb/edgedb-js/blob/b9ddf43bed64eb5a356584396c11244bf854aec6/packages/auth-nextjs/src/shared.ts#L514C48-L514C56