### PR TITLE
Fix cardinality issue in type reflection query

### DIFF
--- a/packages/driver/src/reflection/queries/types.ts
+++ b/packages/driver/src/reflection/queries/types.ts
@@ -197,7 +197,7 @@ export async function getTypes(
           is_computed := len(.computed_fields) != 0,
           is_readonly := .readonly
         } filter .name != '@source' and .name != '@target',
-      } FILTER @is_owned,
+      } FILTER any(@is_owned),
       exclusives := assert_distinct((
         [is schema::ObjectType].constraints
         union


### PR DESCRIPTION
This fixes a warning in 6.0 where we warn if you have a filter clause that has a cardinality of many.

Fixes the error:

"possibly more than one element returned by an expression in a FILTER clause"