### PR TITLE
Add ability to specify OAuth endpoints

### DIFF
--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -188,7 +188,6 @@ export abstract class NextAuth extends NextAuthHelpers {
         redirectToOnSignup: redirectToOnSignup.toString(),
         ...(callbackUrl ? { callbackUrl } : {}),
       });
-      console.log(`Redirecting to ${location}`);
       return NextResponse.redirect(location);
     },
 


### PR DESCRIPTION
If your database is deployed to a private network and is not available at a public URL, this adds the ability to drive the whole flow from your application server, delegating to the auth server from your application server.

---

When testing this manually, I set up a new route handler at `/auth/oauth` that shadows the one built into our `createAuthRouteHandlers` behavior like this:

```ts
export async function GET(request: NextRequest): Promise<NextResponse> {
  const callbackUrl = new URL("auth/server/oauth/callback", authConfig.baseUrl);
  const authorizeUrl = new URL(
    "auth/server/oauth/authorize",
    authConfig.baseUrl,
  );
  request.nextUrl.searchParams.set("callback_url", callbackUrl.toString());
  request.nextUrl.searchParams.set("authorize_url", authorizeUrl.toString());

  return await auth.oAuth.handleOAuth(request);
}
```

Which set the authorize and callback URLs explicitly to routes in my application, and then those route handlers simply called through to these new methods like:

```ts
//  app/auth/server/oauth/authorize.ts
export async function GET(request: NextRequest): Promise<NextResponse> {
  return await auth.oAuth.handleAuthorize(request);
}

// app/auth/server/oauth/callback.ts
export async function GET(request: NextRequest): Promise<NextResponse> {
  return await auth.oAuth.handleCallback(request);
}
```

Of course, instead of just calling this methods, one could do any kind of check here on the request if your intention is to add some behavior here (analytics? logic? check email against an invite list?)