### PR TITLE
Update CLI wrapper for `gel` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,11 +139,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
       - name: Install dev deps
         run: |
           yarn --frozen-lockfile
@@ -162,6 +157,12 @@ jobs:
           npm exec gel -- project init --non-interactive
           npm exec gel -- --version
           npm exec gel -- query 'select sys::get_version_as_str()'
+          if gel --version; then
+            echo "Error: gel command should not be available outside of npm exec"
+            exit 1
+          else
+            echo "gel command is not available outside of npm exec, as expected"
+          fi
 
       - name: Test CLI wrapper with yarn
         run: |
@@ -172,6 +173,12 @@ jobs:
           yarn gel project init --non-interactive
           yarn gel --version
           yarn gel query 'select sys::get_version_as_str()'
+          if gel --version; then
+            echo "Error: gel command should not be available outside of yarn"
+            exit 1
+          else
+            echo "gel command is not available outside of yarn, as expected"
+          fi
 
       - uses: threeal/setup-yarn-action@ec8c075e62bc497968de40011c2b766f5e8f1ac5
         with:
@@ -188,6 +195,12 @@ jobs:
           yarn gel project init --non-interactive
           yarn gel --version
           yarn gel query 'select sys::get_version_as_str()'
+          if gel --version; then
+            echo "Error: gel command should not be available outside of yarn"
+            exit 1
+          else
+            echo "gel command is not available outside of yarn, as expected"
+          fi
 
       - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
         with:
@@ -202,6 +215,12 @@ jobs:
           pnpm exec gel project init --non-interactive
           pnpm exec gel --version
           pnpm exec gel query 'select sys::get_version_as_str()'
+          if gel --version; then
+            echo "Error: gel command should not be available outside of pnpm"
+            exit 1
+          else
+            echo "gel command is not available outside of pnpm, as expected"
+          fi
 
       - uses: oven-sh/setup-bun@8f24390df009a496891208e5e36b8a1de1f45135
       - name: Test CLI wrapper with bun
@@ -213,3 +232,9 @@ jobs:
           bun gel project init --non-interactive
           bun gel --version
           bun gel query 'select sys::get_version_as_str()'
+          if gel --version; then
+            echo "Error: gel command should not be available outside of bun"
+            exit 1
+          else
+            echo "gel command is not available outside of bun, as expected"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install postgis extension
         if: ${{ matrix.gel-version == 'nightly' }}
         run: |
-          edgedb extension install -E postgis -I test --slot 6-alpha-3
+          edgedb extension install postgis -I test --slot 6-alpha-3
 
       - name: Run package tests
         run: |

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -133,8 +133,14 @@ async function whichGelCli() {
 }
 
 async function getCachedCliLocation(): Promise<string> {
-  const stats = await fs.lstat(CACHED_CLI_PATH);
-  if (!stats.isFile()) {
+  try {
+    const stats = await fs.stat(CACHED_CLI_PATH);
+    if (!stats.isFile()) {
+      debug("  - Object found at cached CLI path is not a file. Downloading...");
+      await downloadCliPackage();
+    }
+  } catch (_err) {
+    debug("  - No cached CLI found. Downloading...");
     await downloadCliPackage();
   }
 

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -17,9 +17,8 @@ const debug = Debug("gel:cli");
 const IS_TTY = process.stdout.isTTY;
 const SCRIPT_LOCATION = await fs.realpath(fileURLToPath(import.meta.url));
 const EDGEDB_PKG_ROOT = "https://packages.edgedb.com";
-const CACHE_DIR = envPaths("edgedb").cache;
-const TEMPORARY_CLI_PATH = path.join(CACHE_DIR, "/edgedb-cli");
-const CLI_LOCATION_CACHE_FILE_PATH = path.join(CACHE_DIR, "/cli-location");
+const CACHE_DIR = envPaths("gel", { suffix: "" }).cache;
+const CACHED_CLI_PATH = path.join(CACHE_DIR, "/bin/gel");
 
 interface Package {
   name: string;
@@ -46,20 +45,17 @@ async function main(args: string[]) {
   debug(`  - SCRIPT_LOCATION: ${SCRIPT_LOCATION}`);
   debug(`  - EDGEDB_PKG_ROOT: ${EDGEDB_PKG_ROOT}`);
   debug(`  - CACHE_DIR: ${CACHE_DIR}`);
-  debug(`  - TEMPORARY_CLI_PATH: ${TEMPORARY_CLI_PATH}`);
-  debug(`  - CLI_LOCATION_CACHE_FILE_PATH: ${CLI_LOCATION_CACHE_FILE_PATH}`);
+  debug(`  - CACHED_CLI_PATH: ${CACHED_CLI_PATH}`);
 
   // check to see if we are being tested as a CLI binary wrapper
   if (args.length === 1 && args[0] === "--succeed-if-cli-bin-wrapper") {
     process.exit(0);
   }
 
-  const maybeCachedCliLocation = await getCliLocationFromCache();
-  const cliLocation =
+  const cliLocation: string | null =
     (await whichGelCli()) ??
-    maybeCachedCliLocation ??
-    (await getCliLocationFromTempCli()) ??
-    (await selfInstallFromTempCli()) ??
+    (await getCliLocationFromCachedCli()) ??
+    (await getCachedCliLocation()) ??
     null;
 
   if (cliLocation === null) {
@@ -68,14 +64,6 @@ async function main(args: string[]) {
 
   try {
     runCli(args, cliLocation);
-    if (cliLocation !== maybeCachedCliLocation) {
-      debug("CLI location not cached.");
-      debug(`  - Cached location: ${maybeCachedCliLocation}`);
-      debug(`  - CLI location: ${cliLocation}`);
-      debug(`Updating cache with new CLI location: ${cliLocation}`);
-      await writeCliLocationToCache(cliLocation);
-      debug("Cache updated.");
-    }
   } catch (err) {
     if (
       typeof err === "object" &&
@@ -144,55 +132,22 @@ async function whichGelCli() {
   return null;
 }
 
-async function getCliLocationFromCache(): Promise<string | null> {
-  debug("Checking CLI cache...");
-  try {
-    let cachedBinaryPath: string | null = null;
-    try {
-      cachedBinaryPath = (
-        await fs.readFile(CLI_LOCATION_CACHE_FILE_PATH, { encoding: "utf8" })
-      ).trim();
-    } catch (err: unknown) {
-      if (
-        typeof err === "object" &&
-        err !== null &&
-        "code" in err &&
-        err.code === "ENOENT"
-      ) {
-        debug("  - Cache file does not exist.");
-      } else if (
-        typeof err === "object" &&
-        err !== null &&
-        "code" in err &&
-        err.code === "EACCES"
-      ) {
-        debug("  - No permission to read cache file.");
-      }
-      return null;
-    }
-    debug("  - CLI path in cache at:", cachedBinaryPath);
-
-    try {
-      await fs.access(cachedBinaryPath, fs.constants.F_OK);
-      debug("  - CLI binary found in path:", cachedBinaryPath);
-      return cachedBinaryPath;
-    } catch (err) {
-      debug("  - No CLI found in cache.", err);
-      return null;
-    }
-  } catch (err) {
-    debug("  - Cache file cannot be read.", err);
-    return null;
+async function getCachedCliLocation(): Promise<string> {
+  const stats = await fs.lstat(CACHED_CLI_PATH);
+  if (!stats.isFile()) {
+    await downloadCliPackage();
   }
+
+  await fs.access(CACHED_CLI_PATH, fs.constants.F_OK);
+  return CACHED_CLI_PATH;
 }
 
-async function getCliLocationFromTempCli(): Promise<string | null> {
+async function getCliLocationFromCachedCli(): Promise<string | null> {
   debug("Installing temporary CLI to get install directory...");
-  await downloadCliPackage();
+  const cachedCliLocation = await getCachedCliLocation();
 
-  const installDir = getInstallDir(TEMPORARY_CLI_PATH);
-  const binaryPath = path.join(installDir, "edgedb");
-  await writeCliLocationToCache(binaryPath);
+  const installDir = getInstallDir(cachedCliLocation);
+  const binaryPath = path.join(installDir, "gel");
   debug("  - CLI installed at:", binaryPath);
 
   try {
@@ -205,43 +160,18 @@ async function getCliLocationFromTempCli(): Promise<string | null> {
   }
 }
 
-async function writeCliLocationToCache(cliLocation: string) {
-  debug("Writing CLI location to cache:", cliLocation);
-  const dir = path.dirname(CLI_LOCATION_CACHE_FILE_PATH);
-  await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(CLI_LOCATION_CACHE_FILE_PATH, cliLocation, {
-    encoding: "utf8",
-  });
-}
-
-async function selfInstallFromTempCli(): Promise<string | null> {
-  debug("Self-installing Gel CLI...");
-  // n.b. need -y because in the Vercel build container, $HOME and euid-obtained
-  // home are different, and the CLI installation requires this as confirmation
-  const cmd = ["_self_install", "-y"];
-  if (!IS_TTY) {
-    cmd.push("--quiet");
-  }
-  runCli(cmd, TEMPORARY_CLI_PATH);
-  debug("  - CLI self-installed successfully.");
-  return getCliLocationFromCache();
-}
-
 async function downloadCliPackage() {
-  if (IS_TTY) {
-    console.log("No Gel CLI found, downloading CLI package...");
-  }
   debug("Downloading CLI package...");
   const cliPkg = await findPackage();
-  const downloadDir = path.dirname(TEMPORARY_CLI_PATH);
+  const downloadDir = path.dirname(CACHED_CLI_PATH);
   await fs.mkdir(downloadDir, { recursive: true }).catch((error) => {
     if (error.code !== "EEXIST") throw error;
   });
   const downloadUrl = new URL(cliPkg.installref, EDGEDB_PKG_ROOT);
-  await downloadFile(downloadUrl, TEMPORARY_CLI_PATH);
-  debug("  - CLI package downloaded to:", TEMPORARY_CLI_PATH);
+  await downloadFile(downloadUrl, CACHED_CLI_PATH);
+  debug("  - CLI package downloaded to:", CACHED_CLI_PATH);
 
-  const fd = await fs.open(TEMPORARY_CLI_PATH, "r+");
+  const fd = await fs.open(CACHED_CLI_PATH, "r+");
   await fd.chmod(0o755);
   await fd.datasync();
   await fd.close();

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -136,7 +136,9 @@ async function getCachedCliLocation(): Promise<string> {
   try {
     const stats = await fs.stat(CACHED_CLI_PATH);
     if (!stats.isFile()) {
-      debug("  - Object found at cached CLI path is not a file. Downloading...");
+      debug(
+        "  - Object found at cached CLI path is not a file. Downloading...",
+      );
       await downloadCliPackage();
     }
   } catch (_err) {

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -54,8 +54,8 @@ async function main(args: string[]) {
 
   const maybeCachedCliLocation = await getCliLocationFromCache();
   const cliLocation =
-    maybeCachedCliLocation ??
     (await whichGelCli()) ??
+    maybeCachedCliLocation ??
     (await getCliLocationFromTempCli()) ??
     (await selfInstallFromTempCli()) ??
     null;

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -12,7 +12,7 @@ import Debug from "debug";
 import which from "which";
 import { quote } from "shell-quote";
 
-const debug = Debug("edgedb:cli");
+const debug = Debug("gel:cli");
 
 const IS_TTY = process.stdout.isTTY;
 const SCRIPT_LOCATION = await fs.realpath(fileURLToPath(import.meta.url));
@@ -67,7 +67,7 @@ async function main(args: string[]) {
   }
 
   try {
-    runEdgeDbCli(args, cliLocation);
+    runCli(args, cliLocation);
     if (cliLocation !== maybeCachedCliLocation) {
       debug("CLI location not cached.");
       debug(`  - Cached location: ${maybeCachedCliLocation}`);
@@ -129,7 +129,7 @@ async function whichGelCli() {
     }
 
     try {
-      runEdgeDbCli(["--succeed-if-cli-bin-wrapper"], actualLocation, {
+      runCli(["--succeed-if-cli-bin-wrapper"], actualLocation, {
         stdio: "ignore",
       });
       debug("  - CLI found in PATH is wrapper script. Ignoring.");
@@ -222,7 +222,7 @@ async function selfInstallFromTempCli(): Promise<string | null> {
   if (!IS_TTY) {
     cmd.push("--quiet");
   }
-  runEdgeDbCli(cmd, TEMPORARY_CLI_PATH);
+  runCli(cmd, TEMPORARY_CLI_PATH);
   debug("  - CLI self-installed successfully.");
   return getCliLocationFromCache();
 }
@@ -247,7 +247,7 @@ async function downloadCliPackage() {
   await fd.close();
 }
 
-function runEdgeDbCli(
+function runCli(
   args: string[],
   pathToCli: string,
   execOptions: ExecSyncOptions = { stdio: "inherit" },
@@ -389,7 +389,7 @@ function getBaseDist(arch: string, platform: string, libc = ""): string {
 
 function getInstallDir(cliPath: string): string {
   debug("Getting install directory for CLI path:", cliPath);
-  const installDir = runEdgeDbCli(["info", "--get", "install-dir"], cliPath, {
+  const installDir = runCli(["info", "--get", "install-dir"], cliPath, {
     stdio: "pipe",
   })
     .toString()

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -28,11 +28,13 @@ interface Package {
   installref: string;
 }
 
+const SCRIPT_NAME = import.meta.url.split("/").pop() || "gel";
+
 debug("Process argv:", process.argv);
 // n.b. Using `npx`, the 3rd argument is the script name, unlike
 // `node` where the 2nd argument is the script name.
 let args = process.argv.slice(2);
-if (args[0] === "edgedb") {
+if (args[0] === SCRIPT_NAME) {
   args = args.slice(1);
 }
 await main(args);
@@ -95,9 +97,7 @@ async function main(args: string[]) {
 async function whichGelCli() {
   debug("Checking if CLI is in PATH...");
   const locations =
-    (await which("gel", { nothrow: true, all: true })) ||
-    (await which("edgedb", { nothrow: true, all: true })) ||
-    [];
+    (await which(SCRIPT_NAME, { nothrow: true, all: true })) || [];
 
   for (const location of locations) {
     const actualLocation = await fs.realpath(location);


### PR DESCRIPTION
Now that the package is called `gel`, we need to switch to checking `gel` in argv. Along with this change are a few more actual logical changes:

1. Prefer `PATH` to find the binary instead of the cached location.
2. _Only_ check for the command we're wrapping when using `which` to find the path to the CLI binary.