### PR TITLE
Fix querybuilder `toEdgeQL` when doing 'insert many-to-one, select one' queries using `e.with`

### DIFF
--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -434,24 +434,82 @@ describe("insert", () => {
   });
 
   test("insert many-to-one and select one", async () => {
-    e.params(
-      {
-        name: e.str,
-        nemeses: e.array(e.tuple({ name: e.str })),
-      },
-      (params) => {
-        const hero = e.insert(e.Hero, {
-          name: params.name,
-        });
-        const villains = e.for(e.array_unpack(params.nemeses), (nemesis) => {
-          return e.insert(e.Villain, {
-            name: nemesis.name,
-            nemesis: hero,
+    const edgeql = e
+      .params(
+        {
+          name: e.str,
+          nemeses: e.array(e.tuple({ name: e.str })),
+        },
+        (params) => {
+          const hero = e.insert(e.Hero, {
+            name: params.name,
           });
-        });
+          const villains = e.for(e.array_unpack(params.nemeses), (nemesis) => {
+            return e.insert(e.Villain, {
+              name: nemesis.name,
+              nemesis: hero,
+            });
+          });
 
-        return e.with([villains], e.select(hero));
-      },
-    ).toEdgeQL();
+          return e.with([villains], e.select(hero));
+        },
+      )
+      .toEdgeQL();
+
+    // Also test including `hero` in the `with` refs
+    assert.equal(
+      edgeql,
+      e
+        .params(
+          {
+            name: e.str,
+            nemeses: e.array(e.tuple({ name: e.str })),
+          },
+          (params) => {
+            const hero = e.insert(e.Hero, {
+              name: params.name,
+            });
+            const villains = e.for(
+              e.array_unpack(params.nemeses),
+              (nemesis) => {
+                return e.insert(e.Villain, {
+                  name: nemesis.name,
+                  nemesis: hero,
+                });
+              },
+            );
+
+            return e.with([hero, villains], e.select(hero));
+          },
+        )
+        .toEdgeQL(),
+    );
+    assert.equal(
+      edgeql,
+      e
+        .params(
+          {
+            name: e.str,
+            nemeses: e.array(e.tuple({ name: e.str })),
+          },
+          (params) => {
+            const hero = e.insert(e.Hero, {
+              name: params.name,
+            });
+            const villains = e.for(
+              e.array_unpack(params.nemeses),
+              (nemesis) => {
+                return e.insert(e.Villain, {
+                  name: nemesis.name,
+                  nemesis: hero,
+                });
+              },
+            );
+
+            return e.with([villains, hero], e.select(hero));
+          },
+        )
+        .toEdgeQL(),
+    );
   });
 });

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -432,4 +432,26 @@ describe("insert", () => {
 
     await query.run(client);
   });
+
+  test("insert many-to-one and select one", async () => {
+    e.params(
+      {
+        name: e.str,
+        nemeses: e.array(e.tuple({ name: e.str })),
+      },
+      (params) => {
+        const hero = e.insert(e.Hero, {
+          name: params.name,
+        });
+        const villains = e.for(e.array_unpack(params.nemeses), (nemesis) => {
+          return e.insert(e.Villain, {
+            name: nemesis.name,
+            nemesis: hero,
+          });
+        });
+
+        return e.with([villains], e.select(hero));
+      },
+    ).toEdgeQL();
+  });
 });

--- a/integration-tests/lts/update.test.ts
+++ b/integration-tests/lts/update.test.ts
@@ -105,6 +105,38 @@ describe("update", () => {
     }).toEdgeQL();
   });
 
+  test("nested update and explicit with, unwrapped select should fail", async () => {
+    assert.throws(
+      () =>
+        e
+          .params({ movieId: e.uuid }, (params) => {
+            const movie = e.select(e.Movie, (m) => ({
+              filter: e.op(m.id, "=", params.movieId),
+            }));
+
+            const updateChar = e.update(movie.characters, (c) => ({
+              set: {
+                name: e.str_lower(c.name),
+              },
+            }));
+
+            const updateProfile = e.update(movie.profile, (p) => ({
+              set: {
+                a: e.str_upper(p.a),
+              },
+            }));
+
+            return e.with([updateChar, updateProfile], movie);
+          })
+          .toEdgeQL(),
+      {
+        message:
+          `Ref expressions in with() cannot reference the expression to which the ` +
+          `'WITH' block is being attached. Consider wrapping the expression in a select.`,
+      },
+    );
+  });
+
   test("scoped update", async () => {
     const query = e.update(e.Hero, (hero) => ({
       filter_single: e.op(hero.name, "=", data.spidey.name),

--- a/integration-tests/lts/with.test.ts
+++ b/integration-tests/lts/with.test.ts
@@ -371,11 +371,11 @@ SELECT {
       `WITH
   __withVar_0 := (
     WITH
-      __withVar_1 := { <std::int64>1, <std::int64>2, <std::int64>3 },
-      __withVar_2 := __withVar_1
+      __withVar_2 := { <std::int64>1, <std::int64>2, <std::int64>3 },
+      __withVar_3 := __withVar_2
     SELECT {
-      multi numbers := assert_exists(__withVar_1),
-      multi numbersAlias := assert_exists(__withVar_2)
+      multi numbers := assert_exists(__withVar_2),
+      multi numbersAlias := assert_exists(__withVar_3)
     }
   )
 SELECT {


### PR DESCRIPTION
Fixes a bug where we were not also checking the child exprs of the additional valid scopes added in this fix: https://github.com/edgedb/edgedb-js/pull/1154.

Also fixes bug where scope validity was not being checked in the correct order when some expressions in the `e.with` refs array are children of other exprs.