### PR TITLE
feat(generate): allow `param` function to be composable

### DIFF
--- a/packages/generate/src/syntax/params.ts
+++ b/packages/generate/src/syntax/params.ts
@@ -157,11 +157,26 @@ export function params<
     returnExpr = select(returnExpr) as any;
   }
 
-  return $expressionify({
+  const withParamsExpr = $expressionify({
     __kind__: ExpressionKind.WithParams,
     __element__: returnExpr.__element__,
     __cardinality__: returnExpr.__cardinality__,
     __expr__: returnExpr,
     __params__: Object.values(paramExprs),
   }) as any;
+
+  const callableExpr = function (args: paramsToInputArgs<Params>) {
+    return $expressionify({
+      __kind__: ExpressionKind.WithParams,
+      __element__: returnExpr.__element__,
+      __cardinality__: returnExpr.__cardinality__,
+      __expr__: returnExpr,
+      __params__: Object.values(paramExprs),
+      __args__: args,
+    }) as any;
+  };
+
+  Object.assign(callableExpr, withParamsExpr);
+
+  return callableExpr as any;
 }

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -866,6 +866,25 @@ function renderEdgeQL(
   if (expr.__kind__ === ExpressionKind.With) {
     return renderEdgeQL(expr.__expr__, ctx);
   } else if (expr.__kind__ === ExpressionKind.WithParams) {
+    if ((expr as any).__args__) {
+      const argList = Object.entries((expr as any).__args__)
+        .map(([key, value]) => {
+          if (
+            value &&
+            typeof value === "object" &&
+            (value as any).__kind__ === ExpressionKind.Param
+          ) {
+            return `  __param__${key} := ${renderEdgeQL(value as any, ctx)}`;
+          }
+          const param = expr.__params__.find(
+            (p: any) => p.__name__ === key,
+          ) as any;
+          return `  __param__${key} := ${literalToEdgeQL(param.__element__, value)}`;
+        })
+        .join(",\n");
+
+      return `(WITH\n${argList}\nSELECT ${renderEdgeQL(expr.__expr__, ctx)})`;
+    }
     return `(WITH\n${expr.__params__
       .map((param) => {
         const optional =

--- a/packages/generate/src/syntax/toEdgeQL.ts
+++ b/packages/generate/src/syntax/toEdgeQL.ts
@@ -659,11 +659,12 @@ function walkExprTree(
       break;
     }
     case ExpressionKind.WithParams: {
-      if (parentScope !== null) {
-        throw new Error(
-          `'withParams' does not support being used as a nested expression`,
-        );
-      }
+      // Does this need to be here?, seems to work fine without it.
+      // if (parentScope !== null) {
+      //   throw new Error(
+      //     `'withParams' does not support being used as a nested expression`,
+      //   );
+      // }
       childExprs.push(...walkExprTree(expr.__expr__, parentScope, ctx));
       break;
     }


### PR DESCRIPTION
## Overview

Issue: https://github.com/geldata/gel-js/issues/1290

This PR makes the return from the `param` function callable to allow composition while keeping the existing API stable.

Broken down into 3 parts
- Types
    - Add a `CallableWithParamsExpr` to `expr_WithParams` which adds the function interface on the type level
    - helper `paramsToInputArgs` to map the param's into an object of `$expr_Param` or a TS type so you can call the same function from within a `param` callback or with normal ts types
        - Note here: you can't use base exprs you have to use primitive TS types or "params" that are passed to the `param` callback, so you can not for example partially apply params, but I don't think there is a valid use case for that
     - Helper `paramOrTsType` for making a union for the base TS type of a param expr
 - The `param` function
     - pretty simple, just assign the original return  of the function to a `callableExpr` function that fulfills the above contract 
 - The `toEdgeQL` function
     - Adds a check in the `expr.__kind__ === ExpressionKind.WithParams` branch of `renderEdgeQL`function, which is checking if the expr has any args and building a subquery for them.
 

### Testing
I have done some little smoke tests, not everything works but I have a be able to get a basic composed query working here
```ts
import e from "./edgeql-js";

const testing1 = e.params(
  {
    arg1: e.uuid,
  },
  (params) => e.cast(e.str, params.arg1),
);

const testing2 = e.params(
  {
    arg2: e.uuid,
    arg3: e.optional(e.int16),
  },
  (params) => {
    const arg1 = testing1({
      arg1: params.arg2,
    });

    return e.set(e.select(arg1));
  },
);

const WITHOUT_ARGS = testing1.toEdgeQL();
const WITH_ARGS = testing1({
  arg1: "a216511e-78f4-4ccb-8492-3e5239b2d9db",
}).toEdgeQL();
const WITH_COMPOSE = testing2.toEdgeQL();
const COMPOSE_WITH_ARGS = testing2({
  arg2: "a216511e-78f4-4ccb-8492-3e5239b2d9db",
  arg3: 123,
}).toEdgeQL();

console.log(WITHOUT_ARGS);
console.log("");
console.log(WITH_ARGS);
console.log("");
console.log(WITH_COMPOSE);
console.log("");
console.log(COMPOSE_WITH_ARGS);
```
Which outputs
```bash
WITH
  __param__arg1 := <std::uuid>$arg1
SELECT (SELECT (<std::str>__param__arg1))

WITH
  __param__arg1 := <std::uuid>"a216511e-78f4-4ccb-8492-3e5239b2d9db"
SELECT (SELECT (<std::str>__param__arg1))

WITH
  __param__arg2 := <std::uuid>$arg2,
  __param__arg3 := <OPTIONAL std::int16>$arg3
SELECT (SELECT { (SELECT (WITH
  __param__arg1 := __param__arg2
SELECT (SELECT (<std::str>__param__arg1)))) })

WITH
  __param__arg2 := <std::uuid>"a216511e-78f4-4ccb-8492-3e5239b2d9db",
  __param__arg3 := <std::int16>123
SELECT (SELECT { (SELECT (WITH
  __param__arg1 := __param__arg2
SELECT (SELECT (<std::str>__param__arg1)))) })
```

Running these against a gel instance I get
<img width="1051" alt="Screenshot 2025-06-03 at 10 58 44 pm" src="https://github.com/user-attachments/assets/8dd78f49-6660-4e44-b854-1f2bce6f5bcd" />



#### TODO
- Testing with more complex types and queries
- Testing with client
- ...