### PR TITLE
Compare e.json roundtrip to JSON.stringify->parse

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1701,10 +1701,15 @@ SELECT __scope_0_defaultPerson {
   test("arbitrary json literal", async () => {
     await fc.assert(
       fc.asyncProperty(fc.jsonValue(), async (arbitraryJson) => {
-        const q = e.select(e.json(arbitraryJson));
-        const result = await q.run(client);
-        assert.deepEqual(result, arbitraryJson);
+        const roundTripped = JSON.parse(JSON.stringify(arbitraryJson));
+        const result = await e.select(e.json(arbitraryJson)).run(client);
+        assert.deepEqual(result, roundTripped);
       }),
     );
+  });
+
+  test("json literal special case: -0 is 0 in JSON", async () => {
+    const result = await e.select(e.json(-0)).run(client);
+    assert.equal(result, 0);
   });
 });


### PR DESCRIPTION
This fixes a flaky test because stringifying `-0` results in the string `"0"` instead of `"-0"`, at least on Node. What we really care about is that selecting any arbitrary JSON is the same as a rountrip through JSON.stringify and JSON.parse.