### PR TITLE
Fix some bugs in toEdgeQL when using `e.with`

### DIFF
--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -101,7 +101,7 @@ describe("update", () => {
         },
       }));
 
-      return e.with([updateChar, updateProfile], movie);
+      return e.with([updateChar, updateProfile], e.select(movie));
     }).toEdgeQL();
   });
 

--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -83,6 +83,28 @@ describe("update", () => {
     })).toEdgeQL();
   });
 
+  test("nested update and explicit with", async () => {
+    e.params({ movieId: e.uuid }, (params) => {
+      const movie = e.select(e.Movie, (m) => ({
+        filter: e.op(m.id, "=", params.movieId),
+      }));
+
+      const updateChar = e.update(movie.characters, (c) => ({
+        set: {
+          name: e.str_lower(c.name),
+        },
+      }));
+
+      const updateProfile = e.update(movie.profile, (p) => ({
+        set: {
+          a: e.str_upper(p.a),
+        },
+      }));
+
+      return e.with([updateChar, updateProfile], movie);
+    }).toEdgeQL();
+  });
+
   test("scoped update", async () => {
     const query = e.update(e.Hero, (hero) => ({
       filter_single: e.op(hero.name, "=", data.spidey.name),

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -278,6 +278,8 @@ export function $toEdgeQL(this: any) {
       // check all references and aliases are within this block
       const validScopes = new Set([
         withBlock,
+        // expressions already explictly bound to with block are also valid scopes
+        ...(withBlocks.get(withBlock) ?? []),
         ...walkExprCtx.seen.get(withBlock)!.childExprs,
       ]);
       for (const scope of [

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -432,6 +432,13 @@ function walkExprTree(
       for (const refExpr of expr.__refs__) {
         walkExprTree(refExpr, expr.__expr__, ctx);
         const seenRef = ctx.seen.get(refExpr as any)!;
+        if (seenRef.childExprs.includes(expr.__expr__)) {
+          throw new Error(
+            `Ref expressions in with() cannot reference the expression to ` +
+              `which the 'WITH' block is being attached. ` +
+              `Consider wrapping the expression in a select.`,
+          );
+        }
         if (seenRef.boundScope) {
           throw new Error(`Expression bound to multiple 'WITH' blocks`);
         }


### PR DESCRIPTION
Reported on discord: https://discord.com/channels/841451783728529451/1313928437886619738

Fix 1:
While debugging realised the original query is incorrect: the expressions being added to the `with` block can't reference the select expression the with block is attached to, as that select can't be hoisted into a var in it's own with block. The expression tree walker was not checking for this case (an expr's parent also being one of its child exprs), which could cause an infinite loop in `toEgdeQL`.

Fix 2:
We check in `toEdgeQL` that all the places where a repeated expr is used exist within the scope of the with block it's being hoisted to. Here we were incorrectly not considering expressions already explicitly bound to that with block to be valid scopes.