### PR TITLE
Add server v6 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,23 +20,29 @@ jobs:
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
         include:
+          # Nightly server
           - os: ubuntu-latest
-            node-version: "20"
+            node-version: "22"
             edgedb-version: "nightly"
+          # Upcoming server
           - os: ubuntu-latest
-            node-version: "20"
+            node-version: "22"
             edgedb-version: "6"
+          # LTS server
           - os: ubuntu-latest
-            node-version: "20"
+            node-version: "22"
             edgedb-version: "4"
-          - os: macos-latest
-            node-version: "20"
-            edgedb-version: "stable"
+          # Upcoming Node on stable server
           - os: ubuntu-latest
             node-version: "23"
             edgedb-version: "stable"
+          # Maintenance Node on stable server
           - os: ubuntu-latest
             node-version: "18"
+            edgedb-version: "stable"
+          # macOS
+          - os: macos-latest
+            node-version: "22"
             edgedb-version: "stable"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           # Upcoming server
           - os: ubuntu-latest
             node-version: "22"
-            edgedb-version: "6"
+            edgedb-version: "6.0-beta.2"
           # LTS server
           - os: ubuntu-latest
             node-version: "22"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
-        node-version: ["20", "22"]
+        node-version: ["18", "20", "22", "23"]
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
         include:
@@ -32,14 +32,6 @@ jobs:
           - os: ubuntu-latest
             node-version: "22"
             edgedb-version: "4"
-          # Upcoming Node on stable server
-          - os: ubuntu-latest
-            node-version: "23"
-            edgedb-version: "stable"
-          # Maintenance Node on stable server
-          - os: ubuntu-latest
-            node-version: "18"
-            edgedb-version: "stable"
           # macOS
           - os: macos-latest
             node-version: "22"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ matrix.edgedb-version == 'nightly' }}
     strategy:
       matrix:
-        node-version: ["18", "20", "22"]
+        node-version: ["20", "22"]
         os: [ubuntu-latest]
         edgedb-version: ["stable"]
         include:
@@ -25,18 +25,19 @@ jobs:
             edgedb-version: "nightly"
           - os: ubuntu-latest
             node-version: "20"
-            edgedb-version: "5"
+            edgedb-version: "6"
           - os: ubuntu-latest
             node-version: "20"
             edgedb-version: "4"
-          # - os: ubuntu-latest
-          #   node-version: "20"
-          #   edgedb-version: "3"
-          # XXX: macOS is currently unsupported by setup-edgedb
-          # - os: macos-latest
-          #   node-version: "20"
-          #   edgedb-version: "stable"
-
+          - os: macos-latest
+            node-version: "20"
+            edgedb-version: "stable"
+          - os: ubuntu-latest
+            node-version: "23"
+            edgedb-version: "stable"
+          - os: ubuntu-latest
+            node-version: "18"
+            edgedb-version: "stable"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Also shuffles the test matrix a bit to update Node release support.

18 is now in maintenance, so spend less time testing it. Add 23 to the matrix to test the latest stable with the upcoming Node release.