### PR TITLE
Update github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,39 +22,34 @@ jobs:
         with:
           node-version: 20
 
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
       - name: Install deps
         run: yarn
 
-      # edgedb
+      # gel
 
       - name: Copy readme
         run: cp README.md packages/driver/README.md
 
-      - name: Build edgedb
-        run: yarn workspace edgedb run build
+      - name: Build gel
+        run: yarn workspace gel run build
 
       - id: check_publish_driver
-        name: Dry-run publish 'edgedb' to npm
+        name: Dry-run publish 'gel' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/driver/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If 'edgedb' version unchanged
+      - name: If 'gel' version unchanged
         if: steps.check_publish_driver.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace edgedb version --no-git-tag-version --minor
+          yarn workspace gel version --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/driver/package.json').version")
-          yarn workspace edgedb version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace gel version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish 'edgedb'
+      - name: Publish 'gel'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/driver/package.json
@@ -62,39 +57,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_driver.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create 'edgedb' GitHub Release
+      - name: Create 'gel' GitHub Release
         if: steps.check_publish_driver.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.check_publish_driver.outputs.version }}
-          name: edgedb-js v${{ steps.check_publish_driver.outputs.version }}
+          name: gel-js v${{ steps.check_publish_driver.outputs.version }}
           draft: true
           prerelease: false
 
-      # @edgedb/generate
+      # @gel/generate
 
-      - name: Build @edgedb/generate
-        run: yarn workspace @edgedb/generate run build
+      - name: Build @gel/generate
+        run: yarn workspace @gel/generate run build
 
       - id: check_publish_generate
-        name: Dry-run publish '@edgedb/generate' to npm
+        name: Dry-run publish '@gel/generate' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
-          package: packages/generate/package.json
+          package: packages/gel/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/generate' version unchanged
+      - name: If '@gel/generate' version unchanged
         if: steps.check_publish_generate.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/generate version --no-git-tag-version --minor
+          yarn workspace @gel/generate version --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/generate/package.json').version")
-          yarn workspace @edgedb/generate version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/generate version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/generate'
+      - name: Publish '@gel/generate'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/generate/package.json
@@ -102,39 +97,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_generate.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/generate' GitHub Release
+      - name: Create '@gel/generate' GitHub Release
         if: steps.check_publish_generate.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: generate-v${{ steps.check_publish_generate.outputs.version }}
-          name: "@edgedb/generate v${{ steps.check_publish_generate.outputs.version }}"
+          name: "@gel/generate v${{ steps.check_publish_generate.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/auth-core
+      # @gel/auth-core
 
-      - name: Build @edgedb/auth-core
-        run: yarn workspace @edgedb/auth-core run build
+      - name: Build @gel/auth-core
+        run: yarn workspace @gel/auth-core run build
 
       - id: check_publish_auth_core
-        name: Dry-run publish '@edgedb/auth-core' to npm
+        name: Dry-run publish '@gel/auth-core' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-core/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/auth-core' version unchanged
+      - name: If '@gel/auth-core' version unchanged
         if: steps.check_publish_auth_core.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/auth-core version --no-git-tag-version --minor
+          yarn workspace @gel/auth-core version --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/auth-core/package.json').version")
-          yarn workspace @edgedb/auth-core version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/auth-core version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/auth-core'
+      - name: Publish '@gel/auth-core'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-core/package.json
@@ -142,39 +137,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_auth_core.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/auth-core' Release
+      - name: Create '@gel/auth-core' Release
         if: steps.check_publish_auth_core.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-core-v${{ steps.check_publish_auth_core.outputs.version }}
-          name: "@edgedb/auth-core v${{ steps.check_publish_auth_core.outputs.version }}"
+          name: "@gel/auth-core v${{ steps.check_publish_auth_core.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/auth-nextjs
+      # @gel/auth-nextjs
 
-      - name: Build @edgedb/auth-nextjs
-        run: yarn workspace @edgedb/auth-nextjs run build
+      - name: Build @gel/auth-nextjs
+        run: yarn workspace @gel/auth-nextjs run build
 
       - id: check_publish_auth_nextjs
-        name: Dry-run publish '@edgedb/auth-nextjs' to npm
+        name: Dry-run publish '@gel/auth-nextjs' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-nextjs/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/auth-nextjs' version unchanged
+      - name: If '@gel/auth-nextjs' version unchanged
         if: steps.check_publish_auth_nextjs.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/auth-nextjs version  --no-git-tag-version --minor
+          yarn workspace @gel/auth-nextjs version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/auth-nextjs/package.json').version")
-          yarn workspace @edgedb/auth-nextjs version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/auth-nextjs version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/auth-nextjs'
+      - name: Publish '@gel/auth-nextjs'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-nextjs/package.json
@@ -182,39 +177,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_auth_nextjs.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/auth-nextjs' Release
+      - name: Create '@gel/auth-nextjs' Release
         if: steps.check_publish_auth_nextjs.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-nextjs-v${{ steps.check_publish_auth_nextjs.outputs.version }}
-          name: "@edgedb/auth-nextjs v${{ steps.check_publish_auth_nextjs.outputs.version }}"
+          name: "@gel/auth-nextjs v${{ steps.check_publish_auth_nextjs.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/auth-express
+      # @gel/auth-express
 
-      - name: Build @edgedb/auth-express
-        run: yarn workspace @edgedb/auth-express run build
+      - name: Build @gel/auth-express
+        run: yarn workspace @gel/auth-express run build
 
       - id: check_publish_auth_express
-        name: Dry-run publish '@edgedb/auth-express' to npm
+        name: Dry-run publish '@gel/auth-express' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-express/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/auth-express' version unchanged
+      - name: If '@gel/auth-express' version unchanged
         if: steps.check_publish_auth_express.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/auth-express version  --no-git-tag-version --minor
+          yarn workspace @gel/auth-express version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/auth-express/package.json').version")
-          yarn workspace @edgedb/auth-express version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/auth-express version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/auth-express'
+      - name: Publish '@gel/auth-express'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-express/package.json
@@ -222,39 +217,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_auth_express.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/auth-express' Release
+      - name: Create '@gel/auth-express' Release
         if: steps.check_publish_auth_express.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-express-v${{ steps.check_publish_auth_express.outputs.version }}
-          name: "@edgedb/auth-express v${{ steps.check_publish_auth_express.outputs.version }}"
+          name: "@gel/auth-express v${{ steps.check_publish_auth_express.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/auth-remix
+      # @gel/auth-remix
 
-      - name: Build @edgedb/auth-remix
-        run: yarn workspace @edgedb/auth-remix run build
+      - name: Build @gel/auth-remix
+        run: yarn workspace @gel/auth-remix run build
 
       - id: check_publish_auth_remix
-        name: Dry-run publish '@edgedb/auth-remix' to npm
+        name: Dry-run publish '@gel/auth-remix' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-remix/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/auth-remix' version unchanged
+      - name: If '@gel/auth-remix' version unchanged
         if: steps.check_publish_auth_remix.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/auth-remix version  --no-git-tag-version --minor
+          yarn workspace @gel/auth-remix version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/auth-remix/package.json').version")
-          yarn workspace @edgedb/auth-remix version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/auth-remix version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/auth-remix'
+      - name: Publish '@gel/auth-remix'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-remix/package.json
@@ -262,39 +257,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_auth_remix.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/auth-remix' Release
+      - name: Create '@gel/auth-remix' Release
         if: steps.check_publish_auth_remix.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-remix-v${{ steps.check_publish_auth_remix.outputs.version }}
-          name: "@edgedb/auth-remix v${{ steps.check_publish_auth_remix.outputs.version }}"
+          name: "@gel/auth-remix v${{ steps.check_publish_auth_remix.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/auth-sveltekit
+      # @gel/auth-sveltekit
 
-      - name: Build @edgedb/auth-sveltekit
-        run: yarn workspace @edgedb/auth-sveltekit run build
+      - name: Build @gel/auth-sveltekit
+        run: yarn workspace @gel/auth-sveltekit run build
 
       - id: check_publish_auth_sveltekit
-        name: Dry-run publish '@edgedb/auth-sveltekit' to npm
+        name: Dry-run publish '@gel/auth-sveltekit' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-sveltekit/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/auth-sveltekit' version unchanged
+      - name: If '@gel/auth-sveltekit' version unchanged
         if: steps.check_publish_auth_sveltekit.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/auth-sveltekit version  --no-git-tag-version --minor
+          yarn workspace @gel/auth-sveltekit version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/auth-sveltekit/package.json').version")
-          yarn workspace @edgedb/auth-sveltekit version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/auth-sveltekit version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/auth-sveltekit'
+      - name: Publish '@gel/auth-sveltekit'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/auth-sveltekit/package.json
@@ -302,39 +297,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_auth_sveltekit.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/auth-sveltekit' Release
+      - name: Create '@gel/auth-sveltekit' Release
         if: steps.check_publish_auth_sveltekit.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: auth-sveltekit-v${{ steps.check_publish_auth_sveltekit.outputs.version }}
-          name: "@edgedb/auth-sveltekit v${{ steps.check_publish_auth_sveltekit.outputs.version }}"
+          name: "@gel/auth-sveltekit v${{ steps.check_publish_auth_sveltekit.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/create
+      # @gel/create
 
-      - name: Build @edgedb/create
-        run: yarn workspace @edgedb/create run build
+      - name: Build @gel/create
+        run: yarn workspace @gel/create run build
 
       - id: check_publish_create
-        name: Dry-run publish '@edgedb/create' to npm
+        name: Dry-run publish '@gel/create' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/create/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/create' version unchanged
+      - name: If '@gel/create' version unchanged
         if: steps.check_publish_create.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/create version  --no-git-tag-version --minor
+          yarn workspace @gel/create version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/create/package.json').version")
-          yarn workspace @edgedb/create version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/create version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/create'
+      - name: Publish '@gel/create'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/create/package.json
@@ -342,39 +337,39 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_create.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/create' Release
+      - name: Create '@gel/create' Release
         if: steps.check_publish_create.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: create-v${{ steps.check_publish_create.outputs.version }}
-          name: "@edgedb/create v${{ steps.check_publish_create.outputs.version }}"
+          name: "@gel/create v${{ steps.check_publish_create.outputs.version }}"
           draft: true
           prerelease: false
 
-      # @edgedb/ai
+      # @gel/ai
 
-      - name: Build @edgedb/ai
-        run: yarn workspace @edgedb/ai run build
+      - name: Build @gel/ai
+        run: yarn workspace @gel/ai run build
 
       - id: check_publish_ai
-        name: Dry-run publish '@edgedb/ai' to npm
+        name: Dry-run publish '@gel/ai' to npm
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/ai/package.json
           token: ${{ secrets.NPM_TOKEN }}
           dry-run: true
 
-      - name: If '@edgedb/ai' version unchanged
+      - name: If '@gel/ai' version unchanged
         if: steps.check_publish_ai.outputs.type == ''
         run: |
           echo "Version in package.json has not changed. Creating canary release."
-          yarn workspace @edgedb/ai version  --no-git-tag-version --minor
+          yarn workspace @gel/ai version  --no-git-tag-version --minor
           CURRENT_VERSION=$(node -p "require('./packages/ai/package.json').version")
-          yarn workspace @edgedb/ai version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
+          yarn workspace @gel/ai version --no-git-tag-version --new-version "${CURRENT_VERSION}-canary.$(date +'%Y%m%dT%H%M%S')"
 
-      - name: Publish '@edgedb/ai'
+      - name: Publish '@gel/ai'
         uses: JS-DevTools/npm-publish@4b07b26a2f6e0a51846e1870223e545bae91c552
         with:
           package: packages/ai/package.json
@@ -382,13 +377,13 @@ jobs:
           access: public
           tag: ${{ steps.check_publish_ai.outputs.type == '' && 'canary' || 'latest' }}
 
-      - name: Create '@edgedb/ai' Release
+      - name: Create '@gel/ai' Release
         if: steps.check_publish_ai.outputs.type != ''
         uses: softprops/action-gh-release@v2.0.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ai-v${{ steps.check_publish_ai.outputs.version }}
-          name: "@edgedb/ai v${{ steps.check_publish_ai.outputs.version }}"
+          name: "@gel/ai v${{ steps.check_publish_ai.outputs.version }}"
           draft: true
           prerelease: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,29 +13,29 @@ jobs:
     # when the release PR gets merged by the bot.
     if: needs.prep.outputs.version == 0
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
+    continue-on-error: ${{ matrix.gel-version == 'nightly' }}
     strategy:
       matrix:
         node-version: ["18", "20", "22"]
         os: [ubuntu-latest]
-        edgedb-version: ["stable"]
+        gel-version: ["stable"]
         include:
           - os: ubuntu-latest
             node-version: "20"
-            edgedb-version: "nightly"
+            gel-version: "nightly"
           - os: ubuntu-latest
             node-version: "20"
-            edgedb-version: "5"
+            gel-version: "5"
           - os: ubuntu-latest
             node-version: "20"
-            edgedb-version: "4"
+            gel-version: "4"
           # - os: ubuntu-latest
           #   node-version: "20"
-          #   edgedb-version: "3"
+          #   gel-version: "3"
           # XXX: macOS is currently unsupported by setup-edgedb
           # - os: macos-latest
           #   node-version: "20"
-          #   edgedb-version: "stable"
+          #   gel-version: "stable"
 
     steps:
       - uses: actions/checkout@v4
@@ -77,35 +77,35 @@ jobs:
         run: |
           yarn format
 
-      - name: Install EdgeDB
+      - name: Install Gel
         uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
         with:
           instance-name: test
-          server-version: ${{ matrix.edgedb-version }}
+          server-version: ${{ matrix.gel-version }}
 
-      - name: Show actual EdgeDB server version
+      - name: Show actual Gel server version
         run: |
-          echo ACTIVE_EDGEDB_VERSION=$(edgedb query 'select sys::get_version_as_str()' -I test) >> $GITHUB_ENV
+          echo ACTIVE_GEL_VERSION=$(gel query 'select sys::get_version_as_str()' -I test) >> $GITHUB_ENV
 
       - name: Run package tests
         run: |
           yarn ci:test
 
       - name: Run query builder integration tests lts
-        if: ${{ matrix.edgedb-version == '3' || matrix.edgedb-version == '4' || matrix.edgedb-version == 'stable' || matrix.edgedb-version == 'nightly' }}
+        if: ${{ matrix.gel-version == '3' || matrix.gel-version == '4' || matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}
         run: |
-          turbo run ci:integration-test --filter=@edgedb/integration-lts
-          turbo run bench:types --filter=@edgedb/integration-lts || echo "Benchmark types script failed, proceeding anyway."
+          turbo run ci:integration-test --filter=@gel/integration-lts
+          turbo run bench:types --filter=@gel/integration-lts || echo "Benchmark types script failed, proceeding anyway."
 
       - name: Run query builder integration tests stable
-        if: ${{ matrix.edgedb-version == 'stable' || matrix.edgedb-version == 'nightly' }}
+        if: ${{ matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}
         run: |
-          turbo run ci:integration-test --filter=@edgedb/integration-stable
+          turbo run ci:integration-test --filter=@gel/integration-stable
 
       - name: Run query builder integration tests nightly
-        if: ${{ matrix.edgedb-version == 'nightly' }}
+        if: ${{ matrix.gel-version == 'nightly' }}
         run: |
-          turbo run ci:integration-test --filter=@edgedb/integration-nightly
+          turbo run ci:integration-test --filter=@gel/integration-nightly
 
       - name: Typecheck other packages
         run: |
@@ -144,28 +144,28 @@ jobs:
 
       - name: Build and pack CLI wrapper
         run: |
-          yarn workspace edgedb run build
-          yarn workspace edgedb pack --filename=${{ github.workspace }}/edgedb-cli.tar.gz
+          yarn workspace gel run build
+          yarn workspace gel pack --filename=${{ github.workspace }}/gel-cli.tar.gz
 
       - name: Test CLI wrapper with npm
         run: |
           mkdir ${{ runner.temp }}/temp-npm
           cd ${{ runner.temp }}/temp-npm
           npm init -y
-          npm install ${{ github.workspace }}/edgedb-cli.tar.gz
-          npm exec edgedb -- project init --non-interactive
-          npm exec edgedb -- --version
-          npm exec edgedb -- query 'select sys::get_version_as_str()'
+          npm install ${{ github.workspace }}/gel-cli.tar.gz
+          npm exec gel -- project init --non-interactive
+          npm exec gel -- --version
+          npm exec gel -- query 'select sys::get_version_as_str()'
 
       - name: Test CLI wrapper with yarn
         run: |
           mkdir ${{ runner.temp }}/temp-yarn
           cd ${{ runner.temp }}/temp-yarn
           yarn init -y
-          yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
-          yarn edgedb project init --non-interactive
-          yarn edgedb --version
-          yarn edgedb query 'select sys::get_version_as_str()'
+          yarn add ${{ github.workspace}}/gel-cli.tar.gz
+          yarn gel project init --non-interactive
+          yarn gel --version
+          yarn gel query 'select sys::get_version_as_str()'
 
       - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
         with:
@@ -178,10 +178,10 @@ jobs:
           yarn set version berry
           yarn init -y
           touch yarn.lock
-          yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
-          yarn edgedb project init --non-interactive
-          yarn edgedb --version
-          yarn edgedb query 'select sys::get_version_as_str()'
+          yarn add ${{ github.workspace }}/gel-cli.tar.gz
+          yarn gel project init --non-interactive
+          yarn gel --version
+          yarn gel query 'select sys::get_version_as_str()'
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
         with:
@@ -192,10 +192,10 @@ jobs:
           mkdir ${{ runner.temp }}/temp-pnpm
           cd ${{ runner.temp}}/temp-pnpm
           pnpm init
-          pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
-          pnpm exec edgedb project init --non-interactive
-          pnpm exec edgedb --version
-          pnpm exec edgedb query 'select sys::get_version_as_str()'
+          pnpm add ${{ github.workspace }}/gel-cli.tar.gz
+          pnpm exec gel project init --non-interactive
+          pnpm exec gel --version
+          pnpm exec gel query 'select sys::get_version_as_str()'
 
       - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
       - name: Test CLI wrapper with bun
@@ -203,7 +203,7 @@ jobs:
           mkdir temp-bun
           cd temp-bun
           bun init
-          bun add ${{ github.workspace }}/edgedb-cli.tar.gz
-          bun edgedb project init --non-interactive
-          bun edgedb --version
-          bun edgedb query 'select sys::get_version_as_str()'
+          bun add ${{ github.workspace }}/gel-cli.tar.gz
+          bun gel project init --non-interactive
+          bun gel --version
+          bun gel query 'select sys::get_version_as_str()'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     # when the release PR gets merged by the bot.
     if: needs.prep.outputs.version == 0
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.gel-version == 'nightly' }}
+    continue-on-error: true
     strategy:
       matrix:
         node-version: ["18", "20", "22"]
@@ -32,7 +32,7 @@ jobs:
           # - os: ubuntu-latest
           #   node-version: "20"
           #   gel-version: "3"
-          # XXX: macOS is currently unsupported by setup-edgedb
+          # XXX: macOS is currently unsupported by gel-edgedb
           # - os: macos-latest
           #   node-version: "20"
           #   gel-version: "stable"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
           yarn format
 
       - name: Install Gel
-        uses: edgedb/setup-edgedb@2f1c0c768766b0411f1f3ec3a92f36a319097664
+        uses: edgedb/setup-edgedb@7df433b68e74d550eb024e1d1588e3da84bfaf5a
         with:
           instance-name: test
           server-version: ${{ matrix.gel-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           # - os: ubuntu-latest
           #   node-version: "20"
           #   gel-version: "3"
-          # XXX: macOS is currently unsupported by gel-edgedb
+          # XXX: macOS is currently unsupported by setup-edgedb
           # - os: macos-latest
           #   node-version: "20"
           #   gel-version: "stable"
@@ -145,14 +145,14 @@ jobs:
       - name: Build and pack CLI wrapper
         run: |
           yarn workspace gel run build
-          yarn workspace gel pack --filename=${{ github.workspace }}/gel-cli.tar.gz
+          yarn workspace gel pack --filename=${{ github.workspace }}/edgedb-cli.tar.gz
 
       - name: Test CLI wrapper with npm
         run: |
           mkdir ${{ runner.temp }}/temp-npm
           cd ${{ runner.temp }}/temp-npm
           npm init -y
-          npm install ${{ github.workspace }}/gel-cli.tar.gz
+          npm install ${{ github.workspace }}/edgedb-cli.tar.gz
           npm exec gel -- project init --non-interactive
           npm exec gel -- --version
           npm exec gel -- query 'select sys::get_version_as_str()'
@@ -162,13 +162,13 @@ jobs:
           mkdir ${{ runner.temp }}/temp-yarn
           cd ${{ runner.temp }}/temp-yarn
           yarn init -y
-          yarn add ${{ github.workspace}}/gel-cli.tar.gz
+          yarn add ${{ github.workspace}}/edgedb-cli.tar.gz
           yarn gel project init --non-interactive
           yarn gel --version
           yarn gel query 'select sys::get_version_as_str()'
 
-          - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
-          with:
+      - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
+        with:
           version: latest
           cache: false
       - name: Test CLI wrapper with yarn-berry
@@ -178,7 +178,7 @@ jobs:
           yarn set version berry
           yarn init -y
           touch yarn.lock
-          yarn add ${{ github.workspace }}/gel-cli.tar.gz
+          yarn add ${{ github.workspace }}/edgedb-cli.tar.gz
           yarn gel project init --non-interactive
           yarn gel --version
           yarn gel query 'select sys::get_version_as_str()'
@@ -192,7 +192,7 @@ jobs:
           mkdir ${{ runner.temp }}/temp-pnpm
           cd ${{ runner.temp}}/temp-pnpm
           pnpm init
-          pnpm add ${{ github.workspace }}/gel-cli.tar.gz
+          pnpm add ${{ github.workspace }}/edgedb-cli.tar.gz
           pnpm exec gel project init --non-interactive
           pnpm exec gel --version
           pnpm exec gel query 'select sys::get_version_as_str()'
@@ -203,7 +203,7 @@ jobs:
           mkdir temp-bun
           cd temp-bun
           bun init
-          bun add ${{ github.workspace }}/gel-cli.tar.gz
+          bun add ${{ github.workspace }}/edgedb-cli.tar.gz
           bun gel project init --non-interactive
           bun gel --version
           bun gel query 'select sys::get_version_as_str()'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     # when the release PR gets merged by the bot.
     if: needs.prep.outputs.version == 0
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
         node-version: ["18", "20", "22"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
           yarn format
 
       - name: Install Gel
-        uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
+        uses: edgedb/setup-edgedb@2f1c0c768766b0411f1f3ec3a92f36a319097664
         with:
           instance-name: test
           server-version: ${{ matrix.gel-version }}
@@ -167,8 +167,8 @@ jobs:
           yarn gel --version
           yarn gel query 'select sys::get_version_as_str()'
 
-      - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
-        with:
+          - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
+          with:
           version: latest
           cache: false
       - name: Test CLI wrapper with yarn-berry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
           yarn format
 
       - name: Install Gel
-        uses: edgedb/setup-edgedb@7df433b68e74d550eb024e1d1588e3da84bfaf5a
+        uses: edgedb/setup-edgedb@6763b6de72782d9c2e5ecc1095986a1c707da68f
         with:
           instance-name: test
           server-version: ${{ matrix.gel-version }}

--- a/integration-tests/legacy/gel.toml
+++ b/integration-tests/legacy/gel.toml
@@ -1,4 +1,4 @@
-[gel]
+[edgedb]
 server-version = "2"
 
 [project]

--- a/integration-tests/lts/gel.toml
+++ b/integration-tests/lts/gel.toml
@@ -1,2 +1,2 @@
-[gel]
+[edgedb]
 server-version = "3"

--- a/integration-tests/nightly/gel.toml
+++ b/integration-tests/nightly/gel.toml
@@ -1,2 +1,2 @@
-[gel]
+[edgedb]
 server-version = "nightly"

--- a/integration-tests/stable/gel.toml
+++ b/integration-tests/stable/gel.toml
@@ -1,2 +1,2 @@
-[gel]
+[edgedb]
 server-version = "5"

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -148,9 +148,7 @@ export const startServer = async (
   }
 
   const maybeEnvWithDevMode =
-    process.env.GEL_SERVER_BIN ||
-    process.env.EDGEDB_SERVER_BIN ||
-    process.env.CI
+    process.env.GEL_SERVER_BIN || process.env.CI
       ? {}
       : {
           __EDGEDB_DEVMODE: "1",

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -294,12 +294,12 @@ export async function applyMigrations(
   if (process.platform === "win32") {
     await runCommand("wsl", [
       "-u",
-      "gel",
+      "edgedb",
       "env",
       ...Object.entries(configToEnv(config)).map(
         ([key, val]) => `${key}=${val}`,
       ),
-      "gel",
+      "edgedb",
       "migrate",
       ...(params?.flags || []),
       "--schema-dir",
@@ -307,7 +307,7 @@ export async function applyMigrations(
     ]);
   } else {
     await runCommand(
-      "gel",
+      "edgedb",
       ["migrate", ...(params?.flags || [])],
       configToEnv(config),
     );

--- a/packages/driver/test/testUtil.ts
+++ b/packages/driver/test/testUtil.ts
@@ -85,7 +85,10 @@ export const getServerCommand = (
   strictSecurity = true,
 ): { args: string[]; availableFeatures: string[] } => {
   const availableFeatures: string[] = [];
-  const srvcmd = process.env.GEL_SERVER_BIN || "gel-server";
+
+  // we can check version here and use gel-server for newer versions
+  // but edgedb-server works for all versions
+  const srvcmd = process.env.GEL_SERVER_BIN || "edgedb-server";
 
   let args = [srvcmd];
   if (process.platform === "win32") {
@@ -127,7 +130,6 @@ export const getServerCommand = (
     `--security=${strictSecurity ? "strict" : "insecure_dev_mode"}`,
     "--bootstrap-command=ALTER ROLE edgedb { SET password := 'edgedbtest' }",
   ];
-
   return { args, availableFeatures };
 };
 
@@ -146,7 +148,9 @@ export const startServer = async (
   }
 
   const maybeEnvWithDevMode =
-    process.env.GEL_SERVER_BIN || process.env.CI
+    process.env.GEL_SERVER_BIN ||
+    process.env.EDGEDB_SERVER_BIN ||
+    process.env.CI
       ? {}
       : {
           __EDGEDB_DEVMODE: "1",

--- a/packages/generate/gel.toml
+++ b/packages/generate/gel.toml
@@ -1,2 +1,2 @@
-[gel]
+[edgedb]
 server-version = "nightly"

--- a/turbo.json
+++ b/turbo.json
@@ -25,13 +25,7 @@
       ]
     },
     "ci:test": {
-      "dependsOn": [
-        "build",
-        "gel#test",
-        "@gel/auth-core#test",
-        "@gel/create#test",
-        "@gel/ai#test"
-      ],
+      "dependsOn": ["build", "gel#test", "@gel/auth-core#test"],
       "env": ["CI", "GEL_SERVER_BIN"]
     },
     "ci:integration-test": {


### PR DESCRIPTION
CLI still doesn't recognise [gel] inside gel.toml.  So I updated our `gel.toml` files inside test folders to use `egdedb`.

Do we want to run some CI tests on Windows machines? All tests we have run on ubuntu.

At the end I reverted tests to use `edgedb` for the CLI (`edgedb migrate` etc...) in order to use the current `setup-edgedb` action.