### PR TITLE
Make CLI wrapper install quieter

### DIFF
--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -73,16 +73,16 @@ async function main(args: string[]) {
     null;
 
   if (cliLocation === null) {
-    throw Error("Failed to find or install EdgeDB CLI.");
+    console.error("Failed to find or install EdgeDB CLI.");
+    process.exit(1);
+  }
+
+  const result = runEdgeDbCli(args, cliLocation);
+  if (result.tag === "Err") {
+    process.exit(result.error.status);
   }
 
   try {
-    const result = runEdgeDbCli(args, cliLocation);
-    if (result.tag === "Err") {
-      process.exit(result.error.status);
-      return;
-    }
-
     if (cliLocation !== maybeCachedCliLocation) {
       debug("CLI location not cached.");
       debug(`  - Cached location: ${maybeCachedCliLocation}`);

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-import { execSync, type SpawnSyncReturns, type ExecSyncOptions } from "node:child_process";
+import {
+  execSync,
+  type SpawnSyncReturns,
+  type ExecSyncOptions,
+} from "node:child_process";
 import { createWriteStream } from "node:fs";
 import * as os from "node:os";
 import * as fs from "node:fs/promises";
@@ -262,7 +266,10 @@ function runEdgeDbCli(
     const result = execSync(command, execOptions);
     return { tag: "Ok", stdout: result };
   } catch (error: unknown) {
-    return { tag: "Err", error: error as Error & SpawnSyncReturns<string | Buffer> };
+    return {
+      tag: "Err",
+      error: error as Error & SpawnSyncReturns<string | Buffer>,
+    };
   }
 }
 
@@ -342,7 +349,7 @@ async function getMatchingPkg(
   } else {
     throw Error(
       "no published EdgeDB CLI version matches requested version " +
-      `'${cliVersionRange}'`,
+        `'${cliVersionRange}'`,
     );
   }
 }

--- a/packages/driver/src/cli.mts
+++ b/packages/driver/src/cli.mts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync, type ExecSyncOptions } from "node:child_process";
+import { execSync, type SpawnSyncReturns, type ExecSyncOptions } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import * as os from "node:os";
 import * as fs from "node:fs/promises";
@@ -27,6 +27,18 @@ interface Package {
   revision: string;
   installref: string;
 }
+
+interface Ok {
+  tag: "Ok";
+  stdout: string | Buffer;
+}
+
+interface Err {
+  tag: "Err";
+  error: Error & SpawnSyncReturns<string | Buffer>;
+}
+
+type Result = Ok | Err;
 
 debug("Process argv:", process.argv);
 // n.b. Using `npx`, the 3rd argument is the script name, unlike
@@ -65,7 +77,12 @@ async function main(args: string[]) {
   }
 
   try {
-    runEdgeDbCli(args, cliLocation);
+    const result = runEdgeDbCli(args, cliLocation);
+    if (result.tag === "Err") {
+      process.exit(result.error.status);
+      return;
+    }
+
     if (cliLocation !== maybeCachedCliLocation) {
       debug("CLI location not cached.");
       debug(`  - Cached location: ${maybeCachedCliLocation}`);
@@ -75,17 +92,7 @@ async function main(args: string[]) {
       debug("Cache updated.");
     }
   } catch (err) {
-    if (
-      typeof err === "object" &&
-      err !== null &&
-      "status" in err &&
-      typeof err.status === "number"
-    ) {
-      process.exit(err.status);
-    } else {
-      console.error(err);
-    }
-
+    console.error(err);
     process.exit(1);
   }
 
@@ -214,11 +221,12 @@ async function selfInstallFromTempCli(): Promise<string | null> {
   debug("Self-installing EdgeDB CLI...");
   // n.b. need -y because in the Vercel build container, $HOME and euid-obtained
   // home are different, and the CLI installation requires this as confirmation
-  const cmd = ["_self_install", "-y"];
-  if (!IS_TTY) {
-    cmd.push("--quiet");
+  const cmd = ["_self_install", "-y", "--quiet"];
+  const result = runEdgeDbCli(cmd, TEMPORARY_CLI_PATH);
+  if (result.tag === "Err") {
+    debug("  - CLI self-installation failed with error:", result.error);
+    return null;
   }
-  runEdgeDbCli(cmd, TEMPORARY_CLI_PATH);
   debug("  - CLI self-installed successfully.");
   return getCliLocationFromCache();
 }
@@ -247,10 +255,15 @@ function runEdgeDbCli(
   args: string[],
   pathToCli: string,
   execOptions: ExecSyncOptions = { stdio: "inherit" },
-) {
+): Result {
   const command = quote([pathToCli, ...args]);
   debug(`Running EdgeDB CLI: ${command}`);
-  return execSync(command, execOptions);
+  try {
+    const result = execSync(command, execOptions);
+    return { tag: "Ok", stdout: result };
+  } catch (error: unknown) {
+    return { tag: "Err", error: error as Error & SpawnSyncReturns<string | Buffer> };
+  }
 }
 
 async function findPackage(): Promise<Package> {
@@ -329,7 +342,7 @@ async function getMatchingPkg(
   } else {
     throw Error(
       "no published EdgeDB CLI version matches requested version " +
-        `'${cliVersionRange}'`,
+      `'${cliVersionRange}'`,
     );
   }
 }
@@ -385,11 +398,14 @@ function getBaseDist(arch: string, platform: string, libc = ""): string {
 
 function getInstallDir(cliPath: string): string {
   debug("Getting install directory for CLI path:", cliPath);
-  const installDir = runEdgeDbCli(["info", "--get", "install-dir"], cliPath, {
+  const result = runEdgeDbCli(["info", "--get", "install-dir"], cliPath, {
     stdio: "pipe",
-  })
-    .toString()
-    .trim();
+  });
+  if (result.tag === "Err") {
+    debug("  - Failed to get install directory from CLI:", result.error);
+    throw result.error;
+  }
+  const installDir = result.stdout.toString().trim();
   debug("  - Install directory:", installDir);
   return installDir;
 }

--- a/packages/driver/src/typeutil.ts
+++ b/packages/driver/src/typeutil.ts
@@ -1,3 +1,15 @@
 export type Mutable<T> = {
   -readonly [K in keyof T]: T[K];
 };
+
+export interface Ok<T> {
+  tag: "Ok";
+  value: T;
+}
+
+export interface Err<ErrorT> {
+  tag: "Err";
+  error: ErrorT;
+}
+
+export type Result<T, ErrorT> = Ok<T> | Err<ErrorT>;


### PR DESCRIPTION
1. Do not prompt for confirmation when installing the CLI, even for TTYs
2. More gracefully handle errors from the CLI. `stderr` is already being
   piped to the parent process, so no need to log errors so loudly.