### PR TITLE
Fix accidental required magic link callback

### DIFF
--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -67,12 +67,12 @@ export interface AuthRouteHandlers {
       { verificationToken?: string }
     >,
   ) => Promise<never>;
-  onMagicLinkCallback(
+  onMagicLinkCallback?: (
     params: ParamsOrError<{
       tokenData: TokenData;
       isSignUp: boolean;
     }>,
-  ): Promise<Response>;
+  ) => Promise<Response>;
   onSignout?: () => Promise<never>;
 }
 


### PR DESCRIPTION
In the sveltekit auth helper, we accidentally defined `onMagicLinkCallback` as a required method instead of an optional callback handler.